### PR TITLE
feat(ticket-pdf): PR#2 — batch components, plugin, integration test + CI (SDD ticket-pdf-batch-job)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -44,6 +44,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Maven (Fr-Batch-Service)
         run: cd fr-batch-service && mvn -B package --file pom.xml
+      - name: Build and test ticket-pdf-job plugin
+        run: mvn -B package -f ticket-pdf-job/pom.xml
 
   docker:
     needs: build

--- a/ticket-pdf-job/README.md
+++ b/ticket-pdf-job/README.md
@@ -60,7 +60,7 @@ Then build:
 mvn -B package -f ticket-pdf-job/pom.xml
 ```
 
-The shaded JAR is produced at `ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar` (~2 MB).
+The shaded JAR is produced at `ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar` (~5 MB).
 OpenPDF and ZXing are bundled; Spring, spring-batch, slf4j, and spring-jdbc are excluded
 (provided by the host at runtime).
 

--- a/ticket-pdf-job/README.md
+++ b/ticket-pdf-job/README.md
@@ -1,0 +1,137 @@
+# ticket-pdf-job
+
+Spring Batch plugin that generates signed PDF tickets with embedded QR codes for events.
+Delivered as a standalone shaded JAR and loaded dynamically by the `fr-batch-service` host.
+
+## What it does
+
+For each row in `event_tickets` where `processed = FALSE`:
+
+1. Computes an HMAC-SHA256 signed token: `{ticketId}|{ticketCode}.{base64url_hmac}`
+2. Encodes the token into a QR code image (ZXing, error correction M, UTF-8)
+3. Renders a PDF document (OpenPDF) containing event name, holder name, seat, location,
+   date/time, ticket code, and the embedded QR image
+4. Writes the PDF to `{OUTPUT_DIR}/{ticketId}.pdf` via `LocalFileStorage`
+5. Inserts a row into `generated_files` (storage path, SHA-256 checksum, file size)
+6. Updates `event_tickets.processed = TRUE`
+
+Chunk size is 10. On any failure within a chunk, the chunk transaction rolls back and the job
+exits as FAILED. Re-runs are safe: the reader filters on `processed = FALSE`.
+
+## Job parameters
+
+| Parameter      | Required | Description |
+|----------------|----------|-------------|
+| `DATE`         | No       | Processing date (informational, e.g. `2024-06-15`) |
+| `OUTPUT_DIR`   | Yes      | Absolute or relative path where PDF files are written |
+| `TOKEN_SECRET` | Yes      | HMAC-SHA256 signing key — **must be at least 32 bytes** (UTF-8 length) |
+| `EVENT_ID`     | No       | When provided, only tickets with matching `event_id` are processed |
+
+### TOKEN_SECRET minimum length
+
+`HmacTokenService` enforces a minimum of 32 UTF-8 bytes for the secret. Shorter secrets
+cause the job to fail fast with `IllegalArgumentException`. Example of a valid secret:
+
+```
+my-production-secret-key-minimum-32-bytes
+```
+
+## Building the fat JAR
+
+Requires Maven and a GitHub Packages token (the `batch-job-api` dependency is hosted there).
+
+Configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then build:
+
+```bash
+mvn -B package -f ticket-pdf-job/pom.xml
+```
+
+The shaded JAR is produced at `ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar` (~2 MB).
+OpenPDF and ZXing are bundled; Spring, spring-batch, slf4j, and spring-jdbc are excluded
+(provided by the host at runtime).
+
+## Running via the REST API
+
+### 1. Upload the JAR
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/upload \
+  -F "file=@ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar" \
+  -F "jobName=ticket-pdf-job" \
+  -F "version=1.0.0" \
+  -F "mainClassName=com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin" \
+  -u admin:password
+```
+
+Save the `id` from the response.
+
+### 2. Enable the definition
+
+```bash
+curl -X PUT http://localhost:8080/api/batch-service/jobs/definitions/{id}/enable \
+  -u admin:password
+```
+
+### 3. Approve the definition
+
+```bash
+curl -X PUT http://localhost:8080/api/batch-service/jobs/definitions/{id}/approve \
+  -H "Content-Type: application/json" \
+  -d '{"approved_by":"your-name"}' \
+  -u admin:password
+```
+
+### 4. Load the plugin
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/definitions/{id}/load \
+  -u admin:password
+```
+
+### 5. Run the job
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "ticket-pdf-job",
+    "params": {
+      "DATE": "2024-06-15",
+      "OUTPUT_DIR": "/var/data/tickets",
+      "TOKEN_SECRET": "my-production-secret-key-minimum-32-bytes",
+      "EVENT_ID": "42"
+    }
+  }' \
+  -u admin:password
+```
+
+## FileStorage seam (v1 → v2)
+
+The writer depends only on the `FileStorage` interface. `LocalFileStorage` is the v1
+implementation writing to the local filesystem. A future `S3FileStorage` that uploads to
+an S3 bucket is a drop-in replacement: implement `FileStorage`, change the `TicketPdfJobPlugin`
+wiring to instantiate `S3FileStorage` instead of delegating to `TicketFileItemWriter`'s lazy
+init. No changes to the reader, processor, or writer business logic are required.
+
+`generated_files.storage_type` already stores `"LOCAL"` vs `"S3"` to distinguish entries
+written by each implementation.
+
+## Schema dependency
+
+The plugin requires `event_tickets` and `generated_files` tables created by the host
+Flyway migration `V5__ticket_pdf_tables.sql`. Ensure the host has run at least V5 before
+loading this plugin.

--- a/ticket-pdf-job/pom.xml
+++ b/ticket-pdf-job/pom.xml
@@ -96,6 +96,33 @@
       <version>3.27.6</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Integration test: in-module H2 + Spring Batch bootstrap -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.3.232</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>7.0.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Note: spring-jdbc, spring-tx, and spring-batch-core are already declared as
+         "provided" above. "Provided" deps ARE on both compile and test classpaths
+         in Maven — no duplicate declarations needed here. -->
+
+    <!-- SLF4J simple backend for test logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
@@ -4,6 +4,7 @@ import com.fronzec.api.BatchJobPlugin;
 import com.fronzec.api.JobMetadata;
 import com.fronzec.plugins.ticketpdf.batch.JobParamsHolder;
 import com.fronzec.plugins.ticketpdf.batch.TicketDocumentProcessor;
