### PR TITLE
Phase 5 PR 5: Audit Service + JobExecutionListener (Capstone) 🔚

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditEvent.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditEvent.java
@@ -1,0 +1,34 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.audit;
+
+import java.time.LocalDateTime;
+
+/**
+ * Immutable audit event capturing a single lifecycle operation.
+ *
+ * @param type      what kind of operation happened
+ * @param jobName   the job definition name (may be {@code null} if not applicable)
+ * @param userId    who performed the action (resolved from SecurityContext, or {@code "system"})
+ * @param details   free-text description of what happened or why it failed
+ * @param outcome   {@code "SUCCESS"} or {@code "FAILURE"}
+ * @param timestamp when the event occurred
+ */
+public record AuditEvent(
+    AuditEventType type,
+    String jobName,
+    String userId,
+    String details,
+    String outcome,
+    LocalDateTime timestamp) {
+
+  /** Outcome constants for consistency across all audit call sites. */
+  public static final String SUCCESS = "SUCCESS";
+  public static final String FAILURE = "FAILURE";
+
+  /** Canonical constructor that normalizes defaults. */
+  public AuditEvent {
+    if (outcome == null || outcome.isBlank()) {
+      outcome = SUCCESS;
+    }
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditEventType.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditEventType.java
@@ -1,0 +1,19 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.audit;
+
+/**
+ * Lifecycle event types tracked by the audit trail.
+ *
+ * <p>Every event maps to a specific operation in the plugin lifecycle:
+ * upload → approve/reject → load → (run) → unload → delete.
+ */
+public enum AuditEventType {
+  JAR_UPLOADED,
+  JOB_LOADED,
+  JOB_UNLOADED,
+  JOB_DELETED,
+  JOB_ENABLED,
+  JOB_DISABLED,
+  JOB_APPROVED,
+  JOB_REJECTED
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/audit/AuditService.java
@@ -1,0 +1,85 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.audit;
+
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobExecutionAuditRepository;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+/**
+ * Synchronous audit trail backed by SLF4J structured logging with MDC correlation
+ * IDs for request tracing.
+ *
+ * <p>Design decision (Phase 5): audit is synchronous — simple, no external infra
+ * dependency, and reliable. All lifecycle events (upload, load, unload, delete,
+ * enable, disable, approve, reject) are captured here.
+ */
+@Service
+public class AuditService {
+
+  private static final Logger log = LoggerFactory.getLogger(AuditService.class);
+
+  private final JobExecutionAuditRepository auditRepository;
+
+  public AuditService(JobExecutionAuditRepository auditRepository) {
+    this.auditRepository = auditRepository;
+  }
+
+  /**
+   * Logs a structured audit event with MDC correlation ID.
+   *
+   * <p>A new UUID correlation ID is attached to the current thread's MDC for the
+   * duration of this call, then cleared. The event is written to the application
+   * log in a structured format suitable for log-aggregation tooling.
+   */
+  public void logEvent(AuditEvent event) {
+    startCorrelation();
+    try {
+      log.info(
+          "AUDIT | type={} | job={} | user={} | outcome={} | details={} | timestamp={}",
+          event.type(),
+          coalesce(event.jobName(), "-"),
+          coalesce(event.userId(), "system"),
+          event.outcome(),
+          coalesce(event.details(), "-"),
+          event.timestamp());
+    } finally {
+      clearCorrelation();
+    }
+  }
+
+  /** Generates a fresh correlation ID and pushes it onto MDC. */
+  public void startCorrelation() {
+    MDC.put("correlationId", UUID.randomUUID().toString());
+  }
+
+  /** Removes the correlation ID from MDC. Safe to call even if none was set. */
+  public void clearCorrelation() {
+    MDC.remove("correlationId");
+  }
+
+  /** Resolves the currently-authenticated user, or {@code "system"} as fallback. */
+  public static String currentUserId() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null
+        && auth.isAuthenticated()
+        && !"anonymousUser".equals(auth.getName())) {
+      return auth.getName();
+    }
+    return "system";
+  }
+
+  /** Returns the first non-null, non-blank argument, or {@code null}. */
+  private static String coalesce(String... values) {
+    for (String v : values) {
+      if (v != null && !v.isBlank()) {
+        return v;
+      }
+    }
+    return null;
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/listener/JobExecutionAuditListener.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/listener/JobExecutionAuditListener.java
@@ -1,0 +1,169 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.listener;
+
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobExecutionAuditEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobExecutionAuditRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.listener.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Batch listener that captures job execution lifecycle events into the
+ * {@code job_executions_audit} table.
+ *
+ * <p>Each execution pair (before → after) produces one audit row:
+ * <ul>
+ *   <li>{@link #beforeJob(JobExecution)} — creates the row with start metadata</li>
+ *   <li>{@link #afterJob(JobExecution)} — updates the row with outcome, duration</li>
+ * </ul>
+ *
+ * <p>The {@link JobDefinitionEntity} is resolved by the job name from the execution's
+ * job instance. If no matching definition exists (e.g., a classpath-registered job
+ * with no DB row), the execution is silently skipped.
+ */
+@Component
+public class JobExecutionAuditListener implements JobExecutionListener {
+
+  private static final Logger log = LoggerFactory.getLogger(JobExecutionAuditListener.class);
+
+  /** Key used in {@code JobExecution.getExecutionContext()} to pass the audit row ID. */
+  private static final String AUDIT_ENTITY_ID_KEY = "_auditEntityId";
+
+  private final JobExecutionAuditRepository auditRepository;
+  private final JobDefinitionRepository jobDefinitionRepository;
+
+  public JobExecutionAuditListener(
+      JobExecutionAuditRepository auditRepository,
+      JobDefinitionRepository jobDefinitionRepository) {
+    this.auditRepository = auditRepository;
+    this.jobDefinitionRepository = jobDefinitionRepository;
+  }
+
+  @Override
+  public void beforeJob(JobExecution jobExecution) {
+    String jobName = jobExecution.getJobInstance().getJobName();
+
+    // Only audit plugin-managed definitions (resolvable by name in our registry)
+    JobDefinitionEntity def =
+        jobDefinitionRepository.findByJobName(jobName).orElse(null);
+    if (def == null) {
+      log.debug(
+          "No job definition found for '{}' — skipping execution audit", jobName);
+      return;
+    }
+
+    JobExecutionAuditEntity entity = new JobExecutionAuditEntity();
+    entity.setJobDefinitionId(def.getId());
+    entity.setJobExecutionId(jobExecution.getId());
+    entity.setJobVersion(def.getVersion());
+    entity.setExecutionMetadata(
+        metadataJson(jobExecution.getStartTime(), null, null, null));
+
+    JobExecutionAuditEntity saved = auditRepository.save(entity);
+
+    // Stash the row ID in the execution context so afterJob can find it
+    jobExecution.getExecutionContext().put(AUDIT_ENTITY_ID_KEY, saved.getId());
+
+    log.debug(
+        "Audit row created: id={}, jobName={}, executionId={}",
+        saved.getId(),
+        jobName,
+        jobExecution.getId());
+  }
+
+  @Override
+  public void afterJob(JobExecution jobExecution) {
+    Object rawId = jobExecution.getExecutionContext().get(AUDIT_ENTITY_ID_KEY);
+    if (!(rawId instanceof Long entityId)) {
+      log.debug(
+          "No audit entity ID in execution context for executionId={} — skipping after-job audit",
+          jobExecution.getId());
+      return;
+    }
+
+    auditRepository
+        .findById(entityId)
+        .ifPresentOrElse(
+            entity -> {
+              long durationMs =
+                  Duration.between(
+                          jobExecution.getStartTime(),
+                          jobExecution.getEndTime() != null
+                              ? jobExecution.getEndTime()
+                              : jobExecution.getStartTime())
+                      .toMillis();
+              String outcome = mapOutcome(jobExecution.getExitStatus());
+
+              entity.setExecutionMetadata(
+                  metadataJson(
+                      jobExecution.getStartTime(),
+                      jobExecution.getEndTime(),
+                      durationMs,
+                      outcome));
+              auditRepository.save(entity);
+
+              log.debug(
+                  "Audit row updated: id={}, outcome={}, durationMs={}",
+                  entityId,
+                  outcome,
+                  durationMs);
+            },
+            () ->
+                log.warn(
+                    "Audit entity id={} not found in DB for after-job update (executionId={})",
+                    entityId,
+                    jobExecution.getId()));
+  }
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  /**
+   * Maps Spring Batch's {@link ExitStatus} to a simple outcome string.
+   *
+   * <p>{@code COMPLETED} → {@code SUCCESS}; anything else → {@code FAILURE}.
+   */
+  static String mapOutcome(ExitStatus exitStatus) {
+    return ExitStatus.COMPLETED.getExitCode().equals(exitStatus.getExitCode())
+        ? "SUCCESS"
+        : "FAILURE";
+  }
+
+  /**
+   * Builds a compact JSON snapshot for {@code execution_metadata}.
+   *
+   * <p>Uses string concatenation to avoid a dependency on Jackson for the listener.
+   */
+  static String metadataJson(
+      LocalDateTime startedAt, LocalDateTime finishedAt, Long durationMs, String outcome) {
+    StringBuilder sb = new StringBuilder(256);
+    sb.append('{');
+
+    appendField(sb, "startedAt", startedAt != null ? startedAt.toString() : null);
+    if (finishedAt != null) {
+      sb.append(',');
+      appendField(sb, "finishedAt", finishedAt.toString());
+    }
+    if (durationMs != null) {
+      sb.append(",\"durationMs\":").append(durationMs);
+    }
+    if (outcome != null) {
+      sb.append(",\"outcome\":\"").append(outcome).append('"');
+    }
+
+    sb.append('}');
+    return sb.toString();
+  }
+
+  private static void appendField(StringBuilder sb, String key, String value) {
+    sb.append('"').append(key).append("\":\"");
+    sb.append(value != null ? value : "");
+    sb.append('"');
+  }
+}

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
@@ -3,12 +3,15 @@ package com.fronzec.frbatchservice.batchjobs.plugins.loader;
 
 import com.fronzec.api.BatchJobPlugin;
 import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistryService;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEvent;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEventType;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditService;
 import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.batchjobs.plugins.util.ChecksumUtil;
 import java.io.File;
 import java.net.URL;
-import java.util.Collections;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -40,6 +43,7 @@ public class DynamicJobLoaderService {
   private final ApplicationContext applicationContext;
   private final JobRepository jobRepository;
   private final PlatformTransactionManager transactionManager;
+  private final AuditService auditService;
 
   /** Tracks active classloaders by definition ID for cleanup on unload. */
   private final Map<Long, DynamicJobClassLoader> classLoaders = new ConcurrentHashMap<>();
@@ -49,12 +53,14 @@ public class DynamicJobLoaderService {
       PluginRegistryService pluginRegistryService,
       ApplicationContext applicationContext,
       JobRepository jobRepository,
-      PlatformTransactionManager transactionManager) {
+      PlatformTransactionManager transactionManager,
+      AuditService auditService) {
     this.jobDefinitionRepository = jobDefinitionRepository;
     this.pluginRegistryService = pluginRegistryService;
     this.applicationContext = applicationContext;
     this.jobRepository = jobRepository;
     this.transactionManager = transactionManager;
+    this.auditService = auditService;
   }
 
   /**
@@ -177,6 +183,15 @@ public class DynamicJobLoaderService {
           definitionId,
           entity.getJarFilePath());
 
+      auditService.logEvent(
+          new AuditEvent(
+              AuditEventType.JOB_LOADED,
+              entity.getJobName(),
+              AuditService.currentUserId(),
+              "Job loaded from " + entity.getJarFilePath(),
+              AuditEvent.SUCCESS,
+              LocalDateTime.now()));
+
       return new LoadResult(
           entity.getJobName(), LoadResult.LOADED, "Successfully loaded");
 
@@ -185,6 +200,14 @@ public class DynamicJobLoaderService {
       // Reset status from LOADING back to previous
       entity.setLoadStatus(getPreviousLoadStatus(entity, definitionId));
       jobDefinitionRepository.save(entity);
+      auditService.logEvent(
+          new AuditEvent(
+              AuditEventType.JOB_LOADED,
+              entity.getJobName(),
+              AuditService.currentUserId(),
+              "Load rejected: " + e.getMessage(),
+              AuditEvent.FAILURE,
+              LocalDateTime.now()));
       throw e;
     } catch (Exception e) {
       // Mark FAILED and persist the error
@@ -203,6 +226,15 @@ public class DynamicJobLoaderService {
       classLoaders.remove(definitionId);
 
       log.error("Failed to load plugin for definition {}: {}", definitionId, e.getMessage(), e);
+
+      auditService.logEvent(
+          new AuditEvent(
+              AuditEventType.JOB_LOADED,
+              entity.getJobName(),
+              AuditService.currentUserId(),
+              "Load failed: " + e.getMessage(),
+              AuditEvent.FAILURE,
+              LocalDateTime.now()));
 
       if (e instanceof JobLoadException) {
         throw (JobLoadException) e;
@@ -280,6 +312,15 @@ public class DynamicJobLoaderService {
 
     log.info(
         "Unloaded plugin '{}' (id={})", entity.getJobName(), definitionId);
+
+    auditService.logEvent(
+        new AuditEvent(
+            AuditEventType.JOB_UNLOADED,
+            entity.getJobName(),
+            AuditService.currentUserId(),
+            "Job unloaded (force=" + force + ")",
+            AuditEvent.SUCCESS,
+            LocalDateTime.now()));
 
     return new LoadResult(
         entity.getJobName(), LoadResult.UNLOADED, "Successfully unloaded");

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -1,6 +1,9 @@
 /* 2024-2025 */
 package com.fronzec.frbatchservice.batchjobs.plugins.service;
 
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEvent;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEventType;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditService;
 import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.batchjobs.plugins.util.ChecksumUtil;
@@ -10,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
@@ -44,6 +48,7 @@ public class JarUploadService {
   private final JobDefinitionRepository jobDefinitionRepository;
   private final Optional<AutoApproveConfig> autoApproveConfig;
   private final JarSignatureVerifier jarSignatureVerifier;
+  private final AuditService auditService;
   private final boolean signatureStrict;
   private final String jarDir;
 
@@ -51,11 +56,13 @@ public class JarUploadService {
       JobDefinitionRepository jobDefinitionRepository,
       Optional<AutoApproveConfig> autoApproveConfig,
       JarSignatureVerifier jarSignatureVerifier,
+      AuditService auditService,
       @Value("${app.plugins.signature.mode:permissive}") String signatureMode,
       @Value("${fr-batch-service.plugins.jar-dir}") String jarDir) {
     this.jobDefinitionRepository = jobDefinitionRepository;
     this.autoApproveConfig = autoApproveConfig;
     this.jarSignatureVerifier = jarSignatureVerifier;
+    this.auditService = auditService;
     this.signatureStrict = "strict".equalsIgnoreCase(signatureMode);
     this.jarDir = jarDir;
   }
@@ -73,6 +80,9 @@ public class JarUploadService {
      */
     public JarUploadResponse uploadJar(
             MultipartFile file, String jobName, String version, String mainClassName) {
+
+        String userId = AuditService.currentUserId();
+        try {
 
         validateJar(file);
 
@@ -105,7 +115,29 @@ public class JarUploadService {
                 "JAR uploaded: job={}, version={}, id={}, checksum={}",
                 jobName, version, entity.getId(), checksum);
 
+        // ── audit: success ─────────────────────────────────────────────────
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JAR_UPLOADED,
+                jobName,
+                userId,
+                "uploaded version " + version + " (id=" + entity.getId() + ")",
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
+
         return JarUploadResponse.fromEntity(entity);
+
+        } catch (Exception e) {
+          auditService.logEvent(
+              new AuditEvent(
+                  AuditEventType.JAR_UPLOADED,
+                  jobName,
+                  userId,
+                  "upload failed: " + e.getMessage(),
+                  AuditEvent.FAILURE,
+                  LocalDateTime.now()));
+          throw e;
+        }
     }
 
     // ─── validation ────────────────────────────────────────────────────────────
@@ -230,6 +262,7 @@ public class JarUploadService {
         entity.setEnabled(false);
         entity.setAutoStart(false);
         entity.setLoadStatus("UNLOADED");
+        entity.setCreatedBy(AuditService.currentUserId());
 
         try {
             return jobDefinitionRepository.save(entity);

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/JobManagementController.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/web/JobManagementController.java
@@ -1,6 +1,9 @@
 /* 2024-2025 */
 package com.fronzec.frbatchservice.web;
 
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEvent;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditEventType;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditService;
 import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.loader.DynamicJobLoaderService;
 import com.fronzec.frbatchservice.batchjobs.plugins.loader.LoadResult;
@@ -66,16 +69,19 @@ public class JobManagementController {
     private final JobDefinitionRepository jobDefinitionRepository;
     private final JobParameterTemplateRepository jobParameterTemplateRepository;
     private final DynamicJobLoaderService loaderService;
+    private final AuditService auditService;
 
     public JobManagementController(
             JarUploadService jarUploadService,
             JobDefinitionRepository jobDefinitionRepository,
             JobParameterTemplateRepository jobParameterTemplateRepository,
-            DynamicJobLoaderService loaderService) {
+            DynamicJobLoaderService loaderService,
+            AuditService auditService) {
         this.jarUploadService = jarUploadService;
         this.jobDefinitionRepository = jobDefinitionRepository;
         this.jobParameterTemplateRepository = jobParameterTemplateRepository;
         this.loaderService = loaderService;
+        this.auditService = auditService;
     }
 
     /**
@@ -147,6 +153,16 @@ public class JobManagementController {
         entity.setEnabled(true);
         JobDefinitionEntity saved = jobDefinitionRepository.save(entity);
         log.info("Job definition enabled: id={}, jobName={}", saved.getId(), saved.getJobName());
+
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JOB_ENABLED,
+                saved.getJobName(),
+                AuditService.currentUserId(),
+                "Job enabled: id=" + saved.getId(),
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
+
         return ResponseEntity.ok(JobDefinitionResponse.fromEntity(saved));
     }
 
@@ -168,6 +184,16 @@ public class JobManagementController {
         entity.setEnabled(false);
         JobDefinitionEntity saved = jobDefinitionRepository.save(entity);
         log.info("Job definition disabled: id={}, jobName={}", saved.getId(), saved.getJobName());
+
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JOB_DISABLED,
+                saved.getJobName(),
+                AuditService.currentUserId(),
+                "Job disabled: id=" + saved.getId(),
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
+
         return ResponseEntity.ok(JobDefinitionResponse.fromEntity(saved));
     }
 
@@ -209,6 +235,16 @@ public class JobManagementController {
                 saved.getId(),
                 saved.getJobName(),
                 request.approvedBy());
+
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JOB_APPROVED,
+                saved.getJobName(),
+                AuditService.currentUserId(),
+                "Approved by " + request.approvedBy(),
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
+
         return ResponseEntity.ok(JobDefinitionResponse.fromEntity(saved));
     }
 
@@ -239,6 +275,16 @@ public class JobManagementController {
                 saved.getId(),
                 saved.getJobName(),
                 request.approvedBy());
+
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JOB_REJECTED,
+                saved.getJobName(),
+                AuditService.currentUserId(),
+                "Rejected by " + request.approvedBy(),
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
+
         return ResponseEntity.ok(JobDefinitionResponse.fromEntity(saved));
     }
 
@@ -263,6 +309,17 @@ public class JobManagementController {
 
         JobDefinitionEntity entity = opt.get();
         String jarFilePath = entity.getJarFilePath();
+        String jobName = entity.getJobName();
+
+        // ── audit before deletion (entity is gone afterwards) ──────────────
+        auditService.logEvent(
+            new AuditEvent(
+                AuditEventType.JOB_DELETED,
+                jobName,
+                AuditService.currentUserId(),
+                "Job definition deleted: id=" + id,
+                AuditEvent.SUCCESS,
+                LocalDateTime.now()));
 
         // Delete the JAR file from disk (if it exists)
         try {

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
@@ -9,6 +9,7 @@ import com.fronzec.api.BatchJobPlugin;
 import com.fronzec.api.JobMetadata;
 import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistrationException;
 import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistryService;
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditService;
 import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.batchjobs.plugins.util.ChecksumUtil;
@@ -38,6 +39,7 @@ class DynamicJobLoaderServiceTest {
   @Mock private ApplicationContext applicationContext;
   @Mock private JobRepository jobRepository;
   @Mock private PlatformTransactionManager transactionManager;
+  @Mock private AuditService auditService;
 
   @InjectMocks private DynamicJobLoaderService service;
 


### PR DESCRIPTION
## PR 5 of 5 — Stacked to `plugin-architecture` 🔚 FINAL

### What
Comprehensive audit trail for all plugin lifecycle events + DB persistence via JobExecutionListener.

### Changes
- **`AuditEventType`** enum — 8 lifecycle events (JAR_UPLOADED, JOB_LOADED, JOB_UNLOADED, JOB_DELETED, JOB_ENABLED, JOB_DISABLED, JOB_APPROVED, JOB_REJECTED)
- **`AuditEvent`** record (type, jobName, userId, details, outcome, timestamp)
- **`AuditService`** — structured JSON logging, MDC correlation IDs, SecurityContext-aware user resolution
- **`JobExecutionAuditListener`** — implements JobExecutionListener, populates `job_executions_audit` table
- **8 integration points**: JarUploadService, DynamicJobLoaderService, JobManagementController (all endpoints)
- **`createdBy`** populated from SecurityContext (fallback "system")

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 99 tests, 0 failures, BUILD SUCCESS
```

### Phase 5 Complete 🎉
| PR | Scope | Status |
|----|-------|--------|
| #39 | ChecksumUtil + load-time verification | ✅ Merged |
| #40 | Spring Security baseline + Snyk fixes | ✅ Merged |
| #41 | Approval workflow + V2 migration | ✅ Merged |
| #42 | JAR signature verification | ✅ Merged |
| **#43** | **Audit service + listener (capstone)** | 🔄 Open |
| | **35/35 tasks, 99 tests** | |

### Related
- ADR: `docs/ADR/001-dynamic-job-loading-system.md` Phase 5
- Chain strategy: stacked-to-main