### PR TITLE
Fix: local MySQL dev runtime fixes

### DIFF
--- a/fr-batch-service/pom.xml
+++ b/fr-batch-service/pom.xml
@@ -110,6 +110,10 @@
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+        </dependency>
         <!-- Override transitive jackson-core (brought by flyway-core)
              with 2.21.3 to fix Snyk: resource exhaustion CVE -->
         <dependency>

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/PluginAutoLoader.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/PluginAutoLoader.java
@@ -33,28 +33,32 @@ class PluginAutoLoader implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     log.info("Starting auto-load of enabled plugins...");
-    Map<String, LoadResult> results = loaderService.loadAllEnabled();
+    try {
+      Map<String, LoadResult> results = loaderService.loadAllEnabled();
 
-    long loadedCount =
-        results.values().stream().filter(r -> LoadResult.LOADED.equals(r.status())).count();
-    long alreadyLoadedCount =
+      long loadedCount =
+          results.values().stream().filter(r -> LoadResult.LOADED.equals(r.status())).count();
+      long alreadyLoadedCount =
+          results.values().stream()
+              .filter(r -> LoadResult.LOADED.equals(r.status()) && "Already loaded".equals(r.message()))
+              .count();
+      long failedCount =
+          results.values().stream().filter(r -> LoadResult.FAILED.equals(r.status())).count();
+
+      log.info(
+          "Auto-load complete: {} newly loaded, {} already loaded, {} failed ({} total)",
+          loadedCount - alreadyLoadedCount,
+          alreadyLoadedCount,
+          failedCount,
+          results.size());
+
+      if (failedCount > 0) {
         results.values().stream()
-            .filter(r -> LoadResult.LOADED.equals(r.status()) && "Already loaded".equals(r.message()))
-            .count();
-    long failedCount =
-        results.values().stream().filter(r -> LoadResult.FAILED.equals(r.status())).count();
-
-    log.info(
-        "Auto-load complete: {} newly loaded, {} already loaded, {} failed ({} total)",
-        loadedCount - alreadyLoadedCount,
-        alreadyLoadedCount,
-        failedCount,
-        results.size());
-
-    if (failedCount > 0) {
-      results.values().stream()
-          .filter(r -> LoadResult.FAILED.equals(r.status()))
-          .forEach(r -> log.warn("  Failed to auto-load '{}': {}", r.jobName(), r.message()));
+            .filter(r -> LoadResult.FAILED.equals(r.status()))
+            .forEach(r -> log.warn("  Failed to auto-load '{}': {}", r.jobName(), r.message()));
+      }
+    } catch (Exception e) {
+      log.warn("Auto-load skipped — database may not be ready: {}", e.getMessage());
     }
   }
 }

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -13,6 +13,7 @@ import com.fronzec.frbatchservice.web.dto.JarUploadResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -223,7 +224,7 @@ public class JarUploadService {
         }
 
         try {
-            file.transferTo(target.toFile());
+            Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new RuntimeException("Failed to store JAR at " + target, e);
         }

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/FlywayMigrationRunner.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/FlywayMigrationRunner.java
@@ -1,0 +1,43 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.config;
+
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Runs Flyway migrations explicitly when the default auto-configuration is
+ * bypassed by custom DataSource beans (e.g., {@link
+ * com.fronzec.frbatchservice.datasources.main.JpaConfig}).
+ *
+ * <p>Active only in the {@code local} profile.
+ */
+@Component
+@Profile("local")
+class FlywayMigrationRunner implements InitializingBean {
+
+  private static final Logger log = LoggerFactory.getLogger(FlywayMigrationRunner.class);
+
+  private final DataSource dataSource;
+
+  FlywayMigrationRunner(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    log.info("Running Flyway migrations...");
+    Flyway flyway =
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration")
+            .baselineOnMigrate(true)
+            .load();
+    int applied = flyway.migrate().migrationsExecuted;
+    log.info("Flyway migration complete — {} migration(s) applied", applied);
+  }
+}


### PR DESCRIPTION
## Fix: Local MySQL Dev Runtime

4 fixes discovered during local MySQL testing:

| # | Fix | Why |
|---|-----|-----|
| 1 | **`flyway-mysql`** dependency | Flyway 11+ requires separate MySQL module |
| 2 | **`Files.copy`** instead of `transferTo` | Jetty multipart `transferTo` fails silently |
| 3 | **try-catch** in `PluginAutoLoader` | Prevents crash if DB tables don't exist yet |
| 4 | **`FlywayMigrationRunner`** | Bypasses `JpaConfig` auto-config issue |

### Verification
```
mvn test -f fr-batch-service/pom.xml
# 120 tests, BUILD SUCCESS
```

### Related
- Chain strategy: stacked-to-main