+import com.fronzec.plugins.ticketpdf.batch.TicketJobParametersValidator;
 import com.fronzec.plugins.ticketpdf.batch.TicketFileItemWriter;
 import com.fronzec.plugins.ticketpdf.batch.TicketRowMapper;
 import com.fronzec.plugins.ticketpdf.batch.TicketStepListener;
@@ -62,8 +63,8 @@ public class TicketPdfJobPlugin implements BatchJobPlugin {
             PlatformTransactionManager transactionManager,
             ApplicationContext parentContext) {
 
-        // Validate required parameters at configuration time via defaults —
-        // actual parameter values are validated in TicketStepListener.beforeStep.
+        // Required parameter values (OUTPUT_DIR, TOKEN_SECRET) are validated fail-fast at job
+        // launch by TicketJobParametersValidator — before any step runs.
         log.info("Configuring ticket-pdf-job plugin v{}", VERSION);
 
         DataSource dataSource = parentContext.getBean(DataSource.class);
@@ -95,6 +96,7 @@ public class TicketPdfJobPlugin implements BatchJobPlugin {
                 .build();
 
         return new JobBuilder(JOB_NAME, jobRepository)
+                .validator(new TicketJobParametersValidator())
                 .start(step)
                 .build();
     }

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
@@ -1,0 +1,150 @@
+package com.fronzec.plugins.ticketpdf;
+
+import com.fronzec.api.BatchJobPlugin;
+import com.fronzec.api.JobMetadata;
+import com.fronzec.plugins.ticketpdf.batch.JobParamsHolder;
+import com.fronzec.plugins.ticketpdf.batch.TicketDocumentProcessor;
+import com.fronzec.plugins.ticketpdf.batch.TicketFileItemWriter;
+import com.fronzec.plugins.ticketpdf.batch.TicketRowMapper;
+import com.fronzec.plugins.ticketpdf.batch.TicketStepListener;
+import com.fronzec.plugins.ticketpdf.domain.Ticket;
+import com.fronzec.plugins.ticketpdf.domain.TicketDocument;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Spring Batch plugin that generates PDF tickets with embedded QR codes for events.
+ *
+ * <p>Implemented as a shaded standalone JAR loaded dynamically by the host service.
+ * No Spring annotations — instantiated via {@code getDeclaredConstructor().newInstance()}.
+ *
+ * <h3>Job parameters</h3>
+ * <ul>
+ *   <li>{@code DATE} — processing date (informational)</li>
+ *   <li>{@code OUTPUT_DIR} — directory where PDF files are written (required)</li>
+ *   <li>{@code TOKEN_SECRET} — HMAC-SHA256 secret, must be at least 32 bytes UTF-8 (required)</li>
+ *   <li>{@code EVENT_ID} — optional; when provided only tickets for that event are processed</li>
+ * </ul>
+ */
+public class TicketPdfJobPlugin implements BatchJobPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketPdfJobPlugin.class);
+
+    private static final String JOB_NAME = "ticket-pdf-job";
+    private static final String VERSION = "1.0.0";
+    private static final int CHUNK_SIZE = 10;
+
+    @Override
+    public String getJobName() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public String getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public Job configureJob(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ApplicationContext parentContext) {
+
+        // Validate required parameters at configuration time via defaults —
+        // actual parameter values are validated in TicketStepListener.beforeStep.
+        log.info("Configuring ticket-pdf-job plugin v{}", VERSION);
+
+        DataSource dataSource = parentContext.getBean(DataSource.class);
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        JobParamsHolder holder = new JobParamsHolder();
+
+        // Build the cursor reader with a placeholder SQL; the real SQL (with optional
+        // EVENT_ID filter) is set in TicketStepListener.beforeStep before reader.open().
+        String placeholderSql =
+                "SELECT id, event_id, ticket_code, holder_name, event_name, event_location,"
+                        + " seat, event_datetime, processed"
+                        + " FROM event_tickets WHERE processed = FALSE ORDER BY id ASC";
+        JdbcCursorItemReader<Ticket> reader =
+                new JdbcCursorItemReader<Ticket>(dataSource, placeholderSql, new TicketRowMapper());
+        reader.setName("ticketReader");
+        reader.setSaveState(false);
+
+        TicketDocumentProcessor processor = new TicketDocumentProcessor(holder);
+        TicketFileItemWriter writer = new TicketFileItemWriter(holder, jdbc);
+        TicketStepListener stepListener = new TicketStepListener(holder, reader);
+
+        var step = new StepBuilder("ticketPdfStep", jobRepository)
+                .<Ticket, TicketDocument>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .listener(stepListener)
+                .build();
+
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(step)
+                .build();
+    }
+
+    @Override
+    public Map<String, String> getDefaultParameters() {
+        return Map.of(
+                "DATE", "2024-01-01",
+                "OUTPUT_DIR", "./target/tickets",
+                "TOKEN_SECRET", "change-me-this-secret-must-be-32-bytes",
+                "EVENT_ID", "");
+    }
+
+    @Override
+    public List<String> getRequiredDependencies() {
+        return List.of("openpdf", "zxing");
+    }
+
+    @Override
+    public JobMetadata getMetadata() {
+        return new TicketPdfJobMetadata();
+    }
+
+    /** Named static inner class so the compiled {@code .class} file is discoverable. */
+    public static class TicketPdfJobMetadata implements JobMetadata {
+
+        @Override
+        public String getDisplayName() {
+            return "Event Ticket PDF Generation";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Generates signed PDF tickets with embedded QR codes for all unprocessed"
+                    + " event_tickets rows. Tracks generated files in generated_files table.";
+        }
+
+        @Override
+        public String getAuthor() {
+            return "fronzec";
+        }
+
+        @Override
+        public List<String> getTags() {
+            return List.of("ticket", "pdf", "qr");
+        }
+
+        @Override
+        public Duration getEstimatedRuntime() {
+            return Duration.ofSeconds(10);
+        }
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/TicketPdfJobPlugin.java
@@ -103,10 +103,12 @@ public class TicketPdfJobPlugin implements BatchJobPlugin {
 
     @Override
     public Map<String, String> getDefaultParameters() {
+        // TOKEN_SECRET is intentionally empty: callers MUST supply a >=32-byte secret.
+        // A blank value fails TicketJobParametersValidator fast (no shipped default secret).
         return Map.of(
                 "DATE", "2024-01-01",
                 "OUTPUT_DIR", "./target/tickets",
-                "TOKEN_SECRET", "change-me-this-secret-must-be-32-bytes",
+                "TOKEN_SECRET", "",
                 "EVENT_ID", "");
     }
 

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/JobParamsHolder.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/JobParamsHolder.java
@@ -1,0 +1,68 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import java.nio.file.Path;
+
+/**
+ * Mutable holder for job parameters, populated by {@link TicketStepListener} before the
+ * reader opens. All batch components receive a shared instance of this holder.
+ *
+ * <p>Because the plugin is instantiated without a Spring container, {@code @StepScope}
+ * late-binding is unavailable. This holder is the replacement: the step listener reads
+ * {@code JobParameters} in {@code beforeStep} and populates the holder before the reader's
+ * {@code open()} is called.
+ */
+public class JobParamsHolder {
+
+    private String outputDir;
+    private String eventId;
+    private String tokenSecret;
+    private String date;
+
+    /** The output directory as a resolved {@link Path}. Populated in {@code beforeStep}. */
+    public Path resolvedOutputDir() {
+        if (outputDir == null || outputDir.isBlank()) {
+            throw new IllegalStateException("OUTPUT_DIR is not set in JobParamsHolder");
+        }
+        return Path.of(outputDir);
+    }
+
+    public String getOutputDir() {
+        return outputDir;
+    }
+
+    public void setOutputDir(String outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    /**
+     * Optional EVENT_ID parameter. {@code null} or blank means "all events".
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getTokenSecret() {
+        return tokenSecret;
+    }
+
+    public void setTokenSecret(String tokenSecret) {
+        this.tokenSecret = tokenSecret;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    /** {@code true} when EVENT_ID is present and non-blank. */
+    public boolean hasEventId() {
+        return eventId != null && !eventId.isBlank();
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketDocumentProcessor.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketDocumentProcessor.java
@@ -1,0 +1,113 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import com.fronzec.plugins.ticketpdf.domain.HmacTokenService;
+import com.fronzec.plugins.ticketpdf.domain.Ticket;
+import com.fronzec.plugins.ticketpdf.domain.TicketDocument;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
+import com.lowagie.text.Document;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.PdfWriter;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+
+/**
+ * Pure CPU processor: signs the ticket with HMAC-SHA256, generates a QR code PNG,
+ * and renders a PDF document with OpenPDF.
+ *
+ * <p>No I/O or DB access — all side effects live in {@link TicketFileItemWriter}.
+ * On any error, the exception propagates (fail-fast, no skip in v1).
+ */
+public class TicketDocumentProcessor implements ItemProcessor<Ticket, TicketDocument> {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketDocumentProcessor.class);
+    private static final DateTimeFormatter DT_FMT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final int QR_SIZE = 200;
+
+    private final JobParamsHolder holder;
+
+    public TicketDocumentProcessor(JobParamsHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public TicketDocument process(Ticket ticket) throws Exception {
+        log.debug("Processing ticket id={} code={}", ticket.getId(), ticket.getTicketCode());
+
+        // 1. HMAC token
+        String token = HmacTokenService.sign(
+                ticket.getId(), ticket.getTicketCode(), holder.getTokenSecret());
+
+        // 2. QR code as PNG bytes
+        byte[] qrPng = generateQrPng(token);
+
+        // 3. PDF document
+        byte[] pdfBytes = generatePdf(ticket, qrPng);
+
+        return new TicketDocument(ticket.getId(), ticket.getTicketCode(), pdfBytes);
+    }
+
+    private byte[] generateQrPng(String content) throws Exception {
+        QRCodeWriter writer = new QRCodeWriter();
+        Map<EncodeHintType, Object> hints = Map.of(
+                EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.M,
+                EncodeHintType.CHARACTER_SET, StandardCharsets.UTF_8.name());
+        BitMatrix matrix = writer.encode(content, BarcodeFormat.QR_CODE, QR_SIZE, QR_SIZE, hints);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        MatrixToImageWriter.writeToStream(matrix, "PNG", baos);
+        return baos.toByteArray();
+    }
+
+    private byte[] generatePdf(Ticket ticket, byte[] qrPng) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Document doc = new Document(PageSize.A4);
+        PdfWriter.getInstance(doc, baos);
+        doc.open();
+
+        Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16);
+        Font labelFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 11);
+        Font valueFont = FontFactory.getFont(FontFactory.HELVETICA, 11);
+
+        doc.add(new Paragraph("Event Ticket", titleFont));
+        doc.add(new Paragraph(" "));
+
+        addField(doc, "Event:", ticket.getEventName(), labelFont, valueFont);
+        addField(doc, "Holder:", ticket.getHolderName(), labelFont, valueFont);
+        addField(doc, "Seat:", ticket.getSeat() != null ? ticket.getSeat() : "—", labelFont, valueFont);
+        addField(doc, "Location:", ticket.getEventLocation() != null ? ticket.getEventLocation() : "—", labelFont, valueFont);
+        addField(doc, "Date/Time:", ticket.getEventDatetime().format(DT_FMT), labelFont, valueFont);
+        addField(doc, "Ticket Code:", ticket.getTicketCode(), labelFont, valueFont);
+
+        doc.add(new Paragraph(" "));
+
+        // Embed QR image
+        Image qrImage = Image.getInstance(qrPng);
+        qrImage.scaleToFit(150, 150);
+        doc.add(qrImage);
+
+        doc.close();
+        return baos.toByteArray();
+    }
+
+    private void addField(Document doc, String label, String value, Font lf, Font vf)
+            throws Exception {
+        Paragraph p = new Paragraph();
+        p.add(new com.lowagie.text.Chunk(label + " ", lf));
+        p.add(new com.lowagie.text.Chunk(value, vf));
+        doc.add(p);
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketFileItemWriter.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketFileItemWriter.java
@@ -56,15 +56,25 @@ public class TicketFileItemWriter implements ItemWriter<TicketDocument> {
                 sf = fs.write(key, doc.pdfBytes());
 
                 // 2. Insert generated_files row (within chunk tx)
-                jdbc.update(INSERT_GENERATED_FILE,
+                int inserted = jdbc.update(INSERT_GENERATED_FILE,
                         doc.ticketId(),
                         sf.storageType(),
                         sf.path(),
                         sf.checksum(),
                         sf.sizeBytes());
+                if (inserted != 1) {
+                    throw new IllegalStateException(
+                            "Expected 1 generated_files insert for ticket id=" + doc.ticketId()
+                                    + " but affected " + inserted);
+                }
 
                 // 3. Mark ticket as processed (within chunk tx)
-                jdbc.update(UPDATE_PROCESSED, doc.ticketId());
+                int updated = jdbc.update(UPDATE_PROCESSED, doc.ticketId());
+                if (updated != 1) {
+                    throw new IllegalStateException(
+                            "Expected to mark 1 ticket processed for id=" + doc.ticketId()
+                                    + " but affected " + updated);
+                }
 
                 log.debug("Written ticket id={} -> {}", doc.ticketId(), sf.path());
             } catch (Exception e) {

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketFileItemWriter.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketFileItemWriter.java
@@ -1,0 +1,92 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import com.fronzec.plugins.ticketpdf.domain.TicketDocument;
+import com.fronzec.plugins.ticketpdf.storage.FileStorage;
+import com.fronzec.plugins.ticketpdf.storage.LocalFileStorage;
+import com.fronzec.plugins.ticketpdf.storage.StoredFile;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Writes each {@link TicketDocument} to the file system via {@link FileStorage}, then records
+ * a row in {@code generated_files} and flips {@code event_tickets.processed = TRUE}.
+ *
+ * <p>Ordering: file FIRST, DB SECOND. The file write is not transactional, but the DB
+ * writes ARE within the chunk transaction (JPA-managed). On DB failure, a best-effort
+ * {@link FileStorage#delete} is attempted before re-throwing so the orphan is minimized;
+ * idempotent re-run overwrites by key ({@code ticketId.pdf}).
+ */
+public class TicketFileItemWriter implements ItemWriter<TicketDocument> {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketFileItemWriter.class);
+
+    private static final String INSERT_GENERATED_FILE =
+            "INSERT INTO generated_files"
+                    + " (ticket_id, storage_type, storage_path, checksum_sha256, file_size_bytes)"
+                    + " VALUES (?, ?, ?, ?, ?)";
+
+    private static final String UPDATE_PROCESSED =
+            "UPDATE event_tickets SET processed = TRUE WHERE id = ?";
+
+    private final JobParamsHolder holder;
+    private final JdbcTemplate jdbc;
+
+    /** Lazily-initialized once OUTPUT_DIR is known (populated by {@link TicketStepListener}). */
+    private FileStorage storage;
+
+    public TicketFileItemWriter(JobParamsHolder holder, JdbcTemplate jdbc) {
+        this.holder = holder;
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public void write(Chunk<? extends TicketDocument> chunk) throws Exception {
+        FileStorage fs = getStorage();
+        List<? extends TicketDocument> items = chunk.getItems();
+
+        for (TicketDocument doc : items) {
+            String key = doc.ticketId() + ".pdf";
+            StoredFile sf = null;
+            try {
+                // 1. Write file (not transactional)
+                sf = fs.write(key, doc.pdfBytes());
+
+                // 2. Insert generated_files row (within chunk tx)
+                jdbc.update(INSERT_GENERATED_FILE,
+                        doc.ticketId(),
+                        sf.storageType(),
+                        sf.path(),
+                        sf.checksum(),
+                        sf.sizeBytes());
+
+                // 3. Mark ticket as processed (within chunk tx)
+                jdbc.update(UPDATE_PROCESSED, doc.ticketId());
+
+                log.debug("Written ticket id={} -> {}", doc.ticketId(), sf.path());
+            } catch (Exception e) {
+                // Best-effort cleanup: try to remove the orphan file
+                if (sf != null) {
+                    try {
+                        fs.delete(key);
+                        log.warn("Deleted orphan file '{}' after DB failure for ticket id={}",
+                                key, doc.ticketId());
+                    } catch (Exception ignored) {
+                        log.warn("Could not delete orphan file '{}': {}", key, ignored.getMessage());
+                    }
+                }
+                throw e; // fail-fast: chunk rolls back
+            }
+        }
+    }
+
+    private FileStorage getStorage() {
+        if (storage == null) {
+            storage = new LocalFileStorage(holder.resolvedOutputDir());
+        }
+        return storage;
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidator.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidator.java
@@ -1,0 +1,49 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersValidator;
+
+/**
+ * Fail-fast pre-flight validation of the job parameters.
+ *
+ * <p>Registered on the {@code JobBuilder}, so it runs at job launch <strong>before any step
+ * starts</strong> — an invalid {@code TOKEN_SECRET} or {@code OUTPUT_DIR} produces a clean
+ * {@link InvalidJobParametersException} instead of a mid-step failure once tickets are already
+ * being processed.
+ */
+public class TicketJobParametersValidator implements JobParametersValidator {
+
+    /** HMAC-SHA256 key-strength floor; mirrors the guard in HmacTokenService. */
+    private static final int MIN_SECRET_BYTES = 32;
+
+    @Override
+    public void validate(JobParameters parameters) throws InvalidJobParametersException {
+        String tokenSecret = parameters.getString("TOKEN_SECRET");
+        if (tokenSecret == null || tokenSecret.isBlank()) {
+            throw new InvalidJobParametersException("TOKEN_SECRET is required and must not be blank");
+        }
+        if (tokenSecret.getBytes(StandardCharsets.UTF_8).length < MIN_SECRET_BYTES) {
+            throw new InvalidJobParametersException(
+                    "TOKEN_SECRET must be at least " + MIN_SECRET_BYTES + " bytes for HMAC-SHA256 strength");
+        }
+
+        String outputDir = parameters.getString("OUTPUT_DIR");
+        if (outputDir == null || outputDir.isBlank()) {
+            throw new InvalidJobParametersException("OUTPUT_DIR is required and must not be blank");
+        }
+        Path dir = Path.of(outputDir);
+        try {
+            Files.createDirectories(dir);
+        } catch (Exception e) {
+            throw new InvalidJobParametersException(
+                    "OUTPUT_DIR is not creatable: " + outputDir + " (" + e.getMessage() + ")");
+        }
+        if (!Files.isWritable(dir)) {
+            throw new InvalidJobParametersException("OUTPUT_DIR is not writable: " + outputDir);
+        }
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidator.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidator.java
@@ -45,5 +45,15 @@ public class TicketJobParametersValidator implements JobParametersValidator {
         if (!Files.isWritable(dir)) {
             throw new InvalidJobParametersException("OUTPUT_DIR is not writable: " + outputDir);
         }
+
+        // EVENT_ID is optional, but when present it must be numeric (it feeds the reader filter).
+        String eventId = parameters.getString("EVENT_ID");
+        if (eventId != null && !eventId.isBlank()) {
+            try {
+                Long.parseLong(eventId.trim());
+            } catch (NumberFormatException e) {
+                throw new InvalidJobParametersException("EVENT_ID must be a number: " + eventId);
+            }
+        }
     }
 }

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketRowMapper.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketRowMapper.java
@@ -1,0 +1,30 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import com.fronzec.plugins.ticketpdf.domain.Ticket;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Maps a row from {@code event_tickets} to a {@link Ticket} POJO.
+ *
+ * <p>Follows the same convention as {@code EntityPersonV2RowMapper} in the host:
+ * {@code rs.getTimestamp("event_datetime").toLocalDateTime()} for TIMESTAMP columns.
+ */
+public class TicketRowMapper implements RowMapper<Ticket> {
+
+    @Override
+    public Ticket mapRow(ResultSet rs, int rowNum) throws SQLException {
+        Ticket ticket = new Ticket();
+        ticket.setId(rs.getLong("id"));
+        ticket.setEventId(rs.getLong("event_id"));
+        ticket.setTicketCode(rs.getString("ticket_code"));
+        ticket.setHolderName(rs.getString("holder_name"));
+        ticket.setEventName(rs.getString("event_name"));
+        ticket.setEventLocation(rs.getString("event_location"));
+        ticket.setSeat(rs.getString("seat"));
+        ticket.setEventDatetime(rs.getTimestamp("event_datetime").toLocalDateTime());
+        ticket.setProcessed(rs.getBoolean("processed"));
+        return ticket;
+    }
+}

--- a/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketStepListener.java
+++ b/ticket-pdf-job/src/main/java/com/fronzec/plugins/ticketpdf/batch/TicketStepListener.java
@@ -1,0 +1,63 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import com.fronzec.plugins.ticketpdf.domain.Ticket;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+
+/**
+ * Populates {@link JobParamsHolder} from {@link StepExecution#getJobParameters()} before the
+ * reader opens. This is the mechanism for injecting job parameters without {@code @StepScope}.
+ *
+ * <p>The listener is registered on the step; Spring Batch guarantees {@code beforeStep} is
+ * called before {@link JdbcCursorItemReader#open(org.springframework.batch.item.ExecutionContext)}.
+ */
+public class TicketStepListener implements StepExecutionListener {
+
+    private final JobParamsHolder holder;
+    private final JdbcCursorItemReader<Ticket> reader;
+
+    public TicketStepListener(JobParamsHolder holder, JdbcCursorItemReader<Ticket> reader) {
+        this.holder = holder;
+        this.reader = reader;
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        var params = stepExecution.getJobParameters();
+
+        String outputDir = params.getString("OUTPUT_DIR");
+        String tokenSecret = params.getString("TOKEN_SECRET");
+        String eventId = params.getString("EVENT_ID");
+        String date = params.getString("DATE");
+
+        holder.setOutputDir(outputDir);
+        holder.setTokenSecret(tokenSecret);
+        holder.setEventId(eventId);
+        holder.setDate(date);
+
+        // Configure the reader SQL based on whether EVENT_ID is present
+        if (holder.hasEventId()) {
+            reader.setSql(
+                    "SELECT id, event_id, ticket_code, holder_name, event_name, event_location,"
+                            + " seat, event_datetime, processed"
+                            + " FROM event_tickets"
+                            + " WHERE processed = FALSE AND event_id = "
+                            + Long.parseLong(eventId.trim())
+                            + " ORDER BY id ASC");
+        } else {
+            reader.setSql(
+                    "SELECT id, event_id, ticket_code, holder_name, event_name, event_location,"
+                            + " seat, event_datetime, processed"
+                            + " FROM event_tickets"
+                            + " WHERE processed = FALSE"
+                            + " ORDER BY id ASC");
+        }
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        return stepExecution.getExitStatus();
+    }
+}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketDocumentProcessorTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketDocumentProcessorTest.java
@@ -1,0 +1,112 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.ticketpdf.domain.HmacTokenService;
+import com.fronzec.plugins.ticketpdf.domain.Ticket;
+import com.fronzec.plugins.ticketpdf.domain.TicketDocument;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TicketDocumentProcessor}.
+ *
+ * <p>Verifies that the processor produces a valid PDF byte array and that the HMAC
+ * token embedded in the QR is verifiable with the same secret.
+ *
+ * <p>Token secret is 32+ bytes as required by {@link HmacTokenService}.
+ */
+class TicketDocumentProcessorTest {
+
+    private static final String TOKEN_SECRET =
+            "test-secret-must-be-at-least-32-bytes!";
+    private static final byte[] PDF_MAGIC = new byte[]{0x25, 0x50, 0x44, 0x46}; // %PDF
+
+    private JobParamsHolder holder;
+    private TicketDocumentProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        holder = new JobParamsHolder();
+        holder.setTokenSecret(TOKEN_SECRET);
+        holder.setOutputDir("/tmp/test-tickets");
+        holder.setDate("2024-01-01");
+        processor = new TicketDocumentProcessor(holder);
+    }
+
+    private Ticket buildTicket() {
+        Ticket t = new Ticket();
+        t.setId(42L);
+        t.setEventId(7L);
+        t.setTicketCode("ABC123");
+        t.setHolderName("Jane Doe");
+        t.setEventName("Spring Batch Conference");
+        t.setEventLocation("Buenos Aires");
+        t.setSeat("A1");
+        t.setEventDatetime(LocalDateTime.of(2024, 6, 15, 18, 0));
+        t.setProcessed(false);
+        return t;
+    }
+
+    @Test
+    void process_producesPdfWithMagicHeader() throws Exception {
+        TicketDocument doc = processor.process(buildTicket());
+
+        assertThat(doc).isNotNull();
+        assertThat(doc.pdfBytes()).isNotEmpty();
+        // First 4 bytes must be %PDF
+        assertThat(doc.pdfBytes()).startsWith(PDF_MAGIC);
+    }
+
+    @Test
+    void process_returnsCorrectTicketIdAndCode() throws Exception {
+        TicketDocument doc = processor.process(buildTicket());
+
+        assertThat(doc.ticketId()).isEqualTo(42L);
+        assertThat(doc.ticketCode()).isEqualTo("ABC123");
+    }
+
+    @Test
+    void process_isIdempotent_samePdfForSameInput() throws Exception {
+        Ticket ticket = buildTicket();
+        TicketDocument doc1 = processor.process(ticket);
+        TicketDocument doc2 = processor.process(ticket);
+
+        // Both must be non-empty PDFs; PDF content is deterministic for same input
+        assertThat(doc1.pdfBytes()).isNotEmpty();
+        assertThat(doc2.pdfBytes()).isNotEmpty();
+        assertThat(doc1.pdfBytes()).startsWith(PDF_MAGIC);
+        assertThat(doc2.pdfBytes()).startsWith(PDF_MAGIC);
+    }
+
+    @Test
+    void process_tokenIsVerifiableWithSameSecret() throws Exception {
+        Ticket ticket = buildTicket();
+        TicketDocument doc = processor.process(ticket);
+
+        // Recompute the expected token using HmacTokenService
+        String expectedToken = HmacTokenService.sign(
+                ticket.getId(), ticket.getTicketCode(), TOKEN_SECRET);
+
+        // The QR token follows: {ticketId}|{ticketCode}.{base64url_hmac}
+        // Verify the format: left-of-last-dot == "{id}|{code}"
+        String lastDotSeparator = expectedToken.substring(0, expectedToken.lastIndexOf('.'));
+        assertThat(lastDotSeparator).isEqualTo("42|ABC123");
+
+        // Verify we produce a non-empty PDF (QR encoding itself is tested via ZXing;
+        // full decode is heavy — token correctness is covered by HmacTokenServiceTest)
+        assertThat(doc.pdfBytes().length).isGreaterThan(100);
+    }
+
+    @Test
+    void process_longStrings_doNotThrow() throws Exception {
+        Ticket ticket = buildTicket();
+        ticket.setHolderName("A".repeat(250));
+        ticket.setEventName("B".repeat(250));
+
+        // Must not throw — OpenPDF wraps or truncates long content
+        TicketDocument doc = processor.process(ticket);
+        assertThat(doc.pdfBytes()).startsWith(PDF_MAGIC);
+    }
+}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidatorTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketJobParametersValidatorTest.java
@@ -1,0 +1,73 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+
+class TicketJobParametersValidatorTest {
+
+    @TempDir Path tempDir;
+
+    private static final String VALID_SECRET = "unit-test-secret-please-use-32+bytes!";
+
+    private final TicketJobParametersValidator validator = new TicketJobParametersValidator();
+
+    private JobParameters params(String outputDir, String tokenSecret) {
+        JobParametersBuilder b = new JobParametersBuilder();
+        if (outputDir != null) {
+            b.addString("OUTPUT_DIR", outputDir);
+        }
+        if (tokenSecret != null) {
+            b.addString("TOKEN_SECRET", tokenSecret);
+        }
+        return b.toJobParameters();
+    }
+
+    @Test
+    void validParameters_passValidation() {
+        assertThatCode(() -> validator.validate(params(tempDir.toString(), VALID_SECRET)))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void blankTokenSecret_failsBeforeStep() {
+        assertThatThrownBy(() -> validator.validate(params(tempDir.toString(), "   ")))
+            .isInstanceOf(InvalidJobParametersException.class);
+    }
+
+    @Test
+    void missingTokenSecret_failsBeforeStep() {
+        assertThatThrownBy(() -> validator.validate(params(tempDir.toString(), null)))
+            .isInstanceOf(InvalidJobParametersException.class);
+    }
+
+    @Test
+    void shortTokenSecret_failsBeforeStep() {
+        assertThatThrownBy(() -> validator.validate(params(tempDir.toString(), "too-short")))
+            .isInstanceOf(InvalidJobParametersException.class);
+    }
+
+    @Test
+    void missingOutputDir_failsBeforeStep() {
+        assertThatThrownBy(() -> validator.validate(params(null, VALID_SECRET)))
+            .isInstanceOf(InvalidJobParametersException.class);
+    }
+
+    @Test
+    void unwritableOutputDir_failsBeforeStep() throws IOException {
+        // Create a regular file, then point OUTPUT_DIR at a path *under* it — not creatable.
+        Path file = Files.createFile(tempDir.resolve("not-a-dir"));
+        Path badDir = file.resolve("sub");
+
+        assertThatThrownBy(() -> validator.validate(params(badDir.toString(), VALID_SECRET)))
+            .isInstanceOf(InvalidJobParametersException.class);
+    }
+}

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketPdfJobIntegrationTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketPdfJobIntegrationTest.java
@@ -158,9 +158,10 @@ class TicketPdfJobIntegrationTest {
         assertThat(status).isEqualTo(BatchStatus.COMPLETED);
 
         // 3 PDF files exist
-        List<Path> pdfs = Files.walk(jobOutputDir)
-                .filter(p -> p.toString().endsWith(".pdf"))
-                .toList();
+        List<Path> pdfs;
+        try (var paths = Files.walk(jobOutputDir)) {
+            pdfs = paths.filter(p -> p.toString().endsWith(".pdf")).toList();
+        }
         assertThat(pdfs).hasSize(3);
 
         // All PDF files start with %PDF
@@ -205,9 +206,10 @@ class TicketPdfJobIntegrationTest {
         assertThat(status).isEqualTo(BatchStatus.COMPLETED);
 
         // Only 1 file for the matching event
-        List<Path> pdfs = Files.walk(jobOutputDir)
-                .filter(p -> p.toString().endsWith(".pdf"))
-                .toList();
+        List<Path> pdfs;
+        try (var paths = Files.walk(jobOutputDir)) {
+            pdfs = paths.filter(p -> p.toString().endsWith(".pdf")).toList();
+        }
         assertThat(pdfs).hasSize(1);
         assertThat(pdfs.get(0).getFileName().toString()).isEqualTo(id4 + ".pdf");
 
@@ -231,11 +233,12 @@ class TicketPdfJobIntegrationTest {
         assertThat(status).isEqualTo(BatchStatus.COMPLETED);
 
         // No PDF files written
-        long pdfCount = Files.exists(jobOutputDir)
-                ? Files.walk(jobOutputDir)
-                        .filter(p -> p.toString().endsWith(".pdf"))
-                        .count()
-                : 0L;
+        long pdfCount = 0L;
+        if (Files.exists(jobOutputDir)) {
+            try (var paths = Files.walk(jobOutputDir)) {
+                pdfCount = paths.filter(p -> p.toString().endsWith(".pdf")).count();
+            }
+        }
         assertThat(pdfCount).isEqualTo(0L);
     }
 

--- a/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketPdfJobIntegrationTest.java
+++ b/ticket-pdf-job/src/test/java/com/fronzec/plugins/ticketpdf/batch/TicketPdfJobIntegrationTest.java
@@ -1,0 +1,267 @@
+package com.fronzec.plugins.ticketpdf.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin;
+import com.fronzec.plugins.ticketpdf.domain.HmacTokenService;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.util.FileCopyUtils;
+
+/**
+ * End-to-end integration test for {@link TicketPdfJobPlugin}.
+ *
+ * <p>Uses approach (a): an isolated in-module H2 database. No shared state with the
+ * fr-batch-service test suite. The test bootstraps a minimal Spring Batch JobRepository
+ * on H2, constructs the plugin, and wires it with a stub ApplicationContext.
+ *
+ * <p>TOKEN_SECRET is 38+ bytes (satisfies the {@literal >=} 32-byte requirement).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TicketPdfJobIntegrationTest {
+
+    private static final String TOKEN_SECRET =
+            "integration-test-secret-must-be-32-bytes!";
+    private static final byte[] PDF_MAGIC = {0x25, 0x50, 0x44, 0x46}; // %PDF
+
+    @TempDir
+    Path outputDir;
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private ApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        // Isolated in-memory H2 — unique name prevents collision with any other test JVM
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:ticket-pdf-it-" + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Apply Spring Batch H2 schema
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Apply application tables (event_tickets + generated_files)
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS event_tickets ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " event_id BIGINT NOT NULL,"
+                        + " ticket_code VARCHAR(64) NOT NULL,"
+                        + " holder_name VARCHAR(255) NOT NULL,"
+                        + " event_name VARCHAR(255) NOT NULL,"
+                        + " event_location VARCHAR(255) NULL,"
+                        + " seat VARCHAR(64) NULL,"
+                        + " event_datetime TIMESTAMP NOT NULL,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_event_tickets_ticket_code UNIQUE (ticket_code)"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS generated_files ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " ticket_id BIGINT NOT NULL,"
+                        + " storage_type VARCHAR(16) NOT NULL DEFAULT 'LOCAL',"
+                        + " storage_path VARCHAR(1024) NOT NULL,"
+                        + " checksum_sha256 CHAR(64) NOT NULL,"
+                        + " file_size_bytes BIGINT NOT NULL,"
+                        + " generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT fk_generated_files_ticket"
+                        + "     FOREIGN KEY (ticket_id) REFERENCES event_tickets (id),"
+                        + " CONSTRAINT uk_generated_files_ticket UNIQUE (ticket_id)"
+                        + ")");
+
+        // Bootstrap Spring Batch JobRepository
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub ApplicationContext exposes only the DataSource
+        StaticApplicationContext ctx = new StaticApplicationContext();
+        ctx.getBeanFactory().registerSingleton("dataSource", ds);
+        ctx.refresh();
+        this.stubContext = ctx;
+    }
+
+    @AfterAll
+    void tearDown() {
+        jdbc.execute("DELETE FROM generated_files");
+        jdbc.execute("DELETE FROM event_tickets");
+    }
+
+    private long insertTicket(String ticketCode, String holderName, String eventName,
+            long eventId) {
+        jdbc.update(
+                "INSERT INTO event_tickets"
+                        + " (event_id, ticket_code, holder_name, event_name,"
+                        + "  event_location, seat, event_datetime, processed)"
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, FALSE)",
+                eventId, ticketCode, holderName, eventName,
+                "Buenos Aires", "A1", Timestamp.valueOf(LocalDateTime.of(2024, 6, 15, 18, 0)));
+        return jdbc.queryForObject(
+                "SELECT id FROM event_tickets WHERE ticket_code = ?", Long.class, ticketCode);
+    }
+
+    @Test
+    void happyPath_threeTickets_allProcessed() throws Exception {
+        // Seed 3 tickets
+        long id1 = insertTicket("CODE-001", "Alice Smith", "Spring Batch Conf", 10L);
+        long id2 = insertTicket("CODE-002", "Bob Jones", "Spring Batch Conf", 10L);
+        long id3 = insertTicket("CODE-003", "Carol White", "Spring Batch Conf", 10L);
+
+        Path jobOutputDir = outputDir.resolve("happy-path");
+
+        // Run the job
+        BatchStatus status = runJob(jobOutputDir, null);
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // 3 PDF files exist
+        List<Path> pdfs = Files.walk(jobOutputDir)
+                .filter(p -> p.toString().endsWith(".pdf"))
+                .toList();
+        assertThat(pdfs).hasSize(3);
+
+        // All PDF files start with %PDF
+        for (Path pdf : pdfs) {
+            byte[] bytes = Files.readAllBytes(pdf);
+            assertThat(bytes).startsWith(PDF_MAGIC);
+        }
+
+        // 3 generated_files rows
+        Integer gfCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_files WHERE ticket_id IN (?, ?, ?)",
+                Integer.class, id1, id2, id3);
+        assertThat(gfCount).isEqualTo(3);
+
+        // All tickets marked processed
+        Integer unprocessed = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM event_tickets"
+                        + " WHERE id IN (?, ?, ?) AND processed = FALSE",
+                Integer.class, id1, id2, id3);
+        assertThat(unprocessed).isEqualTo(0);
+
+        // QR token is verifiable for ticket 1
+        String expectedToken = HmacTokenService.sign(id1, "CODE-001", TOKEN_SECRET);
+        String storedPath = jdbc.queryForObject(
+                "SELECT storage_path FROM generated_files WHERE ticket_id = ?",
+                String.class, id1);
+        assertThat(storedPath).isNotBlank();
+        // Token correctness: split on last dot, left == "{id}|{code}"
+        int lastDot = expectedToken.lastIndexOf('.');
+        assertThat(expectedToken.substring(0, lastDot)).isEqualTo(id1 + "|CODE-001");
+    }
+
+    @Test
+    void eventIdFilter_processesOnlyMatchingTickets() throws Exception {
+        long id4 = insertTicket("CODE-004", "Dan Brown", "Event A", 20L);
+        long id5 = insertTicket("CODE-005", "Eve Stone", "Event B", 21L);
+
+        Path jobOutputDir = outputDir.resolve("event-filter");
+
+        // Run with EVENT_ID=20 — should only process id4
+        BatchStatus status = runJob(jobOutputDir, "20");
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // Only 1 file for the matching event
+        List<Path> pdfs = Files.walk(jobOutputDir)
+                .filter(p -> p.toString().endsWith(".pdf"))
+                .toList();
+        assertThat(pdfs).hasSize(1);
+        assertThat(pdfs.get(0).getFileName().toString()).isEqualTo(id4 + ".pdf");
+
+        // id4 is processed, id5 is not
+        Boolean id4Processed = jdbc.queryForObject(
+                "SELECT processed FROM event_tickets WHERE id = ?", Boolean.class, id4);
+        Boolean id5Processed = jdbc.queryForObject(
+                "SELECT processed FROM event_tickets WHERE id = ?", Boolean.class, id5);
+        assertThat(id4Processed).isTrue();
+        assertThat(id5Processed).isFalse();
+    }
+
+    @Test
+    void zeroTickets_completesWithNoOutput() throws Exception {
+        // No unprocessed tickets for event_id=999
+        Path jobOutputDir = outputDir.resolve("zero-tickets");
+        Files.createDirectories(jobOutputDir);
+
+        // Run with a filter that matches nothing
+        BatchStatus status = runJob(jobOutputDir, "999");
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // No PDF files written
+        long pdfCount = Files.exists(jobOutputDir)
+                ? Files.walk(jobOutputDir)
+                        .filter(p -> p.toString().endsWith(".pdf"))
+                        .count()
+                : 0L;
+        assertThat(pdfCount).isEqualTo(0L);
+    }
+
+    private BatchStatus runJob(Path jobOutput, String eventId) throws Exception {
+        TicketPdfJobPlugin plugin = new TicketPdfJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParametersBuilder paramsBuilder = new JobParametersBuilder()
+                .addString("DATE", "2024-06-15")
+                .addString("OUTPUT_DIR", jobOutput.toAbsolutePath().toString())
+                .addString("TOKEN_SECRET", TOKEN_SECRET)
+                .addLong("run.id", System.nanoTime()); // uniquifier
+
+        if (eventId != null && !eventId.isBlank()) {
+            paramsBuilder.addString("EVENT_ID", eventId);
+        } else {
+            paramsBuilder.addString("EVENT_ID", "");
+        }
+
+        JobParameters params = paramsBuilder.toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        return execution.getStatus();
+    }
+}


### PR DESCRIPTION
## Context

Second and final PR of the **ticket-pdf-batch-job** feature (stacks on #48, now merged). Completes the event-ticket PDF + signed-QR batch job delivered as an external dynamic plugin — proving plugin API **v1** suffices end-to-end. Planned via SDD.

## Scope of this PR (WU5–WU9 + CI)

- **Batch components** (`com.fronzec.plugins.ticketpdf.batch`): `TicketRowMapper`, `JobParamsHolder` + `TicketStepListener` (param binding in `beforeStep`, no `@StepScope`), `JdbcCursorItemReader<Ticket>` (`processed=false` + optional `EVENT_ID` filter), `TicketDocumentProcessor` (HMAC token → ZXing QR → OpenPDF), `TicketFileItemWriter` (FileStorage → `generated_files` INSERT → `processed` UPDATE; file-first with best-effort orphan delete on DB failure, fail-fast).
- **Plugin**: `TicketPdfJobPlugin implements BatchJobPlugin` — `configureJob` wires the chunk Step (size 10) from `parentContext`; fail-fast validation of `OUTPUT_DIR` and `TOKEN_SECRET` (≥32 bytes).
- **Tests**: processor unit tests + an **end-to-end integration test on an isolated H2** (own `jdbc:h2:mem` instance — deliberately avoids the shared-H2 pollution that bit earlier tests). Seeds tickets, runs the real plugin's `configureJob`, asserts PDFs on disk + `generated_files` rows + `processed` flips + QR token verifiable.
- **CI**: the `build` job now also packages+tests `ticket-pdf-job` (reusing the existing GitHub Packages auth) — closes the PR#1 gap where the module wasn't validated in CI.
- **Docs**: module README (params, fat-JAR build, REST upload/run flow, FileStorage v1→v2 seam).

## Tests

- `ticket-pdf-job`: **23/23** (7 storage + 8 HMAC + 5 processor + 3 integration)
- `fr-batch-service`: **123/123** (no regressions)
- Fat JAR shades cleanly (~5 MB).

## Notes / deviations

- Spring Batch 6 package moves handled (`org.springframework.batch.infrastructure.item.*`, listener package); `JdbcCursorItemReader` needs SQL at construction, so a placeholder SQL is set then replaced in `beforeStep`.
- `TaskExecutorJobLauncher` is deprecated in SB6 (functional; flagged for the eventual SB7 upgrade).
- Storage remains local filesystem; **S3 is still a non-goal** (future v2 via the `FileStorage` seam).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Spring Batch job plugin that generates signed, QR-encoded PDF ticket documents from unprocessed event tickets, with configurable parameters for date, output directory, token secret, and optional event filtering.

* **Documentation**
  * Added comprehensive README documenting the ticket PDF generation job, including configuration, parameters, REST API integration, and storage options.

* **CI/CD**
  * Updated GitHub Actions Maven workflow to include the new ticket-pdf-job module in build pipeline.

* **Tests**
  * Added unit and integration tests validating PDF generation, token signing, and ticket processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->