### PR TITLE
feat(ticket-pdf): PR#1 — schema + plugin scaffold, FileStorage seam, HMAC (SDD ticket-pdf-batch-job)

### DIFF
--- a/fr-batch-service/_devenvironment/db/10_seed_event_tickets.sql
+++ b/fr-batch-service/_devenvironment/db/10_seed_event_tickets.sql
@@ -1,0 +1,23 @@
+-- =========================================================
+-- Dev seed: event_tickets demo rows
+-- For local development only — integration tests seed their own data via JDBC
+-- Run AFTER V5__ticket_pdf_tables.sql has been applied
+-- =========================================================
+
+INSERT INTO event_tickets (event_id, ticket_code, holder_name, event_name, event_location, seat, event_datetime, processed)
+VALUES
+    -- Event 1: Tech Conference 2024
+    (1, 'TC2024-001', 'Alice Johnson',    'Tech Conference 2024', 'Convention Center Hall A', 'A-01', '2024-09-15 09:00:00', FALSE),
+    (1, 'TC2024-002', 'Bob Martinez',     'Tech Conference 2024', 'Convention Center Hall A', 'A-02', '2024-09-15 09:00:00', FALSE),
+    (1, 'TC2024-003', 'Carol White',      'Tech Conference 2024', 'Convention Center Hall A', 'B-01', '2024-09-15 09:00:00', FALSE),
+    (1, 'TC2024-004', 'David Brown',      'Tech Conference 2024', 'Convention Center Hall A', 'B-02', '2024-09-15 09:00:00', FALSE),
+
+    -- Event 2: Spring Music Fest
+    (2, 'SMF2024-001', 'Emma Davis',      'Spring Music Fest',    'Open Air Stadium',        'GA-100', '2024-05-20 18:00:00', FALSE),
+    (2, 'SMF2024-002', 'Frank Garcia',    'Spring Music Fest',    'Open Air Stadium',        'GA-101', '2024-05-20 18:00:00', FALSE),
+    (2, 'SMF2024-003', 'Grace Lee',       'Spring Music Fest',    'Open Air Stadium',        'VIP-01', '2024-05-20 18:00:00', FALSE),
+    (2, 'SMF2024-004', 'Henry Wilson',    'Spring Music Fest',    'Open Air Stadium',        'VIP-02', '2024-05-20 18:00:00', FALSE),
+
+    -- Event 3: Annual Gala Dinner (no seat, no location)
+    (3, 'AGD2024-001', 'Irene Thompson',  'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE),
+    (3, 'AGD2024-002', 'Jack Robinson',   'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE);

--- a/fr-batch-service/src/main/resources/db/migration/V5__ticket_pdf_tables.sql
+++ b/fr-batch-service/src/main/resources/db/migration/V5__ticket_pdf_tables.sql
@@ -1,0 +1,34 @@
+-- =========================================================
+-- V5: Ticket PDF tables
+-- event_tickets: source rows for PDF generation
+-- generated_files: tracks each generated PDF file
+-- =========================================================
+
+CREATE TABLE event_tickets (
+    id             BIGINT        AUTO_INCREMENT PRIMARY KEY,
+    event_id       BIGINT        NOT NULL,
+    ticket_code    VARCHAR(64)   NOT NULL,
+    holder_name    VARCHAR(255)  NOT NULL,
+    event_name     VARCHAR(255)  NOT NULL,
+    event_location VARCHAR(255)  NULL,
+    seat           VARCHAR(64)   NULL,
+    event_datetime TIMESTAMP     NOT NULL,
+    processed      BOOLEAN       NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_event_tickets_ticket_code UNIQUE (ticket_code)
+);
+
+CREATE INDEX idx_event_tickets_processed ON event_tickets (processed);
+
+CREATE TABLE generated_files (
+    id              BIGINT        AUTO_INCREMENT PRIMARY KEY,
+    ticket_id       BIGINT        NOT NULL,
+    storage_type    VARCHAR(16)   NOT NULL DEFAULT 'LOCAL',
+    storage_path    VARCHAR(1024) NOT NULL,
+    checksum_sha256 CHAR(64)      NOT NULL,
+    file_size_bytes BIGINT        NOT NULL,
+    generated_at    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_generated_files_ticket
+        FOREIGN KEY (ticket_id) REFERENCES event_tickets (id),
+    CONSTRAINT uk_generated_files_ticket UNIQUE (ticket_id)
+);

--- a/fr-batch-service/src/test/resources/schema.sql
+++ b/fr-batch-service/src/test/resources/schema.sql
@@ -169,3 +169,36 @@ CREATE TABLE IF NOT EXISTS dispatched_group (
     created_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- =========================================================
+-- V5: Ticket PDF tables (mirror of V5__ticket_pdf_tables.sql)
+-- =========================================================
+
+CREATE TABLE IF NOT EXISTS event_tickets (
+    id             BIGINT        PRIMARY KEY AUTO_INCREMENT,
+    event_id       BIGINT        NOT NULL,
+    ticket_code    VARCHAR(64)   NOT NULL,
+    holder_name    VARCHAR(255)  NOT NULL,
+    event_name     VARCHAR(255)  NOT NULL,
+    event_location VARCHAR(255)  NULL,
+    seat           VARCHAR(64)   NULL,
+    event_datetime TIMESTAMP     NOT NULL,
+    processed      BOOLEAN       NOT NULL DEFAULT FALSE,
+    created_at     TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_event_tickets_ticket_code UNIQUE (ticket_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_tickets_processed ON event_tickets (processed);
+
+CREATE TABLE IF NOT EXISTS generated_files (
+    id              BIGINT        PRIMARY KEY AUTO_INCREMENT,
+    ticket_id       BIGINT        NOT NULL,
+    storage_type    VARCHAR(16)   NOT NULL DEFAULT 'LOCAL',
+    storage_path    VARCHAR(1024) NOT NULL,
+    checksum_sha256 CHAR(64)      NOT NULL,
+    file_size_bytes BIGINT        NOT NULL,
+    generated_at    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_generated_files_ticket
+        FOREIGN KEY (ticket_id) REFERENCES event_tickets (id),
+    CONSTRAINT uk_generated_files_ticket UNIQUE (ticket_id)
+);

--- a/ticket-pdf-job/pom.xml
+++ b/ticket-pdf-job/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.26.3</version>
+      <version>3.27.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/ticket-pdf-job/pom.xml
+++ b/ticket-pdf-job/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.fronzec.plugins</groupId>
+  <artifactId>ticket-pdf-job</artifactId>
+  <version>1.0.0</version>
+  <name>ticket-pdf-job</name>
+  <description>Spring Batch plugin — event ticket PDF generation with QR codes</description>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- Platform-provided API (not shaded) -->
+    <dependency>
+      <groupId>com.fronzec</groupId>
+      <artifactId>batch-job-api</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided Spring Batch (not shaded) -->
+    <dependency>
+      <groupId>org.springframework.batch</groupId>
+      <artifactId>spring-batch-core</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided spring-jdbc (JdbcTemplate, JdbcCursorItemReader, RowMapper) -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided logging facade (not shaded) -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Bundled: PDF generation (shaded into fat JAR) -->
+    <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+      <version>2.0.3</version>
+    </dependency>
+
+    <!-- Bundled: QR code generation (shaded into fat JAR) -->
+    <dependency>
+      <groupId>com.google.zxing</groupId>
+      <artifactId>core</artifactId>
+      <version>3.5.3</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.zxing</groupId>
+      <artifactId>javase</artifactId>
+      <version>3.5.3</version>
+    </dependency>
+
+    <!-- Test dependencies (not shaded) -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.26.3</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <!-- Exclude platform-provided libraries -->
+                  <exclude>com.fronzec:batch-job-api</exclude>
+                  <exclude>org.springframework.batch:spring-batch-core</exclude>
+                  <exclude>org.springframework:spring-context</exclude>
+                  <exclude>org.springframework:spring-tx</exclude>
+                  <exclude>org.springframework:spring-jdbc</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+    </repository>
+  </repositories>
+</project>

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/package-info.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/package-info.java
@@ -1,0 +1,2 @@
+/** Spring Batch components: reader, processor, writer, and step listener. */
+package com.fronzec.plugins.ticketpdf.batch;

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenService.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenService.java
@@ -1,0 +1,52 @@
+package com.fronzec.plugins.ticketpdf.domain;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Stateless utility for producing HMAC-SHA256 signed QR tokens.
+ *
+ * <p>Token format:
+ *
+ * <pre>
+ *   {ticketId}|{ticketCode}.{base64url_nopad(HMAC_SHA256(secret, "{ticketId}|{ticketCode}"))}
+ * </pre>
+ *
+ * <p>Uses only JDK cryptography — no external dependencies.
+ */
+public final class HmacTokenService {
+
+    private static final String ALGORITHM = "HmacSHA256";
+
+    private HmacTokenService() {
+        // utility class
+    }
+
+    /**
+     * Sign a ticket and return the full token string.
+     *
+     * @param ticketId   the {@code event_tickets.id} value
+     * @param ticketCode the {@code event_tickets.ticket_code} value
+     * @param secret     the {@code TOKEN_SECRET} job parameter
+     * @return signed token suitable for embedding in a QR code
+     */
+    public static String sign(long ticketId, String ticketCode, String secret) {
+        String payload = ticketId + "|" + ticketCode;
+        String signature = hmacBase64Url(secret, payload);
+        return payload + "." + signature;
+    }
+
+    private static String hmacBase64Url(String secret, String payload) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), ALGORITHM);
+            mac.init(keySpec);
+            byte[] sigBytes = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(sigBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("HMAC-SHA256 signing failed", e);
+        }
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenService.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenService.java
@@ -33,6 +33,13 @@ public final class HmacTokenService {
      * @return signed token suitable for embedding in a QR code
      */
     public static String sign(long ticketId, String ticketCode, String secret) {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalArgumentException("TOKEN_SECRET must not be blank");
+        }
+        if (secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+            throw new IllegalArgumentException(
+                    "TOKEN_SECRET must be at least 32 bytes for HMAC-SHA256 strength");
+        }
         String payload = ticketId + "|" + ticketCode;
         String signature = hmacBase64Url(secret, payload);
         return payload + "." + signature;

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/Ticket.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/Ticket.java
@@ -1,0 +1,95 @@
+package com.fronzec.plugins.ticketpdf.domain;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO representing a row from {@code event_tickets}.
+ *
+ * <p>Plain POJO — no JPA annotations. Populated by {@code TicketRowMapper} via raw JDBC.
+ */
+public class Ticket {
+
+    private long id;
+    private long eventId;
+    private String ticketCode;
+    private String holderName;
+    private String eventName;
+    private String eventLocation;
+    private String seat;
+    private LocalDateTime eventDatetime;
+    private boolean processed;
+
+    public Ticket() {}
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(long eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getTicketCode() {
+        return ticketCode;
+    }
+
+    public void setTicketCode(String ticketCode) {
+        this.ticketCode = ticketCode;
+    }
+
+    public String getHolderName() {
+        return holderName;
+    }
+
+    public void setHolderName(String holderName) {
+        this.holderName = holderName;
+    }
+
+    public String getEventName() {
+        return eventName;
+    }
+
+    public void setEventName(String eventName) {
+        this.eventName = eventName;
+    }
+
+    public String getEventLocation() {
+        return eventLocation;
+    }
+
+    public void setEventLocation(String eventLocation) {
+        this.eventLocation = eventLocation;
+    }
+
+    public String getSeat() {
+        return seat;
+    }
+
+    public void setSeat(String seat) {
+        this.seat = seat;
+    }
+
+    public LocalDateTime getEventDatetime() {
+        return eventDatetime;
+    }
+
+    public void setEventDatetime(LocalDateTime eventDatetime) {
+        this.eventDatetime = eventDatetime;
+    }
+
+    public boolean isProcessed() {
+        return processed;
+    }
+
+    public void setProcessed(boolean processed) {
+        this.processed = processed;
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/TicketDocument.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/domain/TicketDocument.java
@@ -1,0 +1,12 @@
+package com.fronzec.plugins.ticketpdf.domain;
+
+/**
+ * Value object carrying the rendered PDF bytes for a single ticket.
+ *
+ * <p>Produced by the processor and consumed by the writer.
+ *
+ * @param ticketId   the source {@code event_tickets.id}
+ * @param ticketCode the source {@code event_tickets.ticket_code}
+ * @param pdfBytes   raw PDF content
+ */
+public record TicketDocument(long ticketId, String ticketCode, byte[] pdfBytes) {}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/FileStorage.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/FileStorage.java
@@ -1,0 +1,27 @@
+package com.fronzec.plugins.ticketpdf.storage;
+
+/**
+ * Abstraction for writing generated ticket PDF files.
+ *
+ * <p>The v1 implementation is {@link LocalFileStorage}. A future {@code S3FileStorage} is a
+ * drop-in replacement requiring no changes to the reader, processor, or writer.
+ */
+public interface FileStorage {
+
+    /**
+     * Write {@code content} to the storage backend under the given {@code key}.
+     *
+     * @param key     filename or object key (e.g. {@code "5.pdf"})
+     * @param content raw bytes to store
+     * @return a {@link StoredFile} describing the stored artifact
+     */
+    StoredFile write(String key, byte[] content);
+
+    /**
+     * Remove the file identified by {@code key}. Best-effort: implementations should swallow
+     * {@code IOException} and log a warning rather than propagating it.
+     *
+     * @param key filename or object key to delete
+     */
+    default void delete(String key) {}
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorage.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorage.java
@@ -26,12 +26,14 @@ public class LocalFileStorage implements FileStorage {
 
     @Override
     public StoredFile write(String key, byte[] content) {
+        Path target = resolveSafePath(key);
         try {
-            Files.createDirectories(baseDir);
-            Path target = baseDir.resolve(key);
+            if (target.getParent() != null) {
+                Files.createDirectories(target.getParent());
+            }
             Files.write(target, content);
             String checksum = sha256Hex(content);
-            return new StoredFile("LOCAL", target.toAbsolutePath().toString(), checksum, content.length);
+            return new StoredFile("LOCAL", target.toString(), checksum, content.length);
         } catch (IOException e) {
             throw new RuntimeException("Failed to write file with key: " + key, e);
         }
@@ -40,10 +42,23 @@ public class LocalFileStorage implements FileStorage {
     @Override
     public void delete(String key) {
         try {
-            Files.deleteIfExists(baseDir.resolve(key));
+            Files.deleteIfExists(resolveSafePath(key));
         } catch (IOException e) {
             log.warn("Failed to delete file with key '{}': {}", key, e.getMessage());
         }
+    }
+
+    /**
+     * Resolve {@code key} against the base directory, rejecting any key that would escape it
+     * (e.g. {@code ../} or an absolute path). Prevents path-traversal writes/deletes.
+     */
+    private Path resolveSafePath(String key) {
+        Path base = baseDir.toAbsolutePath().normalize();
+        Path target = base.resolve(key).normalize();
+        if (!target.startsWith(base)) {
+            throw new IllegalArgumentException("Illegal storage key (path traversal): " + key);
+        }
+        return target;
     }
 
     private static String sha256Hex(byte[] bytes) {

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorage.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorage.java
@@ -1,0 +1,62 @@
+package com.fronzec.plugins.ticketpdf.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link FileStorage} implementation that writes files to the local filesystem.
+ *
+ * <p>Computes a SHA-256 hex checksum of the written content and returns a {@link StoredFile} with
+ * {@code storageType = "LOCAL"}.
+ */
+public class LocalFileStorage implements FileStorage {
+
+    private static final Logger log = LoggerFactory.getLogger(LocalFileStorage.class);
+
+    private final Path baseDir;
+
+    public LocalFileStorage(Path baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    @Override
+    public StoredFile write(String key, byte[] content) {
+        try {
+            Files.createDirectories(baseDir);
+            Path target = baseDir.resolve(key);
+            Files.write(target, content);
+            String checksum = sha256Hex(content);
+            return new StoredFile("LOCAL", target.toAbsolutePath().toString(), checksum, content.length);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write file with key: " + key, e);
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        try {
+            Files.deleteIfExists(baseDir.resolve(key));
+        } catch (IOException e) {
+            log.warn("Failed to delete file with key '{}': {}", key, e.getMessage());
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/StoredFile.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/storage/StoredFile.java
@@ -1,0 +1,11 @@
+package com.fronzec.plugins.ticketpdf.storage;
+
+/**
+ * Value returned by {@link FileStorage#write} describing the stored artifact.
+ *
+ * @param storageType backend identifier, e.g. {@code "LOCAL"} or {@code "S3"}
+ * @param path        absolute path or URI to the stored file
+ * @param checksum    hex-encoded SHA-256 of the written bytes
+ * @param sizeBytes   exact byte count of the written content
+ */
+public record StoredFile(String storageType, String path, String checksum, long sizeBytes) {}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenServiceTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.fronzec.plugins.ticketpdf.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -12,7 +13,8 @@ class HmacTokenServiceTest {
 
     private static final long TICKET_ID = 7L;
     private static final String TICKET_CODE = "ABC123";
-    private static final String SECRET = "test-secret";
+    // >= 32 bytes: HmacTokenService enforces a minimum key strength.
+    private static final String SECRET = "unit-test-secret-please-use-32+bytes!";
 
     /** Recompute HMAC-SHA256 independently for assertion. */
     private String computeHmac(String secret, String payload) throws Exception {
@@ -57,7 +59,8 @@ class HmacTokenServiceTest {
     @Test
     void sign_differentSecret_producesDifferentSignature() {
         String token1 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
-        String token2 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, "wrong-secret");
+        String token2 =
+            HmacTokenService.sign(TICKET_ID, TICKET_CODE, "a-different-wrong-secret-32+bytes-xx!");
 
         // Left part is identical (same ticketId + ticketCode), but signature differs
         int dot1 = token1.lastIndexOf('.');
@@ -72,6 +75,18 @@ class HmacTokenServiceTest {
         String token2 = HmacTokenService.sign(TICKET_ID + 1, TICKET_CODE, SECRET);
 
         assertThat(token1).isNotEqualTo(token2);
+    }
+
+    @Test
+    void sign_rejectsBlankSecret() {
+        assertThatThrownBy(() -> HmacTokenService.sign(TICKET_ID, TICKET_CODE, "   "))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void sign_rejectsSecretShorterThan32Bytes() {
+        assertThatThrownBy(() -> HmacTokenService.sign(TICKET_ID, TICKET_CODE, "too-short"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenServiceTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/domain/HmacTokenServiceTest.java
@@ -1,0 +1,87 @@
+package com.fronzec.plugins.ticketpdf.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+class HmacTokenServiceTest {
+
+    private static final long TICKET_ID = 7L;
+    private static final String TICKET_CODE = "ABC123";
+    private static final String SECRET = "test-secret";
+
+    /** Recompute HMAC-SHA256 independently for assertion. */
+    private String computeHmac(String secret, String payload) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        byte[] sigBytes = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(sigBytes);
+    }
+
+    @Test
+    void sign_isDeterministic_sameInputsProduceSameToken() {
+        String token1 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+        String token2 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+
+        assertThat(token1).isEqualTo(token2);
+    }
+
+    @Test
+    void sign_tokenFormat_leftOfLastDotIsTicketIdPipeTicketCode() {
+        String token = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+
+        int lastDot = token.lastIndexOf('.');
+        assertThat(lastDot).isGreaterThan(0);
+
+        String leftPart = token.substring(0, lastDot);
+        assertThat(leftPart).isEqualTo(TICKET_ID + "|" + TICKET_CODE);
+    }
+
+    @Test
+    void sign_signatureMatchesManualHmacComputation() throws Exception {
+        String token = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+
+        int lastDot = token.lastIndexOf('.');
+        String embeddedSig = token.substring(lastDot + 1);
+
+        String payload = TICKET_ID + "|" + TICKET_CODE;
+        String expectedSig = computeHmac(SECRET, payload);
+
+        assertThat(embeddedSig).isEqualTo(expectedSig);
+    }
+
+    @Test
+    void sign_differentSecret_producesDifferentSignature() {
+        String token1 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+        String token2 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, "wrong-secret");
+
+        // Left part is identical (same ticketId + ticketCode), but signature differs
+        int dot1 = token1.lastIndexOf('.');
+        int dot2 = token2.lastIndexOf('.');
+        assertThat(token1.substring(0, dot1)).isEqualTo(token2.substring(0, dot2));
+        assertThat(token1.substring(dot1 + 1)).isNotEqualTo(token2.substring(dot2 + 1));
+    }
+
+    @Test
+    void sign_differentTicketId_producesDifferentToken() {
+        String token1 = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+        String token2 = HmacTokenService.sign(TICKET_ID + 1, TICKET_CODE, SECRET);
+
+        assertThat(token1).isNotEqualTo(token2);
+    }
+
+    @Test
+    void sign_signatureIsBase64UrlNoPadding() {
+        String token = HmacTokenService.sign(TICKET_ID, TICKET_CODE, SECRET);
+
+        int lastDot = token.lastIndexOf('.');
+        String sig = token.substring(lastDot + 1);
+
+        // Base64url characters: A-Z a-z 0-9 - _ (no +, /, or =)
+        assertThat(sig).matches("[A-Za-z0-9_-]+");
+    }
+}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorageTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorageTest.java
@@ -1,0 +1,102 @@
+package com.fronzec.plugins.ticketpdf.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalFileStorageTest {
+
+    @TempDir Path tempDir;
+
+    private String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_createsFile_andReturnsCorrectStoredFile() throws IOException {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = "hello ticket pdf".getBytes(StandardCharsets.UTF_8);
+        String key = "ticket-42.pdf";
+
+        StoredFile result = storage.write(key, content);
+
+        // File must exist at the returned path
+        Path expectedPath = tempDir.resolve(key);
+        assertThat(expectedPath).exists();
+        assertThat(Files.readAllBytes(expectedPath)).isEqualTo(content);
+
+        // storageType must be LOCAL
+        assertThat(result.storageType()).isEqualTo("LOCAL");
+
+        // path must be the absolute path
+        assertThat(result.path()).isEqualTo(expectedPath.toAbsolutePath().toString());
+
+        // checksum must match independently computed SHA-256
+        assertThat(result.checksum()).isEqualTo(sha256Hex(content));
+
+        // sizeBytes must match content length
+        assertThat(result.sizeBytes()).isEqualTo(content.length);
+    }
+
+    @Test
+    void write_createsParentDirectories_whenBaseDirectoryDoesNotExist() throws IOException {
+        Path nestedDir = tempDir.resolve("sub/dir");
+        LocalFileStorage storage = new LocalFileStorage(nestedDir);
+        byte[] content = "nested content".getBytes(StandardCharsets.UTF_8);
+
+        StoredFile result = storage.write("file.pdf", content);
+
+        assertThat(Path.of(result.path())).exists();
+        assertThat(Files.readAllBytes(Path.of(result.path()))).isEqualTo(content);
+    }
+
+    @Test
+    void write_withEmptyBytes_returnsStoredFileWithZeroSize() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = new byte[0];
+
+        StoredFile result = storage.write("empty.pdf", content);
+
+        assertThat(result.sizeBytes()).isZero();
+        assertThat(result.checksum()).isEqualTo(sha256Hex(content));
+    }
+
+    @Test
+    void delete_removesExistingFile() throws IOException {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = "to be deleted".getBytes(StandardCharsets.UTF_8);
+        storage.write("delete-me.pdf", content);
+
+        Path filePath = tempDir.resolve("delete-me.pdf");
+        assertThat(filePath).exists();
+
+        storage.delete("delete-me.pdf");
+
+        assertThat(filePath).doesNotExist();
+    }
+
+    @Test
+    void delete_onNonExistentKey_doesNotThrow() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        assertThatCode(() -> storage.delete("ghost.pdf")).doesNotThrowAnyException();
+    }
+}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorageTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/storage/LocalFileStorageTest.java
@@ -2,6 +2,7 @@ package com.fronzec.plugins.ticketpdf.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -98,5 +99,22 @@ class LocalFileStorageTest {
         LocalFileStorage storage = new LocalFileStorage(tempDir);
 
         assertThatCode(() -> storage.delete("ghost.pdf")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void write_rejectsPathTraversalKey() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        assertThatThrownBy(
+                () -> storage.write("../escape.pdf", "x".getBytes(StandardCharsets.UTF_8)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void delete_rejectsPathTraversalKey() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        assertThatThrownBy(() -> storage.delete("../../etc/passwd"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## Context

First of **2 chained PRs** implementing a batch job that reads event tickets, generates a PDF per row with a signed QR code, stores it, and records the file in a tracking table. Built as an **external dynamic plugin** to validate that **plugin API v1 (`batch-job-api`) suffices with no API changes** — it does (`configureJob(...)` exposes the host `ApplicationContext`).

Planned via SDD (explore → proposal → spec → design → tasks).

## Scope of this PR (WU1–WU4)

- **V5 Flyway migration** — `event_tickets` (source, incl. `event_id` grouping key) + `generated_files` (tracking, `UNIQUE(ticket_id)` + FK). Mirrored into the H2 test schema (no seed rows). Separate dev seed script (off the Flyway path).
- **Plugin module** `com.fronzec.plugins:ticket-pdf-job` — standalone shaded module (OpenPDF + ZXing bundled; spring/batch/jdbc/slf4j provided).
- **`FileStorage` seam** — `interface FileStorage` + `record StoredFile` + `LocalFileStorage` (SHA-256 + size). The v1→v2 hinge: an `S3FileStorage` slots in later without touching reader/processor/writer.
- **Domain + HMAC** — `Ticket` POJO + `HmacTokenService` (HMAC-SHA256, base64url no-pad QR token).

## Tests

- `ticket-pdf-job`: **11/11** (FileStorage + HMAC, written test-first)
- `fr-batch-service`: **123/123** (V5/schema additive, no regressions)

## Not in this PR (→ PR#2, WU5–WU9)

Batch components (JDBC reader / OpenPDF+QR processor / file+tracking writer), the `TicketPdfJobPlugin` class, the upload→load→run integration test on H2, docs, and build/fat-JAR smoke verification.

## Notes

- Storage is local filesystem for v1; **S3 is an explicit non-goal** (planned v2 via the `FileStorage` seam).
- QR secret is the `TOKEN_SECRET` job parameter (plugin runs outside the Spring container — no `@ConfigurationProperties` binding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ticket PDF generation and storage capabilities
  * Implemented local file storage for generated PDF documents
  * Added secure token generation for ticket verification
  * Database tables created to track tickets and generated PDF artifacts

* **Tests**
  * Added comprehensive test coverage for token generation and file storage operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->