### PR TITLE
Phase 4 PR 1: DynamicJobClassLoader

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobClassLoader.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobClassLoader.java
@@ -1,0 +1,85 @@
+/* 2024-2025 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Set;
+
+/**
+ * A parent-last {@link URLClassLoader} that isolates plugin classes while sharing core Spring
+ * infrastructure through shared-package delegation.
+ *
+ * <p>Shared packages ({@code org.springframework.}, {@code jakarta.}, {@code org.slf4j.},
+ * {@code com.fronzec.api.}) are always delegated to the parent classloader. All other classes are
+ * loaded from the provided JAR URLs first, falling back to the parent only if not found in the
+ * JAR.
+ *
+ * <p><strong>Thread safety:</strong> {@code loadClass} uses per-class-name locking via
+ * {@link #getClassLoadingLock(String)}, matching the standard classloader contract.
+ */
+public class DynamicJobClassLoader extends URLClassLoader {
+
+  private static final Set<String> SHARED_PACKAGES =
+      Set.of(
+          "org.springframework.",
+          "jakarta.",
+          "org.slf4j.",
+          "com.fronzec.api.");
+
+  private final String jobName;
+
+  /**
+   * @param urls JAR URLs to load plugin classes from
+   * @param parent the parent classloader (typically the application classloader, providing shared
+   *     infrastructure)
+   * @param jobName human-readable identifier for diagnostics
+   */
+  public DynamicJobClassLoader(URL[] urls, ClassLoader parent, String jobName) {
+    super(urls, parent);
+    this.jobName = jobName;
+  }
+
+  /**
+   * Parent-last with shared-package filter.
+   *
+   * <p>Classes in shared packages are delegated to the parent immediately. All other classes are
+   * searched in this classloader's JAR URLs first, with the parent as a fallback.
+   */
+  @Override
+  protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    // Shared packages — delegate to parent without consulting JAR
+    if (SHARED_PACKAGES.stream().anyMatch(name::startsWith)) {
+      return getParent().loadClass(name);
+    }
+
+    // Parent-last: try this classloader first, fall back to parent
+    synchronized (getClassLoadingLock(name)) {
+      Class<?> c = findLoadedClass(name);
+      if (c == null) {
+        try {
+          c = findClass(name);
+        } catch (ClassNotFoundException e) {
+          c = getParent().loadClass(name);
+        }
+      }
+      if (resolve) {
+        resolveClass(c);
+      }
+      return c;
+    }
+  }
+
+  /** Best-effort close; safe to call multiple times. */
+  public void cleanup() {
+    try {
+      close();
+    } catch (Exception e) {
+      // best-effort
+    }
+  }
+
+  /** Returns the job name this classloader was created for. */
+  public String getJobName() {
+    return jobName;
+  }
+}

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobClassLoaderTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobClassLoaderTest.java
@@ -1,0 +1,283 @@
+/* 2024-2025 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.jar.*;
+import javax.tools.*;
+import org.junit.jupiter.api.*;
+
+class DynamicJobClassLoaderTest {
+
+  private Path tempDir;
+  private Path jar1Path;
+  private Path jar2Path;
+  private ClassLoader parent;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tempDir = Files.createTempDirectory("classloader-test-");
+    parent = getClass().getClassLoader();
+
+    // v1: "say" returns "v1"
+    jar1Path =
+        createTestJar(
+            tempDir,
+            "com.test.MyPlugin",
+            "package com.test;\npublic class MyPlugin { public String say() { return \"v1\"; } }",
+            "jar1");
+
+    // v2: same class name, different behavior (isolation test)
+    jar2Path =
+        createTestJar(
+            tempDir,
+            "com.test.MyPlugin",
+            "package com.test;\npublic class MyPlugin { public String say() { return \"v2\"; } }",
+            "jar2");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (tempDir != null) {
+      try (var walk = Files.walk(tempDir)) {
+        walk
+            .sorted(Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.deleteIfExists(p);
+                  } catch (IOException ignored) {
+                    // best-effort cleanup
+                  }
+                });
+      } catch (IOException ignored) {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  // ── Shared package delegation ────────────────────────────────────────────
+
+  @Test
+  void sharedPackages_delegateSpringToParent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    Class<?> loaded = loader.loadClass("org.springframework.batch.core.job.Job");
+    assertSame(
+        org.springframework.batch.core.job.Job.class,
+        loaded,
+        "Spring class should come from parent, not JAR");
+  }
+
+  @Test
+  void sharedPackages_delegateSlf4jToParent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    Class<?> loaded = loader.loadClass("org.slf4j.Logger");
+    assertSame(
+        org.slf4j.Logger.class, loaded, "SLF4J class should come from parent");
+  }
+
+  @Test
+  void sharedPackages_delegateJakartaToParent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    Class<?> loaded = loader.loadClass("jakarta.annotation.PostConstruct");
+    assertSame(
+        jakarta.annotation.PostConstruct.class,
+        loaded,
+        "Jakarta class should come from parent");
+  }
+
+  @Test
+  void sharedPackages_delegateApiToParent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    Class<?> loaded = loader.loadClass("com.fronzec.api.BatchJobPlugin");
+    assertSame(
+        com.fronzec.api.BatchJobPlugin.class,
+        loaded,
+        "API class should come from parent");
+  }
+
+  // ── JAR-first loading ────────────────────────────────────────────────────
+
+  @Test
+  void jarClass_loadedFromJarFirst() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    Class<?> pluginClass = loader.loadClass("com.test.MyPlugin");
+    assertNotNull(pluginClass);
+    assertEquals("com.test.MyPlugin", pluginClass.getName());
+
+    // Verify isolation: the class was loaded by our loader, not the parent
+    assertSame(
+        loader,
+        pluginClass.getClassLoader(),
+        "Plugin class should be loaded by DynamicJobClassLoader");
+  }
+
+  @Test
+  void classloaderIsolation_sameClassNameDifferentJars_yieldDifferentClasses() throws Exception {
+    DynamicJobClassLoader loader1 =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "job1");
+    DynamicJobClassLoader loader2 =
+        new DynamicJobClassLoader(new URL[] {jar2Path.toUri().toURL()}, parent, "job2");
+
+    Class<?> class1 = loader1.loadClass("com.test.MyPlugin");
+    Class<?> class2 = loader2.loadClass("com.test.MyPlugin");
+
+    assertNotNull(class1);
+    assertNotNull(class2);
+    assertNotSame(
+        class1,
+        class2,
+        "Same class name from different JARs should yield different Class objects");
+
+    // Verify different behavior from each class
+    Object instance1 = class1.getDeclaredConstructor().newInstance();
+    Object instance2 = class2.getDeclaredConstructor().newInstance();
+
+    assertEquals("v1", class1.getMethod("say").invoke(instance1));
+    assertEquals("v2", class2.getMethod("say").invoke(instance2));
+  }
+
+  // ── Parent fallback ──────────────────────────────────────────────────────
+
+  @Test
+  void nonSharedClass_notInJar_fallsBackToParent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    // java.util.ArrayList is not in shared packages, not in JAR → parent fallback
+    Class<?> listClass = loader.loadClass("java.util.ArrayList");
+    assertSame(
+        java.util.ArrayList.class,
+        listClass,
+        "JDK class should fall back to parent after JAR miss");
+  }
+
+  @Test
+  void unknownClass_notInJar_notInParent_throwsClassNotFoundException() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    assertThrows(
+        ClassNotFoundException.class,
+        () -> loader.loadClass("com.nonexistent.Ghost"),
+        "Missing class should throw ClassNotFoundException");
+  }
+
+  // ── Cleanup ──────────────────────────────────────────────────────────────
+
+  @Test
+  void cleanup_closesClassLoader() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    loader.cleanup();
+
+    // After close(), loading a JAR-only class should fail
+    assertThrows(
+        Exception.class,
+        () -> loader.loadClass("com.test.MyPlugin"),
+        "After cleanup, loading JAR-only class should fail");
+  }
+
+  @Test
+  void cleanup_isIdempotent() throws Exception {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {jar1Path.toUri().toURL()}, parent, "test-job");
+
+    loader.cleanup();
+    // Second cleanup should not throw
+    assertDoesNotThrow(loader::cleanup, "cleanup() should be idempotent");
+  }
+
+  // ── Metadata ─────────────────────────────────────────────────────────────
+
+  @Test
+  void getJobName_returnsConstructorArgument() {
+    DynamicJobClassLoader loader =
+        new DynamicJobClassLoader(new URL[] {}, parent, "my-custom-job");
+    assertEquals("my-custom-job", loader.getJobName());
+  }
+
+  // ── Test JAR helper ──────────────────────────────────────────────────────
+
+  /**
+   * Compiles a single Java source file and packages it into a JAR.
+   *
+   * @param tempDir scratch directory (caller owns cleanup)
+   * @param className fully-qualified class name (e.g. "com.test.MyPlugin")
+   * @param source complete Java source code
+   * @param suffix unique suffix to avoid directory collisions within same tempDir
+   * @return path to the generated JAR file
+   */
+  private static Path createTestJar(
+      Path tempDir, String className, String source, String suffix) throws Exception {
+
+    int lastDot = className.lastIndexOf('.');
+    String packageName = lastDot >= 0 ? className.substring(0, lastDot) : "";
+    String simpleName = lastDot >= 0 ? className.substring(lastDot + 1) : className;
+
+    // Write source file into tempDir/src-{suffix}/...
+    Path srcDir = tempDir.resolve("src-" + suffix);
+    Path packageDir = srcDir;
+    if (!packageName.isEmpty()) {
+      for (String part : packageName.split("\\.")) {
+        packageDir = packageDir.resolve(part);
+      }
+    }
+    Files.createDirectories(packageDir);
+    Files.writeString(packageDir.resolve(simpleName + ".java"), source);
+
+    // Compile to tempDir/classes-{suffix}
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    Path classesDir = tempDir.resolve("classes-" + suffix);
+    Files.createDirectories(classesDir);
+
+    try (StandardJavaFileManager fileManager =
+        compiler.getStandardFileManager(null, null, null)) {
+      Iterable<? extends JavaFileObject> compilationUnits =
+          fileManager.getJavaFileObjects(packageDir.resolve(simpleName + ".java"));
+      compiler
+          .getTask(null, fileManager, null, List.of("-d", classesDir.toString()), null, compilationUnits)
+          .call();
+    }
+
+    // Package compiled class into a JAR
+    Path jarPath = tempDir.resolve(simpleName + "-" + suffix + ".jar");
+    try (JarOutputStream jos =
+        new JarOutputStream(new BufferedOutputStream(new FileOutputStream(jarPath.toFile())))) {
+      try (var walk = Files.walk(classesDir)) {
+        walk
+            .filter(p -> p.toString().endsWith(".class"))
+            .forEach(
+                p -> {
+                  try {
+                    String entryName =
+                        classesDir.relativize(p).toString().replace(File.separatorChar, '/');
+                    jos.putNextEntry(new JarEntry(entryName));
+                    Files.copy(p, jos);
+                    jos.closeEntry();
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+      }
+    }
+
+    return jarPath;
+  }
+}


### PR DESCRIPTION
## PR 1 of 4 — Stacked to `plugin-architecture`

### What
Parent-last `URLClassLoader` that isolates plugin classes while sharing core Spring infrastructure. Foundation for dynamic JAR loading.

### Changes
- **`DynamicJobClassLoader`**: extends `URLClassLoader`, parent-last delegation model
  - Shared packages always delegated to parent: `org.springframework.*`, `jakarta.*`, `org.slf4j.*`, `com.fronzec.api.*`
  - Plugin JAR classes loaded first, fall back to parent
  - Per-class locking for thread safety
  - `cleanup()` closes resources, idempotent
- **11 unit tests**: delegation behavior, classloader isolation, shared package verification, cleanup lifecycle. Tests use programmatic JAR generation via `JavaCompiler` + `JarOutputStream`

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 53 tests, 0 failures, BUILD SUCCESS
```

### Depends on
Nothing — first PR in the chain.

### Next PR
PR 2: `DynamicJobLoaderService` (load/unload/reload orchestrator)

### Related
- ADR: `docs/ADR/001-dynamic-job-loading-system.md` Phase 4
- Chain strategy: stacked-to-main