### PR TITLE
Phase 4 PR 3: Load/Unload/Reload Endpoints + Auto-Loader

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/PluginAutoLoader.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/PluginAutoLoader.java
@@ -1,0 +1,60 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.loader;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/**
+ * Auto-loads all enabled, not-yet-loaded plugin definitions on application startup.
+ *
+ * <p>Runs via {@link ApplicationRunner} after the full application context is
+ * initialised, so repository, registry, and transaction manager dependencies are
+ * ready. Individual plugin failures are logged at {@code WARN} level but do
+ * <strong>not</strong> block startup.
+ *
+ * <p>Package-private scope — this is infrastructure wiring, not a public API
+ * entry point.
+ */
+@Component
+class PluginAutoLoader implements ApplicationRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(PluginAutoLoader.class);
+
+  private final DynamicJobLoaderService loaderService;
+
+  PluginAutoLoader(DynamicJobLoaderService loaderService) {
+    this.loaderService = loaderService;
+  }
+
+  @Override
+  public void run(ApplicationArguments args) {
+    log.info("Starting auto-load of enabled plugins...");
+    Map<String, LoadResult> results = loaderService.loadAllEnabled();
+
+    long loadedCount =
+        results.values().stream().filter(r -> LoadResult.LOADED.equals(r.status())).count();
+    long alreadyLoadedCount =
+        results.values().stream()
+            .filter(r -> LoadResult.LOADED.equals(r.status()) && "Already loaded".equals(r.message()))
+            .count();
+    long failedCount =
+        results.values().stream().filter(r -> LoadResult.FAILED.equals(r.status())).count();
+
+    log.info(
+        "Auto-load complete: {} newly loaded, {} already loaded, {} failed ({} total)",
+        loadedCount - alreadyLoadedCount,
+        alreadyLoadedCount,
+        failedCount,
+        results.size());
+
+    if (failedCount > 0) {
+      results.values().stream()
+          .filter(r -> LoadResult.FAILED.equals(r.status()))
+          .forEach(r -> log.warn("  Failed to auto-load '{}': {}", r.jobName(), r.message()));
+    }
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/GlobalExceptionHandler.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 /* 2024-2025 */
 package com.fronzec.frbatchservice.web;
 
+import com.fronzec.frbatchservice.batchjobs.plugins.loader.JobLoadException;
+import com.fronzec.frbatchservice.batchjobs.plugins.loader.JobUnloadConflictException;
 import com.fronzec.frbatchservice.batchjobs.plugins.service.DuplicateJobDefinitionException;
 import com.fronzec.frbatchservice.batchjobs.plugins.service.InvalidJarException;
 import com.fronzec.frbatchservice.web.dto.ErrorResponse;
@@ -82,6 +84,43 @@ public class GlobalExceptionHandler {
                 "Payload Too Large",
                 "File size exceeds the maximum allowed upload size",
                 request));
+  }
+
+  /**
+   * Maps {@link JobLoadException} — a missing or invalid JAR, a class that does not
+   * implement the plugin contract, or a configuration failure — to {@code 400 Bad
+   * Request}.
+   */
+  @ExceptionHandler(JobLoadException.class)
+  public ResponseEntity<ErrorResponse> handleJobLoad(
+      JobLoadException ex, HttpServletRequest request) {
+    log.error("Job load failed: {}", ex.getMessage());
+    return ResponseEntity.badRequest()
+        .body(buildError(400, "Bad Request", ex.getMessage(), request));
+  }
+
+  /**
+   * Maps {@link JobUnloadConflictException} — a job with running executions where
+   * {@code force} was not requested — to {@code 409 Conflict}.
+   */
+  @ExceptionHandler(JobUnloadConflictException.class)
+  public ResponseEntity<ErrorResponse> handleUnloadConflict(
+      JobUnloadConflictException ex, HttpServletRequest request) {
+    log.warn("Job unload conflict: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(buildError(409, "Conflict", ex.getMessage(), request));
+  }
+
+  /**
+   * Maps {@link IllegalStateException} — e.g. a definition that is disabled or
+   * already loaded — to {@code 409 Conflict}.
+   */
+  @ExceptionHandler(IllegalStateException.class)
+  public ResponseEntity<ErrorResponse> handleIllegalState(
+      IllegalStateException ex, HttpServletRequest request) {
+    log.warn("Illegal state: {}", ex.getMessage());
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(buildError(409, "Conflict", ex.getMessage(), request));
   }
 
   /**

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/JobManagementController.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/JobManagementController.java
@@ -2,6 +2,8 @@
 package com.fronzec.frbatchservice.web;
 
 import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.loader.DynamicJobLoaderService;
+import com.fronzec.frbatchservice.batchjobs.plugins.loader.LoadResult;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobParameterTemplateRepository;
 import com.fronzec.frbatchservice.batchjobs.plugins.service.JarUploadService;
@@ -11,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,6 +47,10 @@ import org.springframework.web.multipart.MultipartFile;
  *   <li>{@code PUT  /definitions/{id}/enable} — enable a definition</li>
  *   <li>{@code PUT  /definitions/{id}/disable} — disable a definition</li>
  *   <li>{@code DELETE /definitions/{id}} — remove DB row + JAR file from disk</li>
+ *   <li>{@code POST /definitions/{id}/load} — load plugin from JAR into registry</li>
+ *   <li>{@code POST /definitions/{id}/unload} — unregister plugin and close classloader</li>
+ *   <li>{@code POST /definitions/{id}/reload} — atomic unload + load</li>
+ *   <li>{@code POST /load-all} — load all enabled, not-yet-loaded definitions</li>
  * </ul>
  */
 @RestController
@@ -55,14 +62,17 @@ public class JobManagementController {
     private final JarUploadService jarUploadService;
     private final JobDefinitionRepository jobDefinitionRepository;
     private final JobParameterTemplateRepository jobParameterTemplateRepository;
+    private final DynamicJobLoaderService loaderService;
 
     public JobManagementController(
             JarUploadService jarUploadService,
             JobDefinitionRepository jobDefinitionRepository,
-            JobParameterTemplateRepository jobParameterTemplateRepository) {
+            JobParameterTemplateRepository jobParameterTemplateRepository,
+            DynamicJobLoaderService loaderService) {
         this.jarUploadService = jarUploadService;
         this.jobDefinitionRepository = jobDefinitionRepository;
         this.jobParameterTemplateRepository = jobParameterTemplateRepository;
+        this.loaderService = loaderService;
     }
 
     /**
@@ -199,5 +209,74 @@ public class JobManagementController {
         jobDefinitionRepository.delete(entity);
         log.info("Job definition deleted: id={}, jobName={}", id, entity.getJobName());
         return ResponseEntity.noContent().build();
+    }
+
+    // ─── Dynamic plugin loading / unloading ────────────────────────────────────
+
+    /**
+     * Loads a job definition from its JAR, instantiates the plugin, and registers it
+     * with the job registry.
+     *
+     * <p>Returns {@code 200 OK} with {@link LoadResult} on success.
+     * {@code 404 Not Found} if the definition does not exist (via
+     * {@link GlobalExceptionHandler#handleNotFound}).
+     * {@code 409 Conflict} if the definition is disabled or already loaded (via
+     * {@code IllegalStateException}).
+     * {@code 400 Bad Request} if the JAR is invalid or the plugin class is missing
+     * (via {@code JobLoadException}).
+     */
+    @PostMapping("/definitions/{id}/load")
+    public ResponseEntity<LoadResult> loadJob(@PathVariable long id) {
+        LoadResult result = loaderService.loadJob(id);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Unloads a previously loaded job: unregisters from the registry, closes the
+     * classloader, and marks the definition as {@code UNLOADED}.
+     *
+     * <p>Returns {@code 200 OK} with {@link LoadResult} on success.
+     * {@code 404 Not Found} if the definition does not exist.
+     * {@code 409 Conflict} if the job has running executions and {@code force} is
+     * {@code false} (via {@link
+     * com.fronzec.frbatchservice.batchjobs.plugins.loader.JobUnloadConflictException}).
+     */
+    @PostMapping("/definitions/{id}/unload")
+    public ResponseEntity<LoadResult> unloadJob(
+            @PathVariable long id,
+            @RequestParam(defaultValue = "false") boolean force) {
+        LoadResult result = loaderService.unloadJob(id, force);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Reloads a job by unloading (forced) then loading sequentially. The operation is
+     * sequential, so the status never appears partially ready.
+     *
+     * <p>Returns {@code 200 OK} with {@link LoadResult} on success.
+     * {@code 404 Not Found} if the definition does not exist.
+     * {@code 400 Bad Request} if the load step fails (via {@code JobLoadException}).
+     */
+    @PostMapping("/definitions/{id}/reload")
+    public ResponseEntity<LoadResult> reloadJob(@PathVariable long id) {
+        LoadResult result = loaderService.reloadJob(id);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * Loads all enabled job definitions whose {@code loadStatus} is not already
+     * {@code LOADED}. Each definition is loaded independently; one failure does not
+     * block the rest.
+     *
+     * <p>Returns {@code 200 OK} with a map from job name to per-definition
+     * {@link LoadResult}.
+     */
+    @PostMapping("/load-all")
+    public ResponseEntity<Map<String, LoadResult>> loadAllEnabled() {
+        Map<String, LoadResult> results = loaderService.loadAllEnabled();
+        log.info(
+                "load-all complete: {} definitions processed",
+                results.size());
+        return ResponseEntity.ok(results);
     }
 }


### PR DESCRIPTION
## PR 3 of 4 — Stacked to `plugin-architecture`

### What
REST layer for dynamic job loading + startup auto-loader. Integration tests come in PR 4.

### Changes
- **4 nuevos endpoints** en `JobManagementController`:
  - `POST /jobs/definitions/{id}/load` — load plugin from uploaded JAR
  - `POST /jobs/definitions/{id}/unload?force=false` — unload with running-job guard
  - `POST /jobs/definitions/{id}/reload` — forced unload + load
  - `POST /jobs/load-all` — batch load all enabled definitions
- **3 nuevos handlers** en `GlobalExceptionHandler`:
  - `JobLoadException` → 400, `JobUnloadConflictException` → 409, `IllegalStateException` → 409
- **`PluginAutoLoader`** (`ApplicationRunner`): carga automática al startup de todas las definiciones con `enabled=true`, no bloquea el arranque

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 69 tests, 0 failures, BUILD SUCCESS
```

### Depends on
PR #36 (merged — DynamicJobLoaderService)

### Next PR
PR 4: Integration tests + backward compat verification (capstone)

### Related
- Chain strategy: stacked-to-main