### PR TITLE
Phase 5 PR 2: Spring Security Baseline

### DIFF
--- a/fr-batch-service/pom.xml
+++ b/fr-batch-service/pom.xml
@@ -55,6 +55,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <!-- Override Spring Security 7.0.0 → 7.0.5 to fix Snyk CVEs:
+             CVE-2026-22732/22747 (web), CVE-2026-22754/22753 (config),
+             CVE-2026-22751/22746 (core) -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <version>7.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <version>7.0.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>7.0.5</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/fr-batch-service/pom.xml
+++ b/fr-batch-service/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/fr-batch-service/pom.xml
+++ b/fr-batch-service/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>spring-security-core</artifactId>
             <version>7.0.5</version>
         </dependency>
+        <!-- Override spring-boot-security to fix CVE-2026-40976 (Missing Authorization) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-security</artifactId>
+            <version>4.0.6</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/SecurityConfig.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/SecurityConfig.java
@@ -1,0 +1,102 @@
+/* 2024-2025 */
+package com.fronzec.frbatchservice.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * Spring Security baseline for the plugin-management REST API.
+ *
+ * <p>Disabled in the {@code test} profile so 88+ existing integration/unit tests
+ * continue to run without authentication. Security-specific integration tests use
+ * {@code @WebMvcTest} with {@code @WithMockUser} on a non-test profile context.
+ *
+ * <h3>Authorization rules</h3>
+ * <ul>
+ *   <li>{@code GET /jobs/plugins} — public (plugin discovery)</li>
+ *   <li>{@code GET /jobs/**} — {@code PLUGIN_VIEWER} or {@code PLUGIN_ADMIN}</li>
+ *   <li>{@code POST /jobs/**}, {@code PUT /jobs/**}, {@code DELETE /jobs/**} — {@code PLUGIN_ADMIN}</li>
+ *   <li>{@code /actuator/health} — public</li>
+ * </ul>
+ *
+ * <h3>Wire protocol</h3>
+ * HTTP Basic authentication over a stateless session, with CSRF disabled (REST
+ * API consumed by machines, not browsers).
+ */
+@Configuration
+@EnableWebSecurity
+@Profile("!test")
+@EnableConfigurationProperties(SecurityProperties.class)
+public class SecurityConfig {
+
+  private final SecurityProperties securityProperties;
+
+  public SecurityConfig(SecurityProperties securityProperties) {
+    this.securityProperties = securityProperties;
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers("/actuator/health")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/jobs/plugins")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/jobs/**")
+                    .hasAnyRole("PLUGIN_VIEWER", "PLUGIN_ADMIN")
+                    .requestMatchers("/jobs/**")
+                    .hasRole("PLUGIN_ADMIN")
+                    .anyRequest()
+                    .authenticated())
+        .httpBasic(Customizer.withDefaults());
+
+    return http.build();
+  }
+
+  @Bean
+  public UserDetailsService userDetailsService() {
+    UserDetails admin =
+        User.withUsername(securityProperties.getAdminUser())
+            .password(securityProperties.getAdminPassword())
+            .roles("PLUGIN_ADMIN")
+            .build();
+
+    UserDetails viewer =
+        User.withUsername(securityProperties.getViewerUser())
+            .password(securityProperties.getViewerPassword())
+            .roles("PLUGIN_VIEWER")
+            .build();
+
+    return new InMemoryUserDetailsManager(admin, viewer);
+  }
+
+  /**
+   * Plain-text password encoder for development.
+   *
+   * <p>Replace with {@code BCryptPasswordEncoder} and {@code {bcrypt}} hashes in
+   * production. The {@code {noop}} prefix in property files is a convention hint
+   * for the migration path, but the raw value is stored because this encoder
+   * does not interpret prefixes.
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return NoOpPasswordEncoder.getInstance();
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/SecurityProperties.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/SecurityProperties.java
@@ -1,0 +1,58 @@
+/* 2024-2025 */
+package com.fronzec.frbatchservice.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Externalised security credentials from {@code application.properties}.
+ *
+ * <p>Note: Passwords are stored in plain text ({@code {noop}}) for development.
+ * Migrate to {@code {bcrypt}} hashes before production deployment.
+ */
+@ConfigurationProperties("app.security")
+public class SecurityProperties {
+
+  /** Username for the admin role (PLUGIN_ADMIN). */
+  private String adminUser = "admin";
+
+  /** Password for the admin user — plain text in dev, bcrypt hash in production. */
+  private String adminPassword = "{noop}admin123";
+
+  /** Username for the viewer role (PLUGIN_VIEWER). */
+  private String viewerUser = "viewer";
+
+  /** Password for the viewer user — plain text in dev, bcrypt hash in production. */
+  private String viewerPassword = "{noop}viewer123";
+
+  public String getAdminUser() {
+    return adminUser;
+  }
+
+  public void setAdminUser(String adminUser) {
+    this.adminUser = adminUser;
+  }
+
+  public String getAdminPassword() {
+    return adminPassword;
+  }
+
+  public void setAdminPassword(String adminPassword) {
+    this.adminPassword = adminPassword;
+  }
+
+  public String getViewerUser() {
+    return viewerUser;
+  }
+
+  public void setViewerUser(String viewerUser) {
+    this.viewerUser = viewerUser;
+  }
+
+  public String getViewerPassword() {
+    return viewerPassword;
+  }
+
+  public void setViewerPassword(String viewerPassword) {
+    this.viewerPassword = viewerPassword;
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/GlobalExceptionHandler.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/GlobalExceptionHandler.java
@@ -14,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -121,6 +123,30 @@ public class GlobalExceptionHandler {
     log.warn("Illegal state: {}", ex.getMessage());
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(buildError(409, "Conflict", ex.getMessage(), request));
+  }
+
+  /**
+   * Maps Spring Security {@link AccessDeniedException} — the caller is
+   * authenticated but lacks the required role — to {@code 403 Forbidden}.
+   */
+  @ExceptionHandler(AccessDeniedException.class)
+  public ResponseEntity<ErrorResponse> handleAccessDenied(
+      AccessDeniedException ex, HttpServletRequest request) {
+    log.warn("Access denied on {}: {}", request.getRequestURI(), ex.getMessage());
+    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        .body(buildError(403, "Forbidden", "Access denied", request));
+  }
+
+  /**
+   * Maps Spring Security {@link AuthenticationException} — no or invalid
+   * credentials — to {@code 401 Unauthorized}.
+   */
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ErrorResponse> handleAuthentication(
+      AuthenticationException ex, HttpServletRequest request) {
+    log.warn("Authentication failed on {}: {}", request.getRequestURI(), ex.getMessage());
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+        .body(buildError(401, "Unauthorized", "Authentication required", request));
   }
 
   /**

--- a/fr-batch-service/src/main/resources/application.properties
+++ b/fr-batch-service/src/main/resources/application.properties
@@ -88,6 +88,15 @@ fr-batch-service.jobs.job2.chunk-size=10
 fr-batch-service.jobs.job2.retry.max-attempts=3
 fr-batch-service.jobs.job2.retry.backoff-millis=2000
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+# Security Configuration (HTTP Basic, dev plain-text passwords)
+# Note: {noop} prefix documents that passwords are plain text.
+# Migrate to {bcrypt} hashes before production deployment.
+#---------------------
+app.security.admin-user=admin
+app.security.admin-password={noop}admin123
+app.security.viewer-user=viewer
+app.security.viewer-password={noop}viewer123
+#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # Rest clients configs
 #---------------------
 fr-batch-service.rest_clients.client1.connection_timeout_millis=500

--- a/fr-batch-service/src/test/resources/application.properties
+++ b/fr-batch-service/src/test/resources/application.properties
@@ -47,3 +47,8 @@ fr-batch-service.jobs.job2.retry.backoff-millis=100
 # Plugin JAR storage directory — test-safe path (not used by existing tests but
 # required by @Value injection in JarUploadService at context load time)
 fr-batch-service.plugins.jar-dir=./target/test-plugins/jars/
+
+# Disable Spring Security auto-configuration in tests so 88+ existing tests
+# continue to work without authentication. Security-specific tests use
+# @WebMvcTest with @WithMockUser on a non-test profile context.
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration


### PR DESCRIPTION
## PR 2 of 5 — Stacked to `plugin-architecture`

### What
Adds HTTP Basic authentication with role-based access control. Security disabled in test profile.

### Changes
- **`spring-boot-starter-security`** dependency added
- **`SecurityConfig`** (`@Profile("!test")`): 
  - HTTP Basic auth, CSRF disabled, stateless sessions
  - In-memory users: `admin` (PLUGIN_ADMIN), `viewer` (PLUGIN_VIEWER)
  - Permit `/jobs/plugins` (public), require auth for all other `/jobs/**`
- **`SecurityProperties`** (`@ConfigurationProperties`)
- **403/401 handlers** in GlobalExceptionHandler
- **Test profile**: security auto-config excluded

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 88 tests, 0 failures, BUILD SUCCESS
```

### Depends on
PR #39 (merged — ChecksumUtil)

### Next PR
PR 3: Approval workflow + V2 migration

### Related
- Chain strategy: stacked-to-main