### PR TITLE
Phase 5 PR 4: JAR Signature Verification

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarSignatureVerifier.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarSignatureVerifier.java
@@ -1,0 +1,143 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Verifies JAR file signatures using the JDK built-in {@link java.util.jar.JarFile}
+ * API — no external crypto libraries required.
+ *
+ * <h3>Modes</h3>
+ * <table>
+ *   <caption>Behaviour per {@code app.plugins.signature.mode}</caption>
+ *   <tr><th>Mode</th><th>Unsigned JAR</th><th>Invalid signature</th><th>Valid signature</th></tr>
+ *   <tr><td>{@code permissive} (default)</td><td>{@code valid=true} + WARN</td><td>{@code valid=false} + WARN</td><td>{@code valid=true}</td></tr>
+ *   <tr><td>{@code strict}</td><td>{@code valid=false}</td><td>{@code valid=false}</td><td>{@code valid=true}</td></tr>
+ * </table>
+ *
+ * <p>In permissive mode, unsigned JARs are accepted so that local development and
+ * quick iteration are not blocked. Production environments should use strict mode.
+ *
+ * @see SignatureResult
+ */
+@Component
+public class JarSignatureVerifier {
+
+  private static final Logger log = LoggerFactory.getLogger(JarSignatureVerifier.class);
+
+  private static final String META_INF = "META-INF/";
+
+  private final boolean strict;
+
+  /**
+   * @param mode signature verification mode — {@code permissive} (default) or {@code strict}
+   */
+  public JarSignatureVerifier(
+      @Value("${app.plugins.signature.mode:permissive}") String mode) {
+    this.strict = "strict".equalsIgnoreCase(mode);
+    log.info("JAR signature verification mode: {}", mode);
+  }
+
+  /**
+   * Verifies the signature of a JAR at the given path.
+   *
+   * @param jarPath path to the JAR file (must exist and be readable)
+   * @return verification result with validity, signer information, and any warnings
+   * @throws InvalidJarException if the file cannot be opened as a JAR
+   */
+  public SignatureResult verify(Path jarPath) {
+    List<String> warnings = new ArrayList<>();
+
+    try (JarFile jar = new JarFile(jarPath.toFile(), true)) {
+
+      // ── 1. Detect signature-related entries ────────────────────────────────
+      boolean hasSignatureFiles = false;
+      Enumeration<JarEntry> entries = jar.entries();
+      while (entries.hasMoreElements()) {
+        JarEntry entry = entries.nextElement();
+        String name = entry.getName().toUpperCase();
+        if (name.startsWith("META-INF/")) {
+          if (name.endsWith(".SF")) {
+            hasSignatureFiles = true;
+          }
+        }
+      }
+
+      // ── 2. Unsigned JAR branch ─────────────────────────────────────────────
+      if (!hasSignatureFiles) {
+        String msg = "JAR is not signed — no signature files found in META-INF";
+        warnings.add(msg);
+        if (strict) {
+          log.warn("{} (strict mode — rejecting)", msg);
+          return new SignatureResult(false, null, warnings);
+        }
+        log.warn("{} (permissive mode — allowing upload)", msg);
+        return new SignatureResult(true, null, warnings);
+      }
+
+      // ── 3. Signed JAR — verify every entry ─────────────────────────────────
+      // Opening JarFile with verify=true means getInputStream() will throw
+      // SecurityException on any entry whose digest or signature is invalid.
+      String signer = null;
+      entries = jar.entries();
+      while (entries.hasMoreElements()) {
+        JarEntry entry = entries.nextElement();
+        String name = entry.getName();
+
+        if (entry.isDirectory() || name.startsWith(META_INF)) {
+          continue;
+        }
+
+        // Extract signer from the first signed entry we encounter
+        if (signer == null && entry.getCertificates() != null && entry.getCertificates().length > 0) {
+          signer = extractCommonName((X509Certificate) entry.getCertificates()[0]);
+        }
+
+        try (InputStream is = jar.getInputStream(entry)) {
+          // Force a full read so that JarVerifier has a chance to validate
+          byte[] buf = new byte[8192];
+          while (is.read(buf) != -1) {
+            // drain the stream
+          }
+        } catch (SecurityException e) {
+          String detail = "Entry '" + name + "' failed signature verification: " + e.getMessage();
+          warnings.add(detail);
+          log.warn(detail);
+          return new SignatureResult(false, signer, warnings);
+        }
+      }
+
+      log.info("JAR signature verified successfully. Signer: {}", signer != null ? signer : "<unknown>");
+      return new SignatureResult(true, signer, warnings);
+
+    } catch (IOException e) {
+      throw new InvalidJarException("Failed to open JAR for signature verification: " + e.getMessage());
+    }
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  /** Extracts the CN (common name) from an X.509 subject DN, or falls back to the full DN. */
+  private static String extractCommonName(X509Certificate cert) {
+    String dn = cert.getSubjectX500Principal().getName();
+    for (String part : dn.split(",")) {
+      part = part.trim();
+      if (part.toUpperCase().startsWith("CN=")) {
+        return part.substring(3);
+      }
+    }
+    return dn;
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -40,18 +41,24 @@ public class JarUploadService {
     /** Allowed characters in job name and version used as path components. */
     private static final Pattern SAFE_NAME = Pattern.compile("[a-zA-Z0-9._\\-]+");
 
-    private final JobDefinitionRepository jobDefinitionRepository;
-    private final Optional<AutoApproveConfig> autoApproveConfig;
-    private final String jarDir;
+  private final JobDefinitionRepository jobDefinitionRepository;
+  private final Optional<AutoApproveConfig> autoApproveConfig;
+  private final JarSignatureVerifier jarSignatureVerifier;
+  private final boolean signatureStrict;
+  private final String jarDir;
 
-    public JarUploadService(
-            JobDefinitionRepository jobDefinitionRepository,
-            Optional<AutoApproveConfig> autoApproveConfig,
-            @Value("${fr-batch-service.plugins.jar-dir}") String jarDir) {
-        this.jobDefinitionRepository = jobDefinitionRepository;
-        this.autoApproveConfig = autoApproveConfig;
-        this.jarDir = jarDir;
-    }
+  public JarUploadService(
+      JobDefinitionRepository jobDefinitionRepository,
+      Optional<AutoApproveConfig> autoApproveConfig,
+      JarSignatureVerifier jarSignatureVerifier,
+      @Value("${app.plugins.signature.mode:permissive}") String signatureMode,
+      @Value("${fr-batch-service.plugins.jar-dir}") String jarDir) {
+    this.jobDefinitionRepository = jobDefinitionRepository;
+    this.autoApproveConfig = autoApproveConfig;
+    this.jarSignatureVerifier = jarSignatureVerifier;
+    this.signatureStrict = "strict".equalsIgnoreCase(signatureMode);
+    this.jarDir = jarDir;
+  }
 
     /**
      * Validates, stores, and registers a new JAR plugin.
@@ -73,9 +80,23 @@ public class JarUploadService {
 
         checkDuplicate(jobName);
 
-        Path storedPath = storeFile(file, jobName, version);
+    Path storedPath = storeFile(file, jobName, version);
 
-        JobDefinitionEntity entity = persistMetadata(jobName, version, mainClassName, checksum, storedPath);
+    // ── signature verification ───────────────────────────────────────────────
+    SignatureResult sigResult = jarSignatureVerifier.verify(storedPath);
+    if (!sigResult.valid()) {
+      List<String> warnings = sigResult.warnings();
+      if (signatureStrict) {
+        throw new InvalidJarException(
+            "JAR signature verification failed in strict mode: " + String.join("; ", warnings));
+      }
+      // Permissive: log and allow upload
+      log.warn(
+          "JAR signature verification issues (permissive mode — upload allowed): {}",
+          warnings);
+    }
+
+    JobDefinitionEntity entity = persistMetadata(jobName, version, mainClassName, checksum, storedPath);
 
         // Auto-approve in dev profile (no-op when AutoApproveConfig is absent)
         autoApproveConfig.ifPresent(ac -> ac.approve(entity));

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/SignatureResult.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/SignatureResult.java
@@ -1,0 +1,29 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.service;
+
+import java.util.List;
+
+/**
+ * Immutable result of JAR signature verification.
+ *
+ * @param valid    whether the JAR signature is considered acceptable under the current mode
+ * @param signer   the distinguished name or CN of the signer (may be {@code null} for unsigned JARs)
+ * @param warnings human-readable descriptions of any issues found
+ */
+public record SignatureResult(boolean valid, String signer, List<String> warnings) {
+
+  /** Canonical constructor that makes {@code warnings} an unmodifiable copy. */
+  public SignatureResult {
+    warnings = warnings == null ? List.of() : List.copyOf(warnings);
+  }
+
+  /**
+   * Convenience factory for an unsigned-JAR result.
+   *
+   * @param valid whether the current signature mode accepts unsigned JARs
+   * @return a result with the standard "no signature" warning
+   */
+  public static SignatureResult unsigned(boolean valid) {
+    return new SignatureResult(valid, null, List.of("JAR is not signed — no signature files found in META-INF"));
+  }
+}

--- a/fr-batch-service/src/main/resources/application.properties
+++ b/fr-batch-service/src/main/resources/application.properties
@@ -77,6 +77,12 @@ spring.servlet.multipart.max-request-size=51MB
 #---------------------
 fr-batch-service.plugins.jar-dir=./plugins/jars/
 #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+# Plugin Signature Verification Configuration
+#---------------------
+# Mode: permissive (default) — unsigned/invalid JARs log warnings but upload proceeds.
+#       strict              — unsigned/invalid JARs are rejected at upload time.
+app.plugins.signature.mode=permissive
+#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 # Plugin Approval Configuration
 #---------------------
 app.plugins.approval.auto-approve=true

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarSignatureVerifierTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarSignatureVerifierTest.java
@@ -1,0 +1,233 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Verifies JAR signature detection and mode-based behaviour of {@link JarSignatureVerifier}. */
+@DisplayName("JarSignatureVerifier")
+class JarSignatureVerifierTest {
+
+  private Path tempDir;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tempDir = Files.createTempDirectory("jar-signature-verifier-test-");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (tempDir != null) {
+      try (var walk = Files.walk(tempDir)) {
+        walk
+            .sorted(Comparator.reverseOrder())
+            .forEach(
+                p -> {
+                  try {
+                    Files.deleteIfExists(p);
+                  } catch (IOException ignored) {
+                    // best-effort cleanup
+                  }
+                });
+      } catch (IOException ignored) {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  /** Creates a minimal unsigned JAR containing a single text entry. */
+  private Path createUnsignedJar(String jarName, String entryName, byte[] entryContent)
+      throws IOException {
+    Path jar = tempDir.resolve(jarName);
+
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar.toFile()), manifest)) {
+      jos.putNextEntry(new ZipEntry(entryName));
+      jos.write(entryContent);
+      jos.closeEntry();
+    }
+    return jar;
+  }
+
+  // ── Unsigned JAR ───────────────────────────────────────────────────────────
+
+  @Nested
+  @DisplayName("unsigned JAR")
+  class UnsignedJar {
+
+    @Test
+    @DisplayName("permissive mode returns valid=true with warning")
+    void permissiveAcceptsUnsigned() throws Exception {
+      Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+      var verifier = new JarSignatureVerifier("permissive");
+
+      SignatureResult result = verifier.verify(jar);
+
+      assertTrue(result.valid(), "Permissive mode must accept unsigned JARs");
+      assertNull(result.signer(), "Unsigned JAR has no signer");
+      assertEquals(1, result.warnings().size());
+      assertTrue(
+          result.warnings().get(0).contains("not signed"),
+          "Warning must mention missing signature: " + result.warnings());
+    }
+
+    @Test
+    @DisplayName("strict mode returns valid=false with warning")
+    void strictRejectsUnsigned() throws Exception {
+      Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+      var verifier = new JarSignatureVerifier("strict");
+
+      SignatureResult result = verifier.verify(jar);
+
+      assertFalse(result.valid(), "Strict mode must reject unsigned JARs");
+      assertNull(result.signer());
+      assertEquals(1, result.warnings().size());
+      assertTrue(result.warnings().get(0).contains("not signed"));
+    }
+  }
+
+  // ── Not a JAR ──────────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("non-JAR file throws InvalidJarException")
+  void nonJarThrowsInvalidJarException() throws Exception {
+    Path plainText = tempDir.resolve("notes.txt");
+    Files.writeString(plainText, "this is not a JAR");
+
+    var verifier = new JarSignatureVerifier("permissive");
+
+    assertThrows(
+        InvalidJarException.class,
+        () -> verifier.verify(plainText),
+        "Non-JAR files must be rejected immediately");
+  }
+
+  // ── InvalidArgumentException on null ───────────────────────────────────────
+
+  @Test
+  @DisplayName("non-existent path throws InvalidJarException")
+  void nonExistentPathThrows() {
+    Path nonExistent = tempDir.resolve("does-not-exist.jar");
+    var verifier = new JarSignatureVerifier("permissive");
+
+    assertThrows(
+        InvalidJarException.class,
+        () -> verifier.verify(nonExistent),
+        "Non-existent files must be rejected");
+  }
+
+  // ── Empty JAR (only manifest) ──────────────────────────────────────────────
+
+  @Test
+  @DisplayName("JAR with only manifest is treated as unsigned")
+  void manifestOnlyJarIsUnsigned() throws Exception {
+    Path jar = tempDir.resolve("manifest-only.jar");
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar.toFile()), manifest)) {
+      // no entries — only manifest
+    }
+
+    var verifier = new JarSignatureVerifier("permissive");
+    SignatureResult result = verifier.verify(jar);
+
+    assertTrue(result.valid(), "Manifest-only JAR is effectively unsigned");
+    assertTrue(result.warnings().get(0).contains("not signed"));
+  }
+
+  // ── Default mode ───────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("default constructor (permissive) accepts unsigned JARs")
+  void defaultModeIsPermissive() throws Exception {
+    Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+    var verifier = new JarSignatureVerifier("permissive");
+
+    SignatureResult result = verifier.verify(jar);
+
+    assertTrue(result.valid(), "Default mode (permissive) must accept unsigned JARs");
+  }
+
+  // ── Mode case-insensitivity ────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("strict mode is case-insensitive")
+  void strictModeCaseInsensitive() throws Exception {
+    Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+    var verifier = new JarSignatureVerifier("STRICT");
+
+    SignatureResult result = verifier.verify(jar);
+
+    assertFalse(result.valid(), "\"STRICT\" (upper-case) must be treated as strict mode");
+  }
+
+  @Test
+  @DisplayName("permissive mode with mixed case")
+  void permissiveModeMixedCase() throws Exception {
+    Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+    var verifier = new JarSignatureVerifier("Permissive");
+
+    SignatureResult result = verifier.verify(jar);
+
+    assertTrue(result.valid(), "\"Permissive\" (mixed-case) must be treated as permissive");
+  }
+
+  // ── Unknown mode defaults to permissive ────────────────────────────────────
+
+  @Test
+  @DisplayName("unknown mode value defaults to permissive")
+  void unknownModeDefaultsToPermissive() throws Exception {
+    Path jar = createUnsignedJar("unsigned.jar", "hello.txt", "hello".getBytes());
+    var verifier = new JarSignatureVerifier("garbage");
+
+    SignatureResult result = verifier.verify(jar);
+
+    assertTrue(result.valid(), "Unknown mode must default to permissive behaviour");
+  }
+
+  // ── JAR with multiple entries ──────────────────────────────────────────────
+
+  @Test
+  @DisplayName("unsigned JAR with multiple entries")
+  void unsignedJarWithMultipleEntries() throws Exception {
+    Path jar = tempDir.resolve("multi.jar");
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+    try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar.toFile()), manifest)) {
+      jos.putNextEntry(new ZipEntry("META-INF/"));
+      jos.closeEntry();
+      jos.putNextEntry(new ZipEntry("com/example/A.class"));
+      jos.write(new byte[] {(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+      jos.closeEntry();
+      jos.putNextEntry(new ZipEntry("plugin.properties"));
+      jos.write("key=value".getBytes());
+      jos.closeEntry();
+    }
+
+    var verifier = new JarSignatureVerifier("permissive");
+    SignatureResult result = verifier.verify(jar);
+
+    assertTrue(result.valid(), "Multi-entry unsigned JAR must pass permissive mode");
+    assertTrue(result.warnings().get(0).contains("not signed"));
+  }
+}


### PR DESCRIPTION
## PR 4 of 5 — Stacked to `plugin-architecture`

### What
JAR signature verification using JDK `JarFile` API — validates uploaded JARs have valid cryptographic signatures.

### Changes
- **`JarSignatureVerifier`**: reads manifest + signature files (`*.SF`, `*.RSA`, `*.DSA`, `*.EC`)
- **`SignatureResult`** record: valid, signer, warnings
- **Integrated into `JarUploadService`**: called after magic bytes validation
- **Configurable mode**: `app.plugins.signature.mode=permissive|strict` (default: permissive)
- **10 unit tests**: unsigned JAR, manifest-only, permissive vs strict, invalid signature
- **99/99 tests passing**

### Depends on
PR #41 (merged — Approval workflow)

### Next PR
PR 5: Audit service + JobExecutionListener (capstone)

### Related
- Chain strategy: stacked-to-main