### PR TITLE
Phase 4 PR 2: DynamicJobLoaderService

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
@@ -245,8 +245,10 @@ public class PluginRegistryService {
                         e.getMessage());
             }
 
+            classloaderRefs.remove(jobName);
+
             log.info(
-                    "Unregistered plugin '{}', classloader reference retained for Phase 4 cleanup",
+                    "Unregistered plugin '{}', classloader reference removed",
                     jobName);
         }
     }

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
@@ -1,0 +1,314 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+import com.fronzec.api.BatchJobPlugin;
+import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistryService;
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
+import java.io.File;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Orchestrates the full lifecycle of dynamically-loaded batch job plugins: load from JAR,
+ * instantiate, configure, register, and unload.
+ *
+ * <p>Owns the {@link DynamicJobClassLoader} lifecycle via a {@link ConcurrentHashMap} keyed by
+ * definition ID. Delegates registry operations to {@link PluginRegistryService}.
+ */
+@Service
+public class DynamicJobLoaderService {
+
+  private static final Logger log = LoggerFactory.getLogger(DynamicJobLoaderService.class);
+
+  private final JobDefinitionRepository jobDefinitionRepository;
+  private final PluginRegistryService pluginRegistryService;
+  private final ApplicationContext applicationContext;
+  private final JobRepository jobRepository;
+  private final PlatformTransactionManager transactionManager;
+
+  /** Tracks active classloaders by definition ID for cleanup on unload. */
+  private final Map<Long, DynamicJobClassLoader> classLoaders = new ConcurrentHashMap<>();
+
+  public DynamicJobLoaderService(
+      JobDefinitionRepository jobDefinitionRepository,
+      PluginRegistryService pluginRegistryService,
+      ApplicationContext applicationContext,
+      JobRepository jobRepository,
+      PlatformTransactionManager transactionManager) {
+    this.jobDefinitionRepository = jobDefinitionRepository;
+    this.pluginRegistryService = pluginRegistryService;
+    this.applicationContext = applicationContext;
+    this.jobRepository = jobRepository;
+    this.transactionManager = transactionManager;
+  }
+
+  /**
+   * Loads a job definition from its JAR, instantiates the plugin, configures the Spring Batch
+   * {@link org.springframework.batch.core.job.Job}, and registers it with the registry.
+   *
+   * @param definitionId the database ID of the job definition to load
+   * @return a {@link LoadResult} describing the outcome
+   * @throws NoSuchElementException if the definition does not exist
+   * @throws IllegalStateException if the definition is disabled or already loaded
+   * @throws JobLoadException if the load fails at any stage (bad JAR, class missing, configure
+   *     failure, etc.)
+   */
+  public LoadResult loadJob(Long definitionId) {
+    JobDefinitionEntity entity =
+        jobDefinitionRepository
+            .findById(definitionId)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "Job definition not found for id: " + definitionId));
+
+    // Pre-condition: must be enabled
+    if (!Boolean.TRUE.equals(entity.getEnabled())) {
+      throw new IllegalStateException(
+          "Job definition \"" + entity.getJobName() + "\" (id=" + definitionId + ") is disabled");
+    }
+
+    // Optimistic guard: already loaded or currently loading
+    if (LoadResult.LOADED.equals(entity.getLoadStatus())) {
+      throw new IllegalStateException(
+          "Job \"" + entity.getJobName() + "\" (id=" + definitionId + ") is already loaded");
+    }
+
+    // Mark LOADING so concurrent attempts see in-flight state
+    entity.setLoadStatus("LOADING");
+    entity.setLoadError(null);
+    jobDefinitionRepository.save(entity);
+
+    DynamicJobClassLoader classLoader = null;
+    try {
+      // Validate JAR file exists
+      File jarFile = new File(entity.getJarFilePath());
+      if (!jarFile.exists()) {
+        throw new JobLoadException(
+            "JAR file not found: " + entity.getJarFilePath());
+      }
+
+      // Create parent-last classloader
+      URL[] jarUrls = new URL[] {jarFile.toURI().toURL()};
+      classLoader =
+          new DynamicJobClassLoader(jarUrls, getClass().getClassLoader(), entity.getJobName());
+
+      // Load the plugin main class
+      Class<?> pluginClass = classLoader.loadClass(entity.getMainClassName());
+
+      // Validate it implements BatchJobPlugin
+      if (!BatchJobPlugin.class.isAssignableFrom(pluginClass)) {
+        throw new JobLoadException(
+            "Main class "
+                + entity.getMainClassName()
+                + " does not implement BatchJobPlugin");
+      }
+
+      // Instantiate and verify
+      BatchJobPlugin plugin = (BatchJobPlugin) pluginClass.getDeclaredConstructor().newInstance();
+
+      if (!plugin.getJobName().equals(entity.getJobName())) {
+        throw new JobLoadException(
+            "Plugin declares jobName=\""
+                + plugin.getJobName()
+                + "\" but definition expects \""
+                + entity.getJobName()
+                + "\"");
+      }
+
+      // Register through existing hook — registerDynamicPlugin() internally calls
+      // plugin.configureJob(...), validates the Job, and registers in JobRegistry
+      pluginRegistryService.registerDynamicPlugin(plugin, classLoader);
+
+      // Track classloader for future unload
+      classLoaders.put(definitionId, classLoader);
+
+      // Persist success
+      entity.setLoadStatus(LoadResult.LOADED);
+      entity.setLoadError(null);
+      jobDefinitionRepository.save(entity);
+
+      log.info(
+          "Loaded plugin '{}' (id={}) from {}",
+          entity.getJobName(),
+          definitionId,
+          entity.getJarFilePath());
+
+      return new LoadResult(
+          entity.getJobName(), LoadResult.LOADED, "Successfully loaded");
+
+    } catch (NoSuchElementException | IllegalStateException e) {
+      // Re-throw without wrapping — these are validation failures, not load errors
+      // Reset status from LOADING back to previous
+      entity.setLoadStatus(getPreviousLoadStatus(entity, definitionId));
+      jobDefinitionRepository.save(entity);
+      throw e;
+    } catch (Exception e) {
+      // Mark FAILED and persist the error
+      entity.setLoadStatus(LoadResult.FAILED);
+      entity.setLoadError(e.getMessage());
+      jobDefinitionRepository.save(entity);
+
+      // Clean up any partial classloader
+      if (classLoader != null) {
+        try {
+          classLoader.cleanup();
+        } catch (Exception cleanupEx) {
+          log.warn("Failed to clean up classloader for definition {}: {}", definitionId, cleanupEx.getMessage());
+        }
+      }
+      classLoaders.remove(definitionId);
+
+      log.error("Failed to load plugin for definition {}: {}", definitionId, e.getMessage(), e);
+
+      if (e instanceof JobLoadException) {
+        throw (JobLoadException) e;
+      }
+      throw new JobLoadException(
+          "Failed to load job \"" + entity.getJobName() + "\": " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Unloads a previously-loaded job: unregisters from the registry, closes the classloader, and
+   * updates the database status.
+   *
+   * @param definitionId the database ID of the job definition to unload
+   * @param force if {@code true}, skip the running-execution guard
+   * @return a {@link LoadResult} describing the outcome
+   * @throws NoSuchElementException if the definition does not exist
+   * @throws JobUnloadConflictException if the job has running executions and {@code force} is
+   *     {@code false}
+   */
+  public LoadResult unloadJob(Long definitionId, boolean force) {
+    JobDefinitionEntity entity =
+        jobDefinitionRepository
+            .findById(definitionId)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "Job definition not found for id: " + definitionId));
+
+    // Guard: check for running executions unless forced
+    if (!force) {
+      // TODO: integrate JobExplorer for precise running-execution check.
+      // Currently uses JobRepository.findRunningJobExecutions() which may not be exhaustive.
+      var runningExecutions =
+          jobRepository.findRunningJobExecutions(entity.getJobName());
+      if (runningExecutions != null && !runningExecutions.isEmpty()) {
+        throw new JobUnloadConflictException(
+            "Job \""
+                + entity.getJobName()
+                + "\" has "
+                + runningExecutions.size()
+                + " running execution(s). Use force=true to override.");
+      }
+    }
+
+    // Unregister from the plugin registry and JobRegistry
+    pluginRegistryService.unregisterDynamicPlugin(entity.getJobName());
+
+    // Close and remove classloader
+    DynamicJobClassLoader classLoader = classLoaders.remove(definitionId);
+    if (classLoader != null) {
+      classLoader.cleanup();
+    } else {
+      log.warn(
+          "No classloader found for definition {} — may not have been loaded through this service",
+          definitionId);
+    }
+
+    // Persist unloaded state
+    entity.setLoadStatus(LoadResult.UNLOADED);
+    entity.setLoadError(null);
+    jobDefinitionRepository.save(entity);
+
+    log.info(
+        "Unloaded plugin '{}' (id={})", entity.getJobName(), definitionId);
+
+    return new LoadResult(
+        entity.getJobName(), LoadResult.UNLOADED, "Successfully unloaded");
+  }
+
+  /**
+   * Reloads a job by unloading (forced) then loading sequentially. The operation is sequential, so
+   * the status never appears partially ready.
+   *
+   * @param definitionId the database ID of the job definition to reload
+   * @return a {@link LoadResult} describing the outcome (always LOADED on success)
+   * @throws NoSuchElementException if the definition does not exist
+   * @throws JobLoadException if the load step fails
+   */
+  public LoadResult reloadJob(Long definitionId) {
+    unloadJob(definitionId, true);
+    return loadJob(definitionId);
+  }
+
+  /**
+   * Loads all enabled job definitions whose {@code loadStatus} is not {@code LOADED}. Each
+   * definition is loaded independently; one failure does not block the rest.
+   *
+   * @return a map from job name to the per-definition {@link LoadResult}
+   */
+  public Map<String, LoadResult> loadAllEnabled() {
+    List<JobDefinitionEntity> enabledDefs = jobDefinitionRepository.findByEnabled(true);
+
+    Map<String, LoadResult> results = new LinkedHashMap<>();
+
+    for (JobDefinitionEntity def : enabledDefs) {
+      // Skip already-loaded definitions
+      if (LoadResult.LOADED.equals(def.getLoadStatus())) {
+        log.debug(
+            "Skipping already-loaded definition '{}' (id={})",
+            def.getJobName(),
+            def.getId());
+        results.put(
+            def.getJobName(),
+            new LoadResult(
+                def.getJobName(), LoadResult.LOADED, "Already loaded"));
+        continue;
+      }
+
+      try {
+        LoadResult result = loadJob(def.getId());
+        results.put(def.getJobName(), result);
+      } catch (Exception e) {
+        log.error(
+            "Failed to auto-load definition '{}' (id={}): {}",
+            def.getJobName(),
+            def.getId(),
+            e.getMessage());
+        results.put(
+            def.getJobName(),
+            new LoadResult(
+                def.getJobName(), LoadResult.FAILED, e.getMessage()));
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Determines the previous load status for rollback when a pre-condition validation fails after
+   * LOADING was already set.
+   */
+  private String getPreviousLoadStatus(JobDefinitionEntity entity, Long definitionId) {
+    // If we already had a classloader, it means we were LOADED before this attempt
+    if (classLoaders.containsKey(definitionId)) {
+      return LoadResult.LOADED;
+    }
+    // Otherwise revert to UNLOADED (the most common prior state for a fresh load)
+    return LoadResult.UNLOADED;
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/JobLoadException.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/JobLoadException.java
@@ -1,0 +1,14 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+/** Thrown when a dynamic plugin JAR fails to load or configure. */
+public class JobLoadException extends RuntimeException {
+
+  public JobLoadException(String message) {
+    super(message);
+  }
+
+  public JobLoadException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/JobUnloadConflictException.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/JobUnloadConflictException.java
@@ -1,0 +1,17 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+/**
+ * Thrown when an unload is blocked because the job has running executions and {@code force}
+ * was not requested. Maps to HTTP 409 Conflict in the controller layer.
+ */
+public class JobUnloadConflictException extends RuntimeException {
+
+  public JobUnloadConflictException(String message) {
+    super(message);
+  }
+
+  public JobUnloadConflictException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/LoadResult.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/LoadResult.java
@@ -1,0 +1,11 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+/** Outcome of a dynamic plugin load, unload, or reload operation. */
+public record LoadResult(String jobName, String status, String message) {
+
+  /** Status constants for consistent usage across the service. */
+  public static final String LOADED = "LOADED";
+  public static final String UNLOADED = "UNLOADED";
+  public static final String FAILED = "FAILED";
+}

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
@@ -1,0 +1,488 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import com.fronzec.api.BatchJobPlugin;
+import com.fronzec.api.JobMetadata;
+import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistrationException;
+import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistryService;
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.context.ApplicationContext;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@ExtendWith(MockitoExtension.class)
+class DynamicJobLoaderServiceTest {
+
+  @Mock private JobDefinitionRepository jobDefinitionRepository;
+  @Mock private PluginRegistryService pluginRegistryService;
+  @Mock private ApplicationContext applicationContext;
+  @Mock private JobRepository jobRepository;
+  @Mock private PlatformTransactionManager transactionManager;
+
+  @InjectMocks private DynamicJobLoaderService service;
+
+  private Path tempDir;
+  private String validJarPath;
+
+  // ── Setup / teardown ──────────────────────────────────────────────────────
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tempDir = Files.createTempDirectory("loader-service-test-");
+    // Create a real (empty) file so JAR existence validation passes
+    Path jarFile = tempDir.resolve("test-plugin.jar");
+    Files.createFile(jarFile);
+    validJarPath = jarFile.toString();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (tempDir != null) {
+      try (var walk = Files.walk(tempDir)) {
+        walk
+            .sorted(Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.deleteIfExists(p);
+                  } catch (IOException ignored) {
+                    // best-effort cleanup
+                  }
+                });
+      } catch (IOException ignored) {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  // ── Helper: entity stub ───────────────────────────────────────────────────
+
+  private JobDefinitionEntity createEntity(
+      long id, String jobName, boolean enabled, String loadStatus) {
+    JobDefinitionEntity entity = new JobDefinitionEntity();
+    entity.setId(id);
+    entity.setJobName(jobName);
+    entity.setJarFilePath(validJarPath);
+    entity.setMainClassName("com.test.TestPlugin");
+    entity.setEnabled(enabled);
+    entity.setLoadStatus(loadStatus);
+    return entity;
+  }
+
+  // ── Successful load ───────────────────────────────────────────────────────
+
+  @Test
+  void loadJob_validPlugin_registersAndReturnsLoaded() throws Exception {
+    JobDefinitionEntity entity = createEntity(1L, "test-job", true, null);
+
+    when(jobDefinitionRepository.findById(1L)).thenReturn(Optional.of(entity));
+    doNothing()
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      LoadResult result = service.loadJob(1L);
+
+      assertEquals("test-job", result.jobName());
+      assertEquals(LoadResult.LOADED, result.status());
+      assertTrue(result.message().contains("Successfully loaded"));
+      assertEquals(LoadResult.LOADED, entity.getLoadStatus());
+      assertNull(entity.getLoadError());
+
+      verify(pluginRegistryService)
+          .registerDynamicPlugin(any(BatchJobPlugin.class), any(DynamicJobClassLoader.class));
+    }
+  }
+
+  // ── Load failures ─────────────────────────────────────────────────────────
+
+  @Test
+  void loadJob_missingJarFile_setsFailed() {
+    JobDefinitionEntity entity = createEntity(2L, "missing-jar-job", true, null);
+    entity.setJarFilePath("/nonexistent/path.jar");
+
+    when(jobDefinitionRepository.findById(2L)).thenReturn(Optional.of(entity));
+
+    JobLoadException ex = assertThrows(JobLoadException.class, () -> service.loadJob(2L));
+    assertTrue(ex.getMessage().contains("JAR file not found"));
+    assertEquals(LoadResult.FAILED, entity.getLoadStatus());
+    assertNotNull(entity.getLoadError());
+  }
+
+  @Test
+  void loadJob_classNotImplementingBatchJobPlugin_setsFailed() throws Exception {
+    JobDefinitionEntity entity = createEntity(3L, "bad-plugin-job", true, null);
+
+    when(jobDefinitionRepository.findById(3L)).thenReturn(Optional.of(entity));
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin")).thenAnswer(inv -> String.class);
+            })) {
+
+      JobLoadException ex = assertThrows(JobLoadException.class, () -> service.loadJob(3L));
+      assertTrue(
+          ex.getMessage().contains("does not implement BatchJobPlugin"),
+          "Expected 'does not implement' but got: " + ex.getMessage());
+      assertEquals(LoadResult.FAILED, entity.getLoadStatus());
+      assertNotNull(entity.getLoadError());
+    }
+  }
+
+  @Test
+  void loadJob_nameMismatch_setsFailed() throws Exception {
+    JobDefinitionEntity entity = createEntity(4L, "other-name", true, null);
+
+    when(jobDefinitionRepository.findById(4L)).thenReturn(Optional.of(entity));
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      JobLoadException ex = assertThrows(JobLoadException.class, () -> service.loadJob(4L));
+      assertTrue(
+          ex.getMessage().contains("declares jobName="),
+          "Expected 'declares jobName=' but got: " + ex.getMessage());
+      assertEquals(LoadResult.FAILED, entity.getLoadStatus());
+    }
+  }
+
+  @Test
+  void loadJob_classNotFound_setsFailed() throws Exception {
+    JobDefinitionEntity entity = createEntity(5L, "bad-class-job", true, null);
+
+    when(jobDefinitionRepository.findById(5L)).thenReturn(Optional.of(entity));
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenThrow(new ClassNotFoundException("com.test.TestPlugin"));
+            })) {
+
+      JobLoadException ex = assertThrows(JobLoadException.class, () -> service.loadJob(5L));
+      assertTrue(
+          ex.getMessage().contains("Failed to load job"),
+          "Expected 'Failed to load job' but got: " + ex.getMessage());
+      assertEquals(LoadResult.FAILED, entity.getLoadStatus());
+      assertNotNull(entity.getLoadError());
+    }
+  }
+
+  @Test
+  void loadJob_configureJobFails_setsFailed() throws Exception {
+    JobDefinitionEntity entity = createEntity(17L, "test-job", true, null);
+
+    when(jobDefinitionRepository.findById(17L)).thenReturn(Optional.of(entity));
+    doThrow(new PluginRegistrationException("configureJob failed"))
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      JobLoadException ex = assertThrows(JobLoadException.class, () -> service.loadJob(17L));
+      assertTrue(
+          ex.getMessage().contains("configureJob failed"),
+          "Expected 'configureJob failed' but got: " + ex.getMessage());
+      assertEquals(LoadResult.FAILED, entity.getLoadStatus());
+      assertNotNull(entity.getLoadError());
+    }
+  }
+
+  // ── Pre-condition validations ─────────────────────────────────────────────
+
+  @Test
+  void loadJob_definitionNotFound_throwsNoSuchElementException() {
+    when(jobDefinitionRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThrows(NoSuchElementException.class, () -> service.loadJob(999L));
+  }
+
+  @Test
+  void loadJob_disabledDefinition_throwsIllegalStateException() {
+    JobDefinitionEntity entity = createEntity(6L, "disabled-job", false, null);
+
+    when(jobDefinitionRepository.findById(6L)).thenReturn(Optional.of(entity));
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> service.loadJob(6L));
+    assertTrue(ex.getMessage().contains("disabled"));
+  }
+
+  @Test
+  void loadJob_alreadyLoaded_throwsIllegalStateException() {
+    JobDefinitionEntity entity = createEntity(7L, "already-loaded", true, LoadResult.LOADED);
+
+    when(jobDefinitionRepository.findById(7L)).thenReturn(Optional.of(entity));
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> service.loadJob(7L));
+    assertTrue(ex.getMessage().contains("already loaded"));
+  }
+
+  // ── Unload ────────────────────────────────────────────────────────────────
+
+  @Test
+  void unloadJob_success_updatesStatus() {
+    JobDefinitionEntity entity =
+        createEntity(8L, "unloadable-job", true, LoadResult.LOADED);
+
+    when(jobDefinitionRepository.findById(8L)).thenReturn(Optional.of(entity));
+    when(jobRepository.findRunningJobExecutions("unloadable-job"))
+        .thenReturn(Collections.emptySet());
+    doNothing().when(pluginRegistryService).unregisterDynamicPlugin("unloadable-job");
+
+    LoadResult result = service.unloadJob(8L, false);
+
+    assertEquals("unloadable-job", result.jobName());
+    assertEquals(LoadResult.UNLOADED, result.status());
+    assertEquals(LoadResult.UNLOADED, entity.getLoadStatus());
+    verify(pluginRegistryService).unregisterDynamicPlugin("unloadable-job");
+  }
+
+  @Test
+  void unloadJob_runningExecutions_notForced_throwsConflict() {
+    JobDefinitionEntity entity =
+        createEntity(9L, "running-job", true, LoadResult.LOADED);
+
+    when(jobDefinitionRepository.findById(9L)).thenReturn(Optional.of(entity));
+    when(jobRepository.findRunningJobExecutions("running-job"))
+        .thenReturn(Set.of(mock(JobExecution.class)));
+
+    JobUnloadConflictException ex =
+        assertThrows(JobUnloadConflictException.class, () -> service.unloadJob(9L, false));
+    assertTrue(ex.getMessage().contains("running execution"));
+    verify(pluginRegistryService, never()).unregisterDynamicPlugin(any());
+  }
+
+  @Test
+  void unloadJob_runningExecutions_forced_succeeds() {
+    JobDefinitionEntity entity =
+        createEntity(10L, "force-unload-job", true, LoadResult.LOADED);
+
+    when(jobDefinitionRepository.findById(10L)).thenReturn(Optional.of(entity));
+    doNothing().when(pluginRegistryService).unregisterDynamicPlugin("force-unload-job");
+
+    LoadResult result = service.unloadJob(10L, true);
+
+    assertEquals(LoadResult.UNLOADED, result.status());
+    verify(pluginRegistryService).unregisterDynamicPlugin("force-unload-job");
+  }
+
+  @Test
+  void unloadJob_definitionNotFound_throwsNoSuchElementException() {
+    when(jobDefinitionRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThrows(NoSuchElementException.class, () -> service.unloadJob(999L, false));
+  }
+
+  // ── Reload ────────────────────────────────────────────────────────────────
+
+  @Test
+  void reloadJob_unloadsThenLoads_atomic() throws Exception {
+    JobDefinitionEntity entity =
+        createEntity(11L, "test-job", true, LoadResult.LOADED);
+
+    when(jobDefinitionRepository.findById(11L)).thenReturn(Optional.of(entity));
+    doNothing().when(pluginRegistryService).unregisterDynamicPlugin("test-job");
+    doNothing()
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      LoadResult result = service.reloadJob(11L);
+
+      assertEquals(LoadResult.LOADED, result.status());
+      verify(pluginRegistryService).unregisterDynamicPlugin("test-job");
+      verify(pluginRegistryService)
+          .registerDynamicPlugin(any(BatchJobPlugin.class), any(DynamicJobClassLoader.class));
+    }
+  }
+
+  // ── loadAllEnabled ────────────────────────────────────────────────────────
+
+  @Test
+  void loadAllEnabled_skipsAlreadyLoaded_loadsOthers() throws Exception {
+    JobDefinitionEntity loaded =
+        createEntity(12L, "already-loaded", true, LoadResult.LOADED);
+    JobDefinitionEntity pending = createEntity(13L, "test-job", true, null);
+
+    when(jobDefinitionRepository.findByEnabled(true)).thenReturn(List.of(loaded, pending));
+    when(jobDefinitionRepository.findById(13L)).thenReturn(Optional.of(pending));
+    doNothing()
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      Map<String, LoadResult> results = service.loadAllEnabled();
+
+      assertEquals(2, results.size());
+      assertTrue(results.containsKey("already-loaded"));
+      assertEquals(LoadResult.LOADED, results.get("already-loaded").status());
+      assertTrue(results.get("already-loaded").message().contains("Already loaded"));
+
+      assertTrue(results.containsKey("test-job"));
+      assertEquals(LoadResult.LOADED, results.get("test-job").status());
+    }
+  }
+
+  @Test
+  void loadAllEnabled_oneFails_othersStillLoaded() throws Exception {
+    JobDefinitionEntity good = createEntity(14L, "test-job", true, null);
+    JobDefinitionEntity bad = createEntity(15L, "bad-job", true, null);
+    bad.setJarFilePath("/nonexistent/bad.jar");
+
+    when(jobDefinitionRepository.findByEnabled(true)).thenReturn(List.of(good, bad));
+    when(jobDefinitionRepository.findById(14L)).thenReturn(Optional.of(good));
+    when(jobDefinitionRepository.findById(15L)).thenReturn(Optional.of(bad));
+    doNothing()
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    try (MockedConstruction<DynamicJobClassLoader> mocked =
+        mockConstruction(
+            DynamicJobClassLoader.class,
+            (mock, ctx) -> {
+              when(mock.loadClass("com.test.TestPlugin"))
+                  .thenAnswer(inv -> TestBatchJobPlugin.class);
+            })) {
+
+      Map<String, LoadResult> results = service.loadAllEnabled();
+
+      assertEquals(2, results.size());
+      assertEquals(LoadResult.LOADED, results.get("test-job").status());
+      assertEquals(LoadResult.FAILED, results.get("bad-job").status());
+      assertTrue(
+          results.get("bad-job").message().contains("JAR file not found"),
+          "Expected 'JAR file not found' but got: " + results.get("bad-job").message());
+    }
+  }
+
+  // ── Inner test plugin ─────────────────────────────────────────────────────
+
+  /**
+   * Minimal {@link BatchJobPlugin} implementation used in {@code mockConstruction} tests where the
+   * mocked classloader returns this class.
+   *
+   * <p>Must be {@code public} so it can be instantiated via reflection from a mocked classloader
+   * context.
+   */
+  public static class TestBatchJobPlugin implements BatchJobPlugin {
+
+    @Override
+    public String getJobName() {
+      return "test-job";
+    }
+
+    @Override
+    public String getVersion() {
+      return "1.0-test";
+    }
+
+    @Override
+    public Job configureJob(
+        JobRepository jobRepository,
+        PlatformTransactionManager transactionManager,
+        ApplicationContext parentContext) {
+      return new JobBuilder("test-job", jobRepository)
+          .start(
+              new StepBuilder("test-step", jobRepository)
+                  .tasklet((c, cc) -> RepeatStatus.FINISHED)
+                  .build())
+          .build();
+    }
+
+    @Override
+    public Map<String, String> getDefaultParameters() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public List<String> getRequiredDependencies() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public JobMetadata getMetadata() {
+      return new JobMetadata() {
+        @Override
+        public String getDisplayName() {
+          return "Test Plugin";
+        }
+
+        @Override
+        public String getDescription() {
+          return "Test BatchJobPlugin implementation";
+        }
+
+        @Override
+        public String getAuthor() {
+          return "test";
+        }
+
+        @Override
+        public List<String> getTags() {
+          return Collections.emptyList();
+        }
+
+        @Override
+        public Duration getEstimatedRuntime() {
+          return Duration.ZERO;
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
## PR 2 of 4 — Stacked to `plugin-architecture`

⚠️ **Budget warning**: 847 lines (356 service + 488 tests). 57% son tests.

### What
`DynamicJobLoaderService` — orquesta la carga de plugins desde JARs usando `DynamicJobClassLoader`.

### Changes
- **`DynamicJobLoaderService`** (@Service): loadJob(), unloadJob(), reloadJob(), loadAllEnabled()
  - Validación: entity existe, enabled, no duplicado
  - Classloader → loadClass → instantiate → configureJob → registerDynamicPlugin
  - Status DB transitions: LOADING → LOADED | FAILED, UNLOADED
  - Running-job guard en unload (con force override)
- **`LoadResult`** record (jobName, status, message)
- **`JobLoadException`** y **`JobUnloadConflictException`**
- **`PluginRegistryService`**: remueve classloaderRef en unregisterDynamicPlugin()
- **16 unit tests** con mockConstruction

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 69 tests, 0 failures, BUILD SUCCESS
```

### Depends on
PR #35 (merged — DynamicJobClassLoader)

### Next PR
PR 3: Controller endpoints + auto-load

### Related
- Chain strategy: stacked-to-main