### PR TITLE
feat(ticket-bundle): multi-step zip bundle plugin (chunk + tasklet)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,8 @@ jobs:
         run: cd fr-batch-service && mvn -B package --file pom.xml
       - name: Build and test ticket-pdf-job plugin
         run: mvn -B package -f ticket-pdf-job/pom.xml
+      - name: Build and test ticket-bundle-job plugin
+        run: mvn -B package -f ticket-bundle-job/pom.xml
 
   docker:
     needs: build

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - uses: actions/checkout@v4

--- a/fr-batch-service/src/main/resources/db/migration/V6__ticket_bundle_tables.sql
+++ b/fr-batch-service/src/main/resources/db/migration/V6__ticket_bundle_tables.sql
@@ -1,0 +1,17 @@
+-- =========================================================
+-- V6: Ticket bundle tables
+-- generated_bundles: tracks the ZIP bundle produced per event
+-- =========================================================
+
+CREATE TABLE generated_bundles (
+    id              BIGINT        AUTO_INCREMENT PRIMARY KEY,
+    event_id        BIGINT        NOT NULL,
+    storage_type    VARCHAR(16)   NOT NULL DEFAULT 'LOCAL',
+    storage_path    VARCHAR(1024) NOT NULL,
+    checksum_sha256 CHAR(64)      NOT NULL,
+    file_size_bytes BIGINT        NOT NULL,
+    ticket_count    INT           NOT NULL,
+    status          VARCHAR(20)   NOT NULL DEFAULT 'COMPLETED',
+    created_at      TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_generated_bundles_event UNIQUE (event_id)
+);

--- a/fr-batch-service/src/test/resources/schema.sql
+++ b/fr-batch-service/src/test/resources/schema.sql
@@ -202,3 +202,20 @@ CREATE TABLE IF NOT EXISTS generated_files (
         FOREIGN KEY (ticket_id) REFERENCES event_tickets (id),
     CONSTRAINT uk_generated_files_ticket UNIQUE (ticket_id)
 );
+
+-- =========================================================
+-- V6: Ticket bundle tables (mirror of V6__ticket_bundle_tables.sql)
+-- =========================================================
+
+CREATE TABLE IF NOT EXISTS generated_bundles (
+    id              BIGINT        PRIMARY KEY AUTO_INCREMENT,
+    event_id        BIGINT        NOT NULL,
+    storage_type    VARCHAR(16)   NOT NULL DEFAULT 'LOCAL',
+    storage_path    VARCHAR(1024) NOT NULL,
+    checksum_sha256 CHAR(64)      NOT NULL,
+    file_size_bytes BIGINT        NOT NULL,
+    ticket_count    INT           NOT NULL,
+    status          VARCHAR(20)   NOT NULL DEFAULT 'COMPLETED',
+    created_at      TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_generated_bundles_event UNIQUE (event_id)
+);

--- a/ticket-bundle-job/README.md
+++ b/ticket-bundle-job/README.md
@@ -1,0 +1,125 @@
+# ticket-bundle-job
+
+Spring Batch plugin that bundles all generated ticket PDFs for an event into a single ZIP
+archive. Delivered as a standalone shaded JAR and loaded dynamically by the `fr-batch-service`
+host.
+
+## What it does
+
+For a given `EVENT_ID`, the job:
+
+1. Reads all rows from `generated_files` joined through `event_tickets` where `event_id = ?`,
+   ordered by `ticket_id` ascending.
+2. Streams each PDF at its absolute `storage_path` into a temp ZIP file on disk.
+   ZIP entry names are prefixed with the ticket ID (`<ticketId>-<filename>`) for determinism.
+3. Uploads the completed ZIP to `{OUTPUT_DIR}/bundles/event-{EVENT_ID}.zip` via
+   `LocalFileStorage` (SHA-256 checksum computed during upload).
+4. Upserts one row in `generated_bundles` (DELETE + INSERT — portable across H2 and MySQL).
+5. Deletes the temp file.
+
+The job is **idempotent**: re-running for the same event overwrites the ZIP and replaces the
+single `generated_bundles` row. The `UNIQUE(event_id)` constraint enforces at most one current
+bundle per event.
+
+If the event has no `generated_files` rows the job completes successfully without producing
+any output (no-op). If any source PDF is missing on disk the job fails immediately
+(fail-fast policy, v1).
+
+## Job parameters
+
+| Parameter    | Required | Description |
+|--------------|----------|-------------|
+| `EVENT_ID`   | Yes      | Positive long identifying the event to bundle |
+| `OUTPUT_DIR` | Yes      | Directory where the output ZIP is written (`bundles/event-{id}.zip` subpath created automatically) |
+| `DATE`       | No       | Processing date (informational, e.g. `2024-06-15`) |
+
+Parameters are validated fail-fast by `BundleJobParametersValidator` before any step executes.
+
+## Two-step flow
+
+```
+Step 1 — ticketBundleZipStep (chunk, size 20)
+  Reader : JdbcCursorItemReader over generated_files JOIN event_tickets WHERE event_id = ?
+  Writer : ZipBundleItemWriter streams each PDF into a temp ZipOutputStream
+  Listener: BundleStepListener — binds params, sets reader SQL, closes ZIP in afterStep,
+            writes bundle.zip.temp.path and bundle.ticket.count to Job ExecutionContext
+
+Step 2 — ticketBundlePersistStep (tasklet)
+  BundlePersistTasklet — reads Job ctx, uploads ZIP via LocalFileStorage,
+                         upserts generated_bundles, deletes temp file
+```
+
+Cross-step state handoff uses two serializable Job ExecutionContext keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `bundle.zip.temp.path` | String | Absolute path of the temp ZIP (absent for empty events) |
+| `bundle.ticket.count`  | int    | Number of PDFs zipped (0 for empty events) |
+
+## Building the fat JAR
+
+Requires Maven and a GitHub Packages token (the `batch-job-api` dependency is hosted there).
+
+Configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then build:
+
+```bash
+mvn -B package -f ticket-bundle-job/pom.xml
+```
+
+The shaded JAR is produced at `ticket-bundle-job/target/ticket-bundle-job-1.0.0.jar`.
+This plugin uses only JDK built-ins (`java.util.zip`) so the shaded JAR contains only
+plugin classes and is very small (< 50 KB).
+
+## Running via the REST API
+
+### 1. Upload the JAR
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/upload \
+  -F "file=@ticket-bundle-job/target/ticket-bundle-job-1.0.0.jar" \
+  -F "jobName=ticket-bundle-job" \
+  -F "version=1.0.0" \
+  -F "mainClassName=com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin"
+```
+
+### 2. Run the job
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "ticket-bundle-job",
+    "params": {
+      "DATE": "2024-06-15",
+      "OUTPUT_DIR": "/var/data/bundles",
+      "EVENT_ID": "42"
+    }
+  }'
+```
+
+## Idempotency
+
+Re-running the job for the same `EVENT_ID` is safe:
+- The upload key `bundles/event-{id}.zip` is deterministic — re-uploading overwrites the previous ZIP.
+- The upsert (DELETE + INSERT) replaces the existing `generated_bundles` row.
+- After any number of re-runs, exactly one ZIP file and one DB row exist for the event.
+
+## Schema dependency
+
+This plugin requires the `event_tickets` and `generated_files` tables from Flyway migration
+`V5__ticket_pdf_tables.sql`, and the `generated_bundles` table from `V6__ticket_bundle_tables.sql`.
+Ensure the host has run at least V6 before loading this plugin.

--- a/ticket-bundle-job/pom.xml
+++ b/ticket-bundle-job/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.fronzec.plugins</groupId>
+  <artifactId>ticket-bundle-job</artifactId>
+  <version>1.0.0</version>
+  <name>ticket-bundle-job</name>
+  <description>Spring Batch plugin — event ticket PDF bundle ZIP generation</description>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- Platform-provided API (not shaded) -->
+    <dependency>
+      <groupId>com.fronzec</groupId>
+      <artifactId>batch-job-api</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided Spring Batch (not shaded) -->
+    <dependency>
+      <groupId>org.springframework.batch</groupId>
+      <artifactId>spring-batch-core</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided spring-jdbc (JdbcTemplate, JdbcCursorItemReader, RowMapper) -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided logging facade (not shaded) -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- No bundled runtime deps: ZIP assembly uses java.util.zip (JDK built-in). -->
+
+    <!-- Test dependencies (not shaded) -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Integration test: in-module H2 + Spring Batch bootstrap -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.3.232</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>7.0.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Note: spring-jdbc, spring-tx, and spring-batch-core are already declared as
+         "provided" above. "Provided" deps ARE on both compile and test classpaths
+         in Maven — no duplicate declarations needed here. -->
+
+    <!-- SLF4J simple backend for test logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <!-- Exclude platform-provided libraries -->
+                  <exclude>com.fronzec:batch-job-api</exclude>
+                  <exclude>org.springframework.batch:spring-batch-core</exclude>
+                  <exclude>org.springframework:spring-context</exclude>
+                  <exclude>org.springframework:spring-tx</exclude>
+                  <exclude>org.springframework:spring-jdbc</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+    </repository>
+  </repositories>
+</project>

--- a/ticket-bundle-job/pom.xml
+++ b/ticket-bundle-job/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.27.6</version>
+      <version>3.27.7</version>
       <scope>test</scope>
     </dependency>
 

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/TicketBundleJobPlugin.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/TicketBundleJobPlugin.java
@@ -1,0 +1,197 @@
+package com.fronzec.plugins.ticketbundle;
+
+import com.fronzec.api.BatchJobPlugin;
+import com.fronzec.api.JobMetadata;
+import com.fronzec.plugins.ticketbundle.batch.BundleJobParametersValidator;
+import com.fronzec.plugins.ticketbundle.batch.BundleParamsHolder;
+import com.fronzec.plugins.ticketbundle.batch.BundlePersistTasklet;
+import com.fronzec.plugins.ticketbundle.batch.BundleStepListener;
+import com.fronzec.plugins.ticketbundle.batch.GeneratedFileRow;
+import com.fronzec.plugins.ticketbundle.batch.GeneratedFileRowMapper;
+import com.fronzec.plugins.ticketbundle.batch.ZipAccumulator;
+import com.fronzec.plugins.ticketbundle.batch.ZipBundleItemWriter;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Spring Batch plugin that bundles all generated ticket PDFs for an event into a single
+ * ZIP archive and records the bundle in the {@code generated_bundles} table.
+ *
+ * <p>Implemented as a shaded standalone JAR loaded dynamically by the host service.
+ * No Spring annotations — instantiated via {@code getDeclaredConstructor().newInstance()}.
+ *
+ * <h3>Job parameters</h3>
+ * <ul>
+ *   <li>{@code EVENT_ID} — required; positive long identifying the event to bundle</li>
+ *   <li>{@code OUTPUT_DIR} — required; directory where the output ZIP is written</li>
+ *   <li>{@code DATE} — informational processing date</li>
+ * </ul>
+ *
+ * <h3>Two-step flow</h3>
+ * <ol>
+ *   <li><strong>ticketBundleZipStep</strong> (chunk, size 20): reads {@code generated_files}
+ *       joined through {@code event_tickets}, streams each PDF into a temp ZIP.</li>
+ *   <li><strong>ticketBundlePersistStep</strong> (tasklet): uploads the ZIP via
+ *       {@link com.fronzec.plugins.ticketbundle.storage.LocalFileStorage}, upserts
+ *       {@code generated_bundles}, deletes the temp file.</li>
+ * </ol>
+ */
+public class TicketBundleJobPlugin implements BatchJobPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketBundleJobPlugin.class);
+
+    private static final String JOB_NAME = "ticket-bundle-job";
+    private static final String VERSION = "1.0.0";
+
+    /**
+     * Chunk size for the ZIP assembly step.
+     * Each item triggers one file-read + one ZIP-entry-write.
+     * 20 balances commit overhead vs. memory (lighter work per item than the PDF job).
+     */
+    private static final int CHUNK_SIZE = 20;
+
+    @Override
+    public String getJobName() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public String getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public Job configureJob(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ApplicationContext parentContext) {
+
+        log.info("Configuring ticket-bundle-job plugin v{}", VERSION);
+
+        // Obtain the DataSource from the host's ApplicationContext.
+        DataSource dataSource = parentContext.getBean(DataSource.class);
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        // Shared parameter holder — populated by BundleStepListener.beforeStep().
+        BundleParamsHolder holder = new BundleParamsHolder();
+
+        // Shared ZIP accumulator — opened by writer on first item, closed by listener.afterStep().
+        ZipAccumulator accumulator = new ZipAccumulator();
+
+        // ── Step 1 components ─────────────────────────────────────────────────────────────────
+        // Placeholder SQL; the real SQL (with literal event_id) is set in BundleStepListener
+        // .beforeStep() before reader.open() is called by Spring Batch.
+        String placeholderSql =
+                "SELECT gf.id, gf.ticket_id, gf.storage_path"
+                        + " FROM generated_files gf"
+                        + " JOIN event_tickets et ON gf.ticket_id = et.id"
+                        + " WHERE et.event_id = 0 ORDER BY gf.ticket_id ASC";
+
+        JdbcCursorItemReader<GeneratedFileRow> reader =
+                new JdbcCursorItemReader<>(dataSource, placeholderSql, new GeneratedFileRowMapper());
+        reader.setName("generatedFileReader");
+        reader.setSaveState(false); // Avoid polluting step ctx with cursor position.
+
+        ZipBundleItemWriter writer = new ZipBundleItemWriter(accumulator);
+
+        BundleStepListener stepListener = new BundleStepListener(holder, reader, accumulator, writer);
+
+        var step1 = new StepBuilder("ticketBundleZipStep", jobRepository)
+                .<GeneratedFileRow, GeneratedFileRow>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .writer(writer)
+                .listener(stepListener)
+                .build();
+
+        // ── Learning note ─────────────────────────────────────────────────────────────────────
+        // The direct Job-ExecutionContext write in BundleStepListener.afterStep() is simple and
+        // explicit. The idiomatic Spring Batch alternative is ExecutionContextPromotionListener:
+        //
+        //   var promotionListener = new ExecutionContextPromotionListener();
+        //   promotionListener.setKeys(new String[]{
+        //       BundleStepListener.CTX_TEMP_PATH, BundleStepListener.CTX_TICKET_COUNT});
+        //   step1Builder.listener(promotionListener);
+        //
+        // That would promote step-scoped keys to job scope after a successful step, decoupling
+        // steps from each other's job ctx. For pedagogical contrast both variants are shown here
+        // and in BundleStepListener Javadoc. The direct write is used in production code because
+        // it is explicit and avoids the need for the step to also write to its step-ctx first.
+        // ─────────────────────────────────────────────────────────────────────────────────────
+
+        // ── Step 2 components ─────────────────────────────────────────────────────────────────
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, jdbc);
+
+        var step2 = new StepBuilder("ticketBundlePersistStep", jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .validator(new BundleJobParametersValidator())
+                .start(step1)
+                .next(step2)
+                .build();
+    }
+
+    @Override
+    public Map<String, String> getDefaultParameters() {
+        // EVENT_ID default is blank: callers MUST supply a valid positive long.
+        // The BundleJobParametersValidator rejects blank values fail-fast before steps run.
+        return Map.of(
+                "DATE", "2024-01-01",
+                "OUTPUT_DIR", "./target/bundles",
+                "EVENT_ID", "");
+    }
+
+    @Override
+    public List<String> getRequiredDependencies() {
+        // ZIP assembly uses java.util.zip (JDK built-in) — no third-party bundled deps.
+        return List.of();
+    }
+
+    @Override
+    public JobMetadata getMetadata() {
+        return new TicketBundleJobMetadata();
+    }
+
+    /** Named static inner class so the compiled {@code .class} file is discoverable. */
+    public static class TicketBundleJobMetadata implements JobMetadata {
+
+        @Override
+        public String getDisplayName() {
+            return "Event Ticket Bundle ZIP";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Bundles all generated ticket PDFs for an event into one ZIP archive and"
+                    + " records the bundle in the generated_bundles table.";
+        }
+
+        @Override
+        public String getAuthor() {
+            return "fronzec";
+        }
+
+        @Override
+        public List<String> getTags() {
+            return List.of("ticket", "bundle", "zip");
+        }
+
+        @Override
+        public Duration getEstimatedRuntime() {
+            return Duration.ofSeconds(10);
+        }
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleJobParametersValidator.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleJobParametersValidator.java
@@ -1,0 +1,50 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersValidator;
+
+/**
+ * Fail-fast pre-flight validation of the job parameters for {@code ticket-bundle-job}.
+ *
+ * <p>Registered on the {@code JobBuilder}, so it runs at job launch <strong>before any step
+ * starts</strong> — an invalid {@code EVENT_ID} or {@code OUTPUT_DIR} produces a clean
+ * {@link InvalidJobParametersException} rather than a mid-step failure.
+ *
+ * <p>Validations performed:
+ * <ol>
+ *   <li>{@code EVENT_ID} must be present and non-blank.</li>
+ *   <li>{@code EVENT_ID} must be parseable as a positive {@code long} (&gt; 0).</li>
+ *   <li>{@code OUTPUT_DIR} must be present and non-blank.</li>
+ * </ol>
+ */
+public class BundleJobParametersValidator implements JobParametersValidator {
+
+    @Override
+    public void validate(JobParameters parameters) throws InvalidJobParametersException {
+        String eventId = parameters.getString("EVENT_ID");
+
+        if (eventId == null || eventId.isBlank()) {
+            throw new InvalidJobParametersException("EVENT_ID is required");
+        }
+
+        long numericEventId;
+        try {
+            numericEventId = Long.parseLong(eventId.trim());
+        } catch (NumberFormatException e) {
+            throw new InvalidJobParametersException(
+                    "EVENT_ID must be a numeric value, got: " + eventId);
+        }
+
+        if (numericEventId <= 0) {
+            throw new InvalidJobParametersException(
+                    "EVENT_ID must be a positive long, got: " + numericEventId);
+        }
+
+        String outputDir = parameters.getString("OUTPUT_DIR");
+        if (outputDir == null || outputDir.isBlank()) {
+            throw new InvalidJobParametersException(
+                    "OUTPUT_DIR is required and must be non-blank");
+        }
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleParamsHolder.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleParamsHolder.java
@@ -1,0 +1,62 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import java.nio.file.Path;
+
+/**
+ * Mutable holder for job parameters, populated by {@link BundleStepListener} before the
+ * reader opens. All batch components share a single instance of this holder.
+ *
+ * <p>Because the plugin is instantiated without a Spring container, {@code @StepScope}
+ * late-binding is unavailable. This holder is the replacement: the step listener reads
+ * {@code JobParameters} in {@code beforeStep} and populates the holder before the reader's
+ * {@code open()} is called.
+ */
+public class BundleParamsHolder {
+
+    private String eventId;
+    private String outputDir;
+
+    /**
+     * Returns the output directory as a resolved {@link Path}. Must be called after
+     * {@code beforeStep} populates the holder.
+     *
+     * @return resolved output directory path
+     * @throws IllegalStateException if {@code OUTPUT_DIR} has not been set
+     */
+    public Path resolvedOutputDir() {
+        if (outputDir == null || outputDir.isBlank()) {
+            throw new IllegalStateException("OUTPUT_DIR is not set in BundleParamsHolder");
+        }
+        return Path.of(outputDir);
+    }
+
+    /**
+     * Returns the raw EVENT_ID string as provided in job parameters.
+     *
+     * @return event ID string, or {@code null} if not yet set
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+
+    public String getOutputDir() {
+        return outputDir;
+    }
+
+    public void setOutputDir(String outputDir) {
+        this.outputDir = outputDir;
+    }
+
+    /**
+     * Returns {@code true} when {@code EVENT_ID} is present and non-blank.
+     *
+     * @return {@code true} if event ID is set
+     */
+    public boolean hasEventId() {
+        return eventId != null && !eventId.isBlank();
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTasklet.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTasklet.java
@@ -77,9 +77,17 @@ public class BundlePersistTasklet implements Tasklet {
         long eventId = Long.parseLong(holder.getEventId().trim());
 
         // EMPTY-EVENT NO-OP: step 1 found no rows; skip upload and insert.
-        if (ticketCount == 0 || tempPath == null || tempPath.isBlank()) {
+        if (ticketCount == 0) {
             log.warn("no generated files for event {}; nothing to bundle", eventId);
             return RepeatStatus.FINISHED;
+        }
+
+        // HANDOFF GUARD: a non-zero ticket count without a temp path is a handoff failure —
+        // step 1 wrote tickets but the ZIP path was never propagated to the job context.
+        if (tempPath == null || tempPath.isBlank()) {
+            throw new IllegalStateException(
+                    "Missing job context key '" + BundleStepListener.CTX_TEMP_PATH
+                            + "' for non-empty bundle (ticket_count=" + ticketCount + ")");
         }
 
         Path tempZip = Path.of(tempPath);

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTasklet.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTasklet.java
@@ -1,0 +1,133 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import com.fronzec.plugins.ticketbundle.storage.LocalFileStorage;
+import com.fronzec.plugins.ticketbundle.storage.StoredFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Tasklet for step 2 of the ticket-bundle-job.
+ *
+ * <p>Reads the temp ZIP path and ticket count written to the Job ExecutionContext by
+ * {@link BundleStepListener#afterStep}, uploads the ZIP via {@link LocalFileStorage},
+ * and upserts one row in {@code generated_bundles} (DELETE + INSERT — portable across
+ * H2 MODE=MySQL and MySQL; no dialect-specific {@code MERGE} or {@code ON DUPLICATE KEY}).
+ *
+ * <p><strong>Empty-event no-op</strong>: when {@code bundle.ticket.count == 0} (no rows
+ * found for the event), the tasklet logs a warning and returns {@code FINISHED} without
+ * uploading or inserting anything.
+ *
+ * <p><strong>Temp file cleanup</strong>: the temp ZIP is deleted in a {@code finally}
+ * block so it is always removed, even when the JDBC upsert fails.
+ *
+ * <p><strong>Idempotency</strong>: the upload key {@code bundles/event-{id}.zip} is
+ * deterministic, so re-uploading overwrites the previous file. The DELETE+INSERT replaces
+ * the existing {@code generated_bundles} row. A re-run for the same event always converges
+ * to exactly one zip file and one DB row.
+ */
+public class BundlePersistTasklet implements Tasklet {
+
+    private static final Logger log = LoggerFactory.getLogger(BundlePersistTasklet.class);
+
+    private static final String DELETE_SQL =
+            "DELETE FROM generated_bundles WHERE event_id = ?";
+
+    private static final String INSERT_SQL =
+            "INSERT INTO generated_bundles"
+                    + " (event_id, storage_type, storage_path, checksum_sha256,"
+                    + "  file_size_bytes, ticket_count, status)"
+                    + " VALUES (?, ?, ?, ?, ?, ?, 'COMPLETED')";
+
+    private final BundleParamsHolder holder;
+    private final JdbcTemplate jdbc;
+
+    /**
+     * Constructs the tasklet.
+     *
+     * @param holder shared parameter holder (provides event ID and output directory)
+     * @param jdbc   JDBC template bound to the DataSource from the parent context
+     */
+    public BundlePersistTasklet(BundleParamsHolder holder, JdbcTemplate jdbc) {
+        this.holder = holder;
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext)
+            throws Exception {
+
+        // Read handoff keys from the JOB ExecutionContext (written by BundleStepListener).
+        var jobCtx = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        int ticketCount = jobCtx.getInt(BundleStepListener.CTX_TICKET_COUNT, 0);
+        String tempPath = jobCtx.containsKey(BundleStepListener.CTX_TEMP_PATH)
+                ? jobCtx.getString(BundleStepListener.CTX_TEMP_PATH)
+                : null;
+
+        long eventId = Long.parseLong(holder.getEventId().trim());
+
+        // EMPTY-EVENT NO-OP: step 1 found no rows; skip upload and insert.
+        if (ticketCount == 0 || tempPath == null || tempPath.isBlank()) {
+            log.warn("no generated files for event {}; nothing to bundle", eventId);
+            return RepeatStatus.FINISHED;
+        }
+
+        Path tempZip = Path.of(tempPath);
+        try {
+            // Read the temp ZIP into memory (single artifact — acceptable).
+            // Note: a streaming upload would be the S3-era improvement for very large bundles.
+            byte[] zipBytes = Files.readAllBytes(tempZip);
+
+            // Upload via LocalFileStorage (output sandbox); key is deterministic for idempotency.
+            LocalFileStorage storage = new LocalFileStorage(holder.resolvedOutputDir());
+            String uploadKey = "bundles/event-" + eventId + ".zip";
+            StoredFile stored = storage.write(uploadKey, zipBytes);
+
+            log.info("Uploaded bundle for event_id={} -> {} ({} bytes, sha256={})",
+                    eventId, stored.path(), stored.sizeBytes(), stored.checksum());
+
+            // UPSERT: DELETE then INSERT (portable; no MERGE / ON DUPLICATE KEY).
+            // Both statements run within the tasklet's chunk transaction — the DELETE is
+            // rolled back if the INSERT fails, leaving no partial state.
+            jdbc.update(DELETE_SQL, eventId);
+
+            int inserted = jdbc.update(INSERT_SQL,
+                    eventId,
+                    stored.storageType(),
+                    stored.path(),
+                    stored.checksum(),
+                    stored.sizeBytes(),
+                    ticketCount);
+
+            if (inserted != 1) {
+                throw new IllegalStateException(
+                        "Expected 1 generated_bundles insert for event_id=" + eventId
+                                + " but affected " + inserted);
+            }
+
+            log.info("Recorded generated_bundles row: event_id={}, ticket_count={}, status=COMPLETED",
+                    eventId, ticketCount);
+
+        } finally {
+            // Always delete the temp file — even when the JDBC step fails.
+            try {
+                Files.deleteIfExists(tempZip);
+                log.debug("Deleted temp ZIP: {}", tempZip);
+            } catch (Exception e) {
+                log.warn("Failed to delete temp ZIP '{}': {}", tempZip, e.getMessage());
+            }
+        }
+
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListener.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListener.java
@@ -69,6 +69,10 @@ public class BundleStepListener implements StepExecutionListener {
 
     @Override
     public void beforeStep(StepExecution stepExecution) {
+        // Reset the accumulator first: the host JobRegistry caches the Job (and this listener's
+        // accumulator instance) across executions, so we must clear state before each new run.
+        accumulator.reset();
+
         var params = stepExecution.getJobParameters();
 
         String eventId = params.getString("EVENT_ID");
@@ -92,20 +96,39 @@ public class BundleStepListener implements StepExecutionListener {
     public ExitStatus afterStep(StepExecution stepExecution) {
         // Close the ZipOutputStream in try/finally so the stream is always released,
         // even when the chunk step fails mid-way (prevents corrupt/locked temp files).
+        Exception closeException = null;
         try {
             accumulator.close();
         } catch (Exception e) {
-            log.error("Failed to close ZIP accumulator after step", e);
+            closeException = e;
+            log.error("Failed to close ZIP accumulator after step — ZIP may be corrupt", e);
         } finally {
-            // Write handoff keys to the JOB ExecutionContext so step 2 can read them.
             var jobCtx = stepExecution.getJobExecution().getExecutionContext();
-            jobCtx.putInt(CTX_TICKET_COUNT, accumulator.ticketCount());
-            if (accumulator.isOpened() && accumulator.zipPath() != null) {
-                jobCtx.putString(CTX_TEMP_PATH, accumulator.zipPath().toString());
+            if (closeException == null) {
+                // Success path: write both handoff keys so step 2 can proceed.
+                jobCtx.putInt(CTX_TICKET_COUNT, accumulator.ticketCount());
+                if (accumulator.isOpened() && accumulator.zipPath() != null) {
+                    jobCtx.putString(CTX_TEMP_PATH, accumulator.zipPath().toString());
+                }
+                log.info("Step finished: ticket_count={}, temp_zip={}",
+                        accumulator.ticketCount(),
+                        accumulator.isOpened() ? accumulator.zipPath() : "<none>");
+            } else {
+                // Failure path: do NOT write CTX_TEMP_PATH so step 2 cannot pick up a corrupt
+                // bundle. Best-effort delete the orphaned temp file.
+                jobCtx.putInt(CTX_TICKET_COUNT, accumulator.ticketCount());
+                if (accumulator.zipPath() != null) {
+                    try {
+                        java.nio.file.Files.deleteIfExists(accumulator.zipPath());
+                    } catch (Exception ignored) {
+                        log.warn("Could not delete orphaned temp ZIP {}", accumulator.zipPath());
+                    }
+                }
             }
-            log.info("Step finished: ticket_count={}, temp_zip={}",
-                    accumulator.ticketCount(),
-                    accumulator.isOpened() ? accumulator.zipPath() : "<none>");
+        }
+
+        if (closeException != null) {
+            return new ExitStatus("FAILED", "ZIP finalization failure: " + closeException.getMessage());
         }
         return stepExecution.getExitStatus();
     }

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListener.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListener.java
@@ -1,0 +1,127 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+
+/**
+ * Populates {@link BundleParamsHolder} from job parameters before the reader opens, and
+ * closes the {@link ZipAccumulator} stream after the step (success or failure).
+ *
+ * <p>This is the mechanism for injecting job parameters without {@code @StepScope}: the
+ * step listener reads {@code JobParameters} in {@code beforeStep} and populates the shared
+ * holder before {@link JdbcCursorItemReader#open} is called.
+ *
+ * <p><strong>ZipOutputStream lifecycle</strong>: {@code afterStep} closes the accumulator's
+ * stream in a {@code try/finally} block — guaranteeing that the temp ZIP is finalised and
+ * released even when the step fails mid-chunk (addresses design Risk R6).
+ *
+ * <p><strong>ExecutionContext handoff</strong>: after closing the stream, {@code afterStep}
+ * writes two keys to the <em>Job</em> ExecutionContext so {@link BundlePersistTasklet} (step 2)
+ * can read them:
+ * <ul>
+ *   <li>{@code bundle.zip.temp.path} — absolute path of the temp ZIP (absent when zero items)</li>
+ *   <li>{@code bundle.ticket.count} — number of PDFs zipped (0 for empty event)</li>
+ * </ul>
+ *
+ * <p><em>Alternative (not implemented here)</em>: {@code ExecutionContextPromotionListener}
+ * is the idiomatic Spring Batch way to promote step-scoped context keys to job scope after
+ * a successful step. That avoids the tight coupling between this listener and the job context.
+ * It is documented in {@link com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin#configureJob}
+ * as a learning note.
+ */
+public class BundleStepListener implements StepExecutionListener {
+
+    private static final Logger log = LoggerFactory.getLogger(BundleStepListener.class);
+
+    /** Job ExecutionContext key for the temporary ZIP file path. */
+    static final String CTX_TEMP_PATH = "bundle.zip.temp.path";
+
+    /** Job ExecutionContext key for the count of zipped PDFs. */
+    static final String CTX_TICKET_COUNT = "bundle.ticket.count";
+
+    private final BundleParamsHolder holder;
+    private final JdbcCursorItemReader<GeneratedFileRow> reader;
+    private final ZipAccumulator accumulator;
+    private final ZipBundleItemWriter writer;
+
+    /**
+     * Constructs the listener.
+     *
+     * @param holder     shared parameter holder to populate in {@code beforeStep}
+     * @param reader     the cursor reader whose SQL is configured in {@code beforeStep}
+     * @param accumulator the ZIP accumulator to close in {@code afterStep}
+     * @param writer     the item writer that needs the event ID before step open
+     */
+    public BundleStepListener(
+            BundleParamsHolder holder,
+            JdbcCursorItemReader<GeneratedFileRow> reader,
+            ZipAccumulator accumulator,
+            ZipBundleItemWriter writer) {
+        this.holder = holder;
+        this.reader = reader;
+        this.accumulator = accumulator;
+        this.writer = writer;
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        var params = stepExecution.getJobParameters();
+
+        String eventId = params.getString("EVENT_ID");
+        String outputDir = params.getString("OUTPUT_DIR");
+
+        holder.setEventId(eventId);
+        holder.setOutputDir(outputDir);
+
+        // Pass the numeric event ID to the writer so it can name the temp file.
+        long numericEventId = Long.parseLong(eventId.trim());
+        writer.setEventId(numericEventId);
+
+        // Set the reader SQL with the literal event ID (safe: already validated as a
+        // positive long by BundleJobParametersValidator before any step runs).
+        reader.setSql(buildSql(eventId.trim()));
+
+        log.info("Configured ticket-bundle-job for event_id={}", eventId);
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        // Close the ZipOutputStream in try/finally so the stream is always released,
+        // even when the chunk step fails mid-way (prevents corrupt/locked temp files).
+        try {
+            accumulator.close();
+        } catch (Exception e) {
+            log.error("Failed to close ZIP accumulator after step", e);
+        } finally {
+            // Write handoff keys to the JOB ExecutionContext so step 2 can read them.
+            var jobCtx = stepExecution.getJobExecution().getExecutionContext();
+            jobCtx.putInt(CTX_TICKET_COUNT, accumulator.ticketCount());
+            if (accumulator.isOpened() && accumulator.zipPath() != null) {
+                jobCtx.putString(CTX_TEMP_PATH, accumulator.zipPath().toString());
+            }
+            log.info("Step finished: ticket_count={}, temp_zip={}",
+                    accumulator.ticketCount(),
+                    accumulator.isOpened() ? accumulator.zipPath() : "<none>");
+        }
+        return stepExecution.getExitStatus();
+    }
+
+    /**
+     * Builds the reader SQL with the event ID literal-inlined.
+     * The event ID is already validated as a positive long before this runs.
+     *
+     * @param eventId string representation of the numeric event ID
+     * @return SQL string for the cursor reader
+     */
+    static String buildSql(String eventId) {
+        return "SELECT gf.id, gf.ticket_id, gf.storage_path"
+                + " FROM generated_files gf"
+                + " JOIN event_tickets et ON gf.ticket_id = et.id"
+                + " WHERE et.event_id = " + Long.parseLong(eventId)
+                + " ORDER BY gf.ticket_id ASC";
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRow.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRow.java
@@ -1,0 +1,11 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+/**
+ * Immutable projection of a row from the {@code generated_files} table, joined through
+ * {@code event_tickets} to resolve the event scope.
+ *
+ * @param id          primary key of the {@code generated_files} row
+ * @param ticketId    foreign key back to {@code event_tickets}
+ * @param storagePath absolute local path where the generated ticket PDF is stored
+ */
+public record GeneratedFileRow(long id, long ticketId, String storagePath) {}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRowMapper.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRowMapper.java
@@ -1,0 +1,24 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Maps a row from the joined {@code generated_files / event_tickets} query to a
+ * {@link GeneratedFileRow} record.
+ *
+ * <p>The expected column aliases in the result set are {@code id}, {@code ticket_id},
+ * and {@code storage_path} — matching the SELECT in
+ * {@link BundleStepListener#buildSql(String)}.
+ */
+public class GeneratedFileRowMapper implements RowMapper<GeneratedFileRow> {
+
+    @Override
+    public GeneratedFileRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new GeneratedFileRow(
+                rs.getLong("id"),
+                rs.getLong("ticket_id"),
+                rs.getString("storage_path"));
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulator.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulator.java
@@ -78,6 +78,26 @@ public class ZipAccumulator {
     }
 
     /**
+     * Resets all state so this instance can be reused for a new job execution.
+     *
+     * <p>Must be called at the start of {@link BundleStepListener#beforeStep} because the
+     * host's {@code JobRegistry} caches the {@link org.springframework.batch.core.job.Job}
+     * returned by {@code configureJob()} and reuses it — along with this accumulator — for
+     * every execution. Without a reset, {@code lazyOpen()} would see {@code opened == true},
+     * skip opening a fresh stream, and {@code ticketCount} would carry over from the previous
+     * run, corrupting subsequent bundles.
+     *
+     * <p>Do NOT call {@link #close()} here; the close lifecycle is managed exclusively by
+     * {@link BundleStepListener#afterStep}.
+     */
+    public void reset() {
+        zipPath = null;
+        zos = null;
+        ticketCount = 0;
+        opened = false;
+    }
+
+    /**
      * Returns the path to the temporary ZIP file, or {@code null} if the accumulator has
      * not been opened yet (i.e. zero items were processed).
      *

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulator.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulator.java
@@ -1,0 +1,107 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stateful accumulator that manages the lifecycle of a temporary ZIP file being built
+ * during the chunk step.
+ *
+ * <p>The ZIP stream is opened lazily on the first call to {@link #lazyOpen(long)} and
+ * must be closed exactly once by {@link BundleStepListener#afterStep} (in a {@code try/finally}
+ * block), regardless of step success or failure.
+ *
+ * <p><strong>Thread safety</strong>: this class is NOT thread-safe. It is designed for
+ * single-threaded Spring Batch step execution.
+ */
+public class ZipAccumulator {
+
+    private static final Logger log = LoggerFactory.getLogger(ZipAccumulator.class);
+
+    private Path zipPath;
+    private ZipOutputStream zos;
+    private int ticketCount;
+    private boolean opened;
+
+    /**
+     * Lazily opens the temporary ZIP file on the first call. Subsequent calls are no-ops.
+     *
+     * @param eventId used to name the temp file for traceability
+     * @throws IOException if the temp file cannot be created or the stream cannot be opened
+     */
+    public void lazyOpen(long eventId) throws IOException {
+        if (!opened) {
+            zipPath = Files.createTempFile("ticket-bundle-" + eventId + "-", ".zip");
+            zos = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(zipPath)));
+            opened = true;
+            log.debug("Opened temp ZIP at {}", zipPath);
+        }
+    }
+
+    /**
+     * Streams the bytes from {@code sourcePath} into a new ZIP entry named {@code entryName}.
+     *
+     * <p>Uses {@link Files#copy(Path, java.io.OutputStream)} for streaming copy (8 KB buffer)
+     * rather than reading all bytes at once — keeping memory flat for large events.
+     *
+     * @param entryName the name of the ZIP entry (e.g. {@code "42-ticket.pdf"})
+     * @param sourcePath the local file to read
+     * @throws IOException if reading {@code sourcePath} or writing to the ZIP stream fails
+     */
+    public void addEntry(String entryName, Path sourcePath) throws IOException {
+        zos.putNextEntry(new ZipEntry(entryName));
+        Files.copy(sourcePath, zos);
+        zos.closeEntry();
+        ticketCount++;
+    }
+
+    /**
+     * Closes the underlying {@link ZipOutputStream}, finalising the ZIP central directory.
+     * Safe to call even if the accumulator was never opened (no-op).
+     *
+     * <p>Called from {@link BundleStepListener#afterStep} inside a {@code try/finally}
+     * so the stream is closed even if the step fails mid-chunk.
+     *
+     * @throws IOException if closing the stream fails
+     */
+    public void close() throws IOException {
+        if (opened && zos != null) {
+            zos.close();
+            log.debug("Closed temp ZIP at {}", zipPath);
+        }
+    }
+
+    /**
+     * Returns the path to the temporary ZIP file, or {@code null} if the accumulator has
+     * not been opened yet (i.e. zero items were processed).
+     *
+     * @return temp ZIP path, or {@code null}
+     */
+    public Path zipPath() {
+        return zipPath;
+    }
+
+    /**
+     * Returns the number of ZIP entries written so far.
+     *
+     * @return ticket count
+     */
+    public int ticketCount() {
+        return ticketCount;
+    }
+
+    /**
+     * Returns {@code true} if {@link #lazyOpen(long)} has been called at least once.
+     *
+     * @return {@code true} if the ZIP stream has been opened
+     */
+    public boolean isOpened() {
+        return opened;
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipBundleItemWriter.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/ZipBundleItemWriter.java
@@ -1,0 +1,79 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.batch.infrastructure.item.Chunk;
+
+/**
+ * Item writer for the ZIP assembly chunk step.
+ *
+ * <p>For each {@link GeneratedFileRow} in the chunk:
+ * <ol>
+ *   <li>Verifies the source PDF exists on disk — FAIL-FAST if missing.</li>
+ *   <li>Lazily opens the {@link ZipAccumulator}'s temp ZIP on the first item.</li>
+ *   <li>Streams the PDF bytes into a new ZIP entry named {@code <ticketId>-<filename>}.</li>
+ * </ol>
+ *
+ * <p><strong>Source file reads</strong>: done directly via {@code java.nio} over the
+ * absolute {@code storage_path} from the database row. The {@code LocalFileStorage} sandbox
+ * is NOT used on the read side — that class is output-only (write/delete).
+ *
+ * <p><strong>ZIP stream lifecycle</strong>: this writer does NOT close the
+ * {@link ZipAccumulator}. Closing happens in {@link BundleStepListener#afterStep}
+ * inside a {@code try/finally} block, guaranteeing cleanup even on mid-chunk failure.
+ */
+public class ZipBundleItemWriter implements ItemWriter<GeneratedFileRow> {
+
+    private static final Logger log = LoggerFactory.getLogger(ZipBundleItemWriter.class);
+
+    private final ZipAccumulator accumulator;
+    private long eventId;
+
+    /**
+     * Constructs a writer backed by the given accumulator.
+     *
+     * @param accumulator shared accumulator that owns the temp ZIP stream
+     */
+    public ZipBundleItemWriter(ZipAccumulator accumulator) {
+        this.accumulator = accumulator;
+    }
+
+    /**
+     * Sets the event ID used for naming the temp file on lazy open.
+     * Called by {@link BundleStepListener#beforeStep} before the reader opens.
+     *
+     * @param eventId the event ID from job parameters
+     */
+    public void setEventId(long eventId) {
+        this.eventId = eventId;
+    }
+
+    @Override
+    public void write(Chunk<? extends GeneratedFileRow> chunk) throws Exception {
+        for (GeneratedFileRow row : chunk) {
+            Path sourcePath = Path.of(row.storagePath());
+
+            // FAIL-FAST: a missing source file means the bundle would be incomplete.
+            // Silently skipping is worse than a loud failure (v1 policy).
+            // See design section 7: skip-and-count is the v2 enhancement via faultTolerant().
+            if (!Files.exists(sourcePath)) {
+                throw new IllegalStateException(
+                        "source PDF missing for ticket id=" + row.ticketId()
+                                + ": " + row.storagePath());
+            }
+
+            // Lazy-open the temp ZIP on the first item of the first chunk.
+            accumulator.lazyOpen(eventId);
+
+            // Entry name always prefixed with ticketId for determinism (resolves entry-name
+            // collision when two tickets share the same filename).
+            String entryName = row.ticketId() + "-" + sourcePath.getFileName();
+            accumulator.addEntry(entryName, sourcePath);
+
+            log.debug("Added ZIP entry '{}' for ticket id={}", entryName, row.ticketId());
+        }
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/package-info.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/batch/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Spring Batch components for the ticket-bundle-job plugin.
+ *
+ * <p>Contains the chunk-step reader/writer/listener (step 1 — ZIP assembly)
+ * and the tasklet step (step 2 — bundle persist), plus supporting domain types
+ * and the fail-fast job parameters validator.
+ */
+package com.fronzec.plugins.ticketbundle.batch;

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/package-info.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Event Ticket Bundle ZIP plugin for the Spring Batch dynamic plugin platform.
+ *
+ * <p>Given an {@code EVENT_ID} job parameter this plugin reads all already-generated
+ * ticket PDF files from {@code generated_files} (joined through {@code event_tickets}),
+ * streams them into a single ZIP archive, uploads the archive via a {@code FileStorage}
+ * seam, and records one idempotent row in {@code generated_bundles}.
+ *
+ * <p>The plugin is loaded dynamically by the host service via {@link java.util.ServiceLoader};
+ * the implementation class is {@link com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin}.
+ */
+package com.fronzec.plugins.ticketbundle;

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/FileStorage.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/FileStorage.java
@@ -1,0 +1,27 @@
+package com.fronzec.plugins.ticketbundle.storage;
+
+/**
+ * Abstraction for writing generated ZIP bundle files.
+ *
+ * <p>The v1 implementation is {@link LocalFileStorage}. A future {@code S3FileStorage} is a
+ * drop-in replacement requiring no changes to the tasklet or any other batch component.
+ */
+public interface FileStorage {
+
+    /**
+     * Write {@code content} to the storage backend under the given {@code key}.
+     *
+     * @param key     filename or object key (e.g. {@code "bundles/event-10.zip"})
+     * @param content raw bytes to store
+     * @return a {@link StoredFile} describing the stored artifact
+     */
+    StoredFile write(String key, byte[] content);
+
+    /**
+     * Remove the file identified by {@code key}. Best-effort: implementations should swallow
+     * {@code IOException} and log a warning rather than propagating it.
+     *
+     * @param key filename or object key to delete
+     */
+    default void delete(String key) {}
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/LocalFileStorage.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/LocalFileStorage.java
@@ -1,0 +1,91 @@
+package com.fronzec.plugins.ticketbundle.storage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link FileStorage} implementation that writes files to the local filesystem.
+ *
+ * <p>Computes a SHA-256 hex checksum of the written content and returns a {@link StoredFile} with
+ * {@code storageType = "LOCAL"}.
+ *
+ * <p><strong>Output-only</strong>: this class is used exclusively to <em>write</em> the output
+ * ZIP bundle. Source PDF files are read directly via {@code java.nio} over their absolute
+ * {@code storage_path} — they are NOT routed through this class (which would trip the
+ * {@link #resolveSafePath} sandbox). See {@code ZipBundleItemWriter} for the read side.
+ */
+public class LocalFileStorage implements FileStorage {
+
+    private static final Logger log = LoggerFactory.getLogger(LocalFileStorage.class);
+
+    private final Path baseDir;
+
+    /**
+     * Constructs a {@code LocalFileStorage} rooted at {@code baseDir}.
+     *
+     * @param baseDir the base directory under which all keys are resolved
+     */
+    public LocalFileStorage(Path baseDir) {
+        this.baseDir = baseDir;
+    }
+
+    @Override
+    public StoredFile write(String key, byte[] content) {
+        Path target = resolveSafePath(key);
+        try {
+            if (target.getParent() != null) {
+                Files.createDirectories(target.getParent());
+            }
+            Files.write(target, content);
+            String checksum = sha256Hex(content);
+            return new StoredFile("LOCAL", target.toString(), checksum, content.length);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write file with key: " + key, e);
+        }
+    }
+
+    @Override
+    public void delete(String key) {
+        try {
+            Files.deleteIfExists(resolveSafePath(key));
+        } catch (IOException e) {
+            log.warn("Failed to delete file with key '{}': {}", key, e.getMessage());
+        }
+    }
+
+    /**
+     * Resolve {@code key} against the base directory, rejecting any key that would escape it
+     * (e.g. {@code ../} or an absolute path). Prevents path-traversal writes/deletes.
+     *
+     * @param key the storage key to resolve
+     * @return the safe, normalized absolute path
+     * @throws IllegalArgumentException if the key escapes the base directory
+     */
+    private Path resolveSafePath(String key) {
+        Path base = baseDir.toAbsolutePath().normalize();
+        Path target = base.resolve(key).normalize();
+        if (!target.startsWith(base)) {
+            throw new IllegalArgumentException("Illegal storage key (path traversal): " + key);
+        }
+        return target;
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+}

--- a/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/StoredFile.java
+++ b/ticket-bundle-job/src/main/java/com/fronzec/plugins/ticketbundle/storage/StoredFile.java
@@ -1,0 +1,11 @@
+package com.fronzec.plugins.ticketbundle.storage;
+
+/**
+ * Value returned by {@link FileStorage#write} describing the stored artifact.
+ *
+ * @param storageType backend identifier, e.g. {@code "LOCAL"} or {@code "S3"}
+ * @param path        absolute path or URI to the stored file
+ * @param checksum    hex-encoded SHA-256 of the written bytes
+ * @param sizeBytes   exact byte count of the written content
+ */
+public record StoredFile(String storageType, String path, String checksum, long sizeBytes) {}

--- a/ticket-bundle-job/src/main/resources/META-INF/services/com.fronzec.api.BatchJobPlugin
+++ b/ticket-bundle-job/src/main/resources/META-INF/services/com.fronzec.api.BatchJobPlugin
@@ -1,0 +1,1 @@
+com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundleJobParametersValidatorTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundleJobParametersValidatorTest.java
@@ -1,0 +1,92 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+
+/**
+ * Unit tests for {@link BundleJobParametersValidator}.
+ */
+class BundleJobParametersValidatorTest {
+
+    private static final String VALID_EVENT_ID = "42";
+    private static final String VALID_OUTPUT_DIR = "/tmp/bundles";
+
+    private final BundleJobParametersValidator validator = new BundleJobParametersValidator();
+
+    private JobParameters params(String eventId, String outputDir) {
+        JobParametersBuilder b = new JobParametersBuilder();
+        if (eventId != null) {
+            b.addString("EVENT_ID", eventId);
+        }
+        if (outputDir != null) {
+            b.addString("OUTPUT_DIR", outputDir);
+        }
+        return b.toJobParameters();
+    }
+
+    @Test
+    void validate_missingEventId_throws() {
+        assertThatThrownBy(() -> validator.validate(params(null, VALID_OUTPUT_DIR)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("EVENT_ID");
+    }
+
+    @Test
+    void validate_blankEventId_throws() {
+        assertThatThrownBy(() -> validator.validate(params("   ", VALID_OUTPUT_DIR)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("EVENT_ID");
+    }
+
+    @Test
+    void validate_zeroEventId_throws() {
+        assertThatThrownBy(() -> validator.validate(params("0", VALID_OUTPUT_DIR)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void validate_negativeEventId_throws() {
+        assertThatThrownBy(() -> validator.validate(params("-5", VALID_OUTPUT_DIR)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("positive");
+    }
+
+    @Test
+    void validate_nonNumericEventId_throws() {
+        assertThatThrownBy(() -> validator.validate(params("not-a-number", VALID_OUTPUT_DIR)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("numeric");
+    }
+
+    @Test
+    void validate_missingOutputDir_throws() {
+        assertThatThrownBy(() -> validator.validate(params(VALID_EVENT_ID, null)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("OUTPUT_DIR");
+    }
+
+    @Test
+    void validate_blankOutputDir_throws() {
+        assertThatThrownBy(() -> validator.validate(params(VALID_EVENT_ID, "  ")))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("OUTPUT_DIR");
+    }
+
+    @Test
+    void validate_validParams_noException() {
+        assertThatCode(() -> validator.validate(params(VALID_EVENT_ID, VALID_OUTPUT_DIR)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_largeEventId_passes() {
+        assertThatCode(() -> validator.validate(params("9999999999", VALID_OUTPUT_DIR)))
+                .doesNotThrowAnyException();
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTaskletTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTaskletTest.java
@@ -1,6 +1,7 @@
 package com.fronzec.plugins.ticketbundle.batch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -179,6 +180,25 @@ class BundlePersistTaskletTest {
 
         // Temp file MUST be deleted even on failure (finally block)
         assertThat(tempZip).doesNotExist();
+    }
+
+    @Test
+    void execute_nonZeroCountWithNoTempPath_throwsIllegalStateException() throws Exception {
+        // ticketCount > 0 but CTX_TEMP_PATH was never written to the job context (FIX #2):
+        // this is a handoff failure and must be surfaced, not silently no-op'd.
+        BundleParamsHolder holder = new BundleParamsHolder();
+        holder.setEventId("55");
+        holder.setOutputDir(tempDir.toString());
+
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, jdbc);
+
+        // Build a context with ticketCount=2 but no CTX_TEMP_PATH entry
+        ChunkContext ctx = buildChunkContext(55L, tempDir.toString(), null, 2);
+
+        assertThatThrownBy(() -> tasklet.execute(null, ctx))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(BundleStepListener.CTX_TEMP_PATH)
+                .hasMessageContaining("ticket_count=2");
     }
 
     @Test

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTaskletTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundlePersistTaskletTest.java
@@ -1,0 +1,216 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+
+/**
+ * Unit tests for {@link BundlePersistTasklet}.
+ *
+ * <p>Uses a real H2 database for the JDBC assertions, avoiding the need for Mockito.
+ * The Spring Batch domain objects (StepExecution, JobExecution, ChunkContext) are
+ * constructed manually with minimal wiring — no Spring context needed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BundlePersistTaskletTest {
+
+    @TempDir Path tempDir;
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:tasklet-test-" + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS generated_bundles ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " event_id BIGINT NOT NULL,"
+                        + " storage_type VARCHAR(16) NOT NULL DEFAULT 'LOCAL',"
+                        + " storage_path VARCHAR(1024) NOT NULL,"
+                        + " checksum_sha256 CHAR(64) NOT NULL,"
+                        + " file_size_bytes BIGINT NOT NULL,"
+                        + " ticket_count INT NOT NULL,"
+                        + " status VARCHAR(20) NOT NULL DEFAULT 'COMPLETED',"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_gb_event UNIQUE (event_id)"
+                        + ")");
+    }
+
+    @BeforeEach
+    void cleanTable() {
+        jdbc.execute("DELETE FROM generated_bundles");
+    }
+
+    private ChunkContext buildChunkContext(long eventId, String outputDir,
+            String tempZipPath, int ticketCount) {
+        JobParameters params = new JobParametersBuilder()
+                .addString("EVENT_ID", String.valueOf(eventId))
+                .addString("OUTPUT_DIR", outputDir)
+                .addLong("run.id", System.nanoTime())
+                .toJobParameters();
+
+        JobInstance jobInstance = new JobInstance(1L, "ticket-bundle-job");
+        JobExecution jobExecution = new JobExecution(1L, jobInstance, params);
+
+        // Write the handoff keys to the JOB ExecutionContext
+        ExecutionContext jobCtx = jobExecution.getExecutionContext();
+        jobCtx.putInt(BundleStepListener.CTX_TICKET_COUNT, ticketCount);
+        if (tempZipPath != null) {
+            jobCtx.putString(BundleStepListener.CTX_TEMP_PATH, tempZipPath);
+        }
+
+        StepExecution stepExecution = new StepExecution("ticketBundlePersistStep", jobExecution);
+        StepContext stepContext = new StepContext(stepExecution);
+        return new ChunkContext(stepContext);
+    }
+
+    @Test
+    void execute_zeroCount_skipsUploadAndInsert() throws Exception {
+        BundleParamsHolder holder = new BundleParamsHolder();
+        holder.setEventId("10");
+        holder.setOutputDir(tempDir.toString());
+
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, jdbc);
+
+        ChunkContext ctx = buildChunkContext(10L, tempDir.toString(), null, 0);
+        RepeatStatus status = tasklet.execute(null, ctx);
+
+        assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+
+        // No DB insert performed
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = 10", Integer.class);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void execute_uploadsZipAndInserts_generatedBundles() throws Exception {
+        // Create a real temp zip file on disk
+        Path tempZip = Files.createTempFile(tempDir, "bundle-test-", ".zip");
+        byte[] zipContent = new byte[]{0x50, 0x4B, 0x05, 0x06}; // minimal zip end-of-central-dir
+        Files.write(tempZip, zipContent);
+
+        BundleParamsHolder holder = new BundleParamsHolder();
+        holder.setEventId("42");
+        holder.setOutputDir(tempDir.toString());
+
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, jdbc);
+
+        ChunkContext ctx = buildChunkContext(42L, tempDir.toString(), tempZip.toString(), 3);
+        RepeatStatus status = tasklet.execute(null, ctx);
+
+        assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+
+        // Temp file deleted
+        assertThat(tempZip).doesNotExist();
+
+        // DB row inserted
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT * FROM generated_bundles WHERE event_id = 42");
+        assertThat(rows).hasSize(1);
+
+        Map<String, Object> row = rows.get(0);
+        assertThat(row.get("ticket_count")).isEqualTo(3);
+        assertThat(row.get("status")).isEqualTo("COMPLETED");
+        assertThat((String) row.get("storage_path")).isNotBlank();
+        assertThat((String) row.get("checksum_sha256")).hasSize(64);
+        assertThat((Long) row.get("file_size_bytes")).isGreaterThan(0L);
+    }
+
+    @Test
+    void execute_deletesTemp_evenOnJdbcFailure() throws Exception {
+        // Create a temp zip file
+        Path tempZip = Files.createTempFile(tempDir, "fail-test-", ".zip");
+        Files.write(tempZip, new byte[]{0x50, 0x4B});
+
+        BundleParamsHolder holder = new BundleParamsHolder();
+        holder.setEventId("999");
+        holder.setOutputDir(tempDir.toString());
+
+        // Use a broken JDBC template that will fail on INSERT
+        JdbcDataSource badDs = new JdbcDataSource();
+        badDs.setURL("jdbc:h2:mem:nonexistent-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        badDs.setUser("sa");
+        badDs.setPassword("");
+        JdbcTemplate brokenJdbc = new JdbcTemplate(badDs);
+        // The generated_bundles table doesn't exist on the bad datasource -> INSERT will fail
+
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, brokenJdbc);
+
+        ChunkContext ctx = buildChunkContext(999L, tempDir.toString(), tempZip.toString(), 2);
+
+        try {
+            tasklet.execute(null, ctx);
+        } catch (Exception ignored) {
+            // Expected — INSERT fails
+        }
+
+        // Temp file MUST be deleted even on failure (finally block)
+        assertThat(tempZip).doesNotExist();
+    }
+
+    @Test
+    void execute_idempotent_deleteAndReinsert() throws Exception {
+        // Pre-seed a row for event 77
+        jdbc.update(
+                "INSERT INTO generated_bundles"
+                        + " (event_id, storage_type, storage_path, checksum_sha256,"
+                        + "  file_size_bytes, ticket_count, status)"
+                        + " VALUES (77, 'LOCAL', '/old/path.zip', ?, 100, 2, 'COMPLETED')",
+                "a".repeat(64));
+
+        Path tempZip = Files.createTempFile(tempDir, "idempotent-", ".zip");
+        Files.write(tempZip, new byte[]{0x50, 0x4B, 0x05, 0x06});
+
+        BundleParamsHolder holder = new BundleParamsHolder();
+        holder.setEventId("77");
+        holder.setOutputDir(tempDir.toString());
+
+        BundlePersistTasklet tasklet = new BundlePersistTasklet(holder, jdbc);
+
+        ChunkContext ctx = buildChunkContext(77L, tempDir.toString(), tempZip.toString(), 5);
+        tasklet.execute(null, ctx);
+
+        // Still exactly one row after re-run
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = 77", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        // ticket_count updated to new value
+        Integer newCount = jdbc.queryForObject(
+                "SELECT ticket_count FROM generated_bundles WHERE event_id = 77", Integer.class);
+        assertThat(newCount).isEqualTo(5);
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListenerTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/BundleStepListenerTest.java
@@ -1,0 +1,125 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+
+/**
+ * Unit tests for {@link BundleStepListener#afterStep}, covering the ZIP close-failure
+ * path (FIX #4): when accumulator.close() throws, afterStep must return ExitStatus.FAILED
+ * and must NOT write CTX_TEMP_PATH to the job ExecutionContext.
+ */
+class BundleStepListenerTest {
+
+    @TempDir
+    Path tempDir;
+
+    /**
+     * Test double: a ZipAccumulator whose close() always throws IOException.
+     * Extends ZipAccumulator directly because no methods are final.
+     */
+    private static class ThrowingZipAccumulator extends ZipAccumulator {
+        private final Path stubbedZipPath;
+
+        ThrowingZipAccumulator(Path stubbedZipPath) {
+            this.stubbedZipPath = stubbedZipPath;
+        }
+
+        @Override
+        public void close() throws IOException {
+            throw new IOException("simulated ZIP finalization failure");
+        }
+
+        @Override
+        public Path zipPath() {
+            return stubbedZipPath;
+        }
+
+        @Override
+        public boolean isOpened() {
+            return true;
+        }
+
+        @Override
+        public int ticketCount() {
+            return 3;
+        }
+    }
+
+    private StepExecution buildStepExecution() {
+        JobParameters params = new JobParametersBuilder()
+                .addString("EVENT_ID", "42")
+                .addString("OUTPUT_DIR", tempDir.toString())
+                .toJobParameters();
+        JobInstance instance = new JobInstance(1L, "ticket-bundle-job");
+        JobExecution jobExecution = new JobExecution(1L, instance, params);
+        return new StepExecution("ticketBundleZipStep", jobExecution);
+    }
+
+    @Test
+    void afterStep_closeFailure_returnsFailed_andDoesNotWriteTempPath() throws Exception {
+        // Create a real file on disk so the best-effort delete in afterStep can run without NPE.
+        Path fakeZip = tempDir.resolve("fake-bundle.zip");
+        Files.writeString(fakeZip, "fake zip content");
+
+        ThrowingZipAccumulator throwingAccumulator = new ThrowingZipAccumulator(fakeZip);
+
+        // BundleStepListener wires the accumulator; reader and writer can be null here
+        // because beforeStep is not called — we exercise afterStep only.
+        BundleParamsHolder holder = new BundleParamsHolder();
+        BundleStepListener listener = new BundleStepListener(holder, null, throwingAccumulator, null);
+
+        StepExecution stepExecution = buildStepExecution();
+        ExitStatus result = listener.afterStep(stepExecution);
+
+        // Must report FAILED so Spring Batch does not proceed to step 2.
+        assertThat(result.getExitCode()).isEqualTo("FAILED");
+        assertThat(result.getExitDescription()).contains("ZIP finalization failure");
+
+        // CTX_TEMP_PATH must NOT have been written — step 2 must not pick up a corrupt bundle.
+        ExecutionContext jobCtx = stepExecution.getJobExecution().getExecutionContext();
+        assertThat(jobCtx.containsKey(BundleStepListener.CTX_TEMP_PATH)).isFalse();
+
+        // The orphaned temp file should have been deleted by the best-effort cleanup.
+        assertThat(fakeZip).doesNotExist();
+    }
+
+    @Test
+    void afterStep_successPath_writesBothHandoffKeys() throws Exception {
+        // Use a real accumulator that is already in "opened with 2 entries" state via reset+open.
+        ZipAccumulator accumulator = new ZipAccumulator();
+        Path sourceFile = tempDir.resolve("entry.pdf");
+        Files.writeString(sourceFile, "%PDF-test", StandardCharsets.UTF_8);
+        accumulator.lazyOpen(42L);
+        accumulator.addEntry("42-entry.pdf", sourceFile);
+        // Do NOT close yet — the listener's afterStep will close it.
+
+        BundleParamsHolder holder = new BundleParamsHolder();
+        BundleStepListener listener = new BundleStepListener(holder, null, accumulator, null);
+
+        StepExecution stepExecution = buildStepExecution();
+        // Default exit status for a step that completes without errors
+        stepExecution.setExitStatus(ExitStatus.COMPLETED);
+
+        ExitStatus result = listener.afterStep(stepExecution);
+
+        assertThat(result).isEqualTo(ExitStatus.COMPLETED);
+
+        ExecutionContext jobCtx = stepExecution.getJobExecution().getExecutionContext();
+        assertThat(jobCtx.containsKey(BundleStepListener.CTX_TEMP_PATH)).isTrue();
+        assertThat(jobCtx.getInt(BundleStepListener.CTX_TICKET_COUNT, -1)).isEqualTo(1);
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRowMapperTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/GeneratedFileRowMapperTest.java
@@ -1,0 +1,64 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link GeneratedFileRowMapper}.
+ *
+ * <p>Uses an in-memory H2 database and a real {@link java.sql.ResultSet} to avoid needing
+ * Mockito (not a dependency of this module).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GeneratedFileRowMapperTest {
+
+    private JdbcTemplate jdbc;
+    private final GeneratedFileRowMapper mapper = new GeneratedFileRowMapper();
+
+    @BeforeAll
+    void setUp() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:mapper-test-" + System.nanoTime() + ";DB_CLOSE_DELAY=-1");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE generated_files_mapper_test ("
+                        + " id BIGINT PRIMARY KEY,"
+                        + " ticket_id BIGINT NOT NULL,"
+                        + " storage_path VARCHAR(1024) NOT NULL"
+                        + ")");
+        jdbc.execute("INSERT INTO generated_files_mapper_test VALUES (42, 7, '/data/tickets/7.pdf')");
+        jdbc.execute("INSERT INTO generated_files_mapper_test VALUES (1, 2, '/tmp/bundle-test.pdf')");
+    }
+
+    @Test
+    void mapRow_mapsAllFieldsCorrectly() {
+        GeneratedFileRow row = jdbc.queryForObject(
+                "SELECT id, ticket_id, storage_path FROM generated_files_mapper_test WHERE id = 42",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.id()).isEqualTo(42L);
+        assertThat(row.ticketId()).isEqualTo(7L);
+        assertThat(row.storagePath()).isEqualTo("/data/tickets/7.pdf");
+    }
+
+    @Test
+    void mapRow_mapsStoragePath_fromStoragePathColumn() {
+        GeneratedFileRow row = jdbc.queryForObject(
+                "SELECT id, ticket_id, storage_path FROM generated_files_mapper_test WHERE id = 1",
+                mapper);
+
+        assertThat(row).isNotNull();
+        // Confirm the storage_path column (not zip_path or any other alias) is mapped
+        assertThat(row.storagePath()).isEqualTo("/tmp/bundle-test.pdf");
+        assertThat(row.ticketId()).isEqualTo(2L);
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/TicketBundleJobIntegrationTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/TicketBundleJobIntegrationTest.java
@@ -1,0 +1,360 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * End-to-end integration test for {@link TicketBundleJobPlugin}.
+ *
+ * <p>Uses an isolated in-module H2 database. No shared state with the fr-batch-service
+ * test suite. The test bootstraps a minimal Spring Batch JobRepository on H2, constructs
+ * the plugin, and wires it with a stub ApplicationContext.
+ *
+ * <p>CRITICAL: source PDFs are read from their absolute {@code storage_path}, so this test
+ * creates REAL temp files under {@code @TempDir} and seeds {@code generated_files.storage_path}
+ * with those absolute paths.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class TicketBundleJobIntegrationTest {
+
+    private static final byte[] PDF_MAGIC = {0x25, 0x50, 0x44, 0x46}; // %PDF
+
+    @TempDir
+    Path outputDir;
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private ApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:ticket-bundle-it-" + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Apply Spring Batch H2 schema
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Create application tables
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS event_tickets ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " event_id BIGINT NOT NULL,"
+                        + " ticket_code VARCHAR(64) NOT NULL,"
+                        + " holder_name VARCHAR(255) NOT NULL,"
+                        + " event_name VARCHAR(255) NOT NULL,"
+                        + " event_location VARCHAR(255) NULL,"
+                        + " seat VARCHAR(64) NULL,"
+                        + " event_datetime TIMESTAMP NOT NULL,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_event_tickets_ticket_code UNIQUE (ticket_code)"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS generated_files ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " ticket_id BIGINT NOT NULL,"
+                        + " storage_type VARCHAR(16) NOT NULL DEFAULT 'LOCAL',"
+                        + " storage_path VARCHAR(1024) NOT NULL,"
+                        + " checksum_sha256 CHAR(64) NOT NULL,"
+                        + " file_size_bytes BIGINT NOT NULL,"
+                        + " generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT fk_generated_files_ticket"
+                        + "     FOREIGN KEY (ticket_id) REFERENCES event_tickets (id),"
+                        + " CONSTRAINT uk_generated_files_ticket UNIQUE (ticket_id)"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS generated_bundles ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " event_id BIGINT NOT NULL,"
+                        + " storage_type VARCHAR(16) NOT NULL DEFAULT 'LOCAL',"
+                        + " storage_path VARCHAR(1024) NOT NULL,"
+                        + " checksum_sha256 CHAR(64) NOT NULL,"
+                        + " file_size_bytes BIGINT NOT NULL,"
+                        + " ticket_count INT NOT NULL,"
+                        + " status VARCHAR(20) NOT NULL DEFAULT 'COMPLETED',"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_generated_bundles_event UNIQUE (event_id)"
+                        + ")");
+
+        // Bootstrap Spring Batch JobRepository
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub ApplicationContext exposes only the DataSource
+        StaticApplicationContext ctx = new StaticApplicationContext();
+        ctx.getBeanFactory().registerSingleton("dataSource", ds);
+        ctx.refresh();
+        this.stubContext = ctx;
+    }
+
+    @BeforeEach
+    void cleanTables() {
+        jdbc.execute("DELETE FROM generated_bundles");
+        jdbc.execute("DELETE FROM generated_files");
+        jdbc.execute("DELETE FROM event_tickets");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────────────────
+
+    private long insertTicket(String ticketCode, long eventId) {
+        jdbc.update(
+                "INSERT INTO event_tickets"
+                        + " (event_id, ticket_code, holder_name, event_name,"
+                        + "  event_location, seat, event_datetime, processed)"
+                        + " VALUES (?, ?, ?, ?, ?, ?, ?, FALSE)",
+                eventId, ticketCode, "Test Holder", "Test Event",
+                "Test Venue", "A1",
+                Timestamp.valueOf(LocalDateTime.of(2024, 6, 15, 18, 0)));
+        return jdbc.queryForObject(
+                "SELECT id FROM event_tickets WHERE ticket_code = ?", Long.class, ticketCode);
+    }
+
+    private Path createSourcePdf(String filename) throws Exception {
+        Path file = outputDir.resolve(filename);
+        byte[] content = ("%PDF-test-content-" + filename)
+                .getBytes(StandardCharsets.UTF_8);
+        Files.write(file, content);
+        return file;
+    }
+
+    private long insertGeneratedFile(long ticketId, Path sourcePath) {
+        byte[] content;
+        try {
+            content = Files.readAllBytes(sourcePath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        String checksum = "a".repeat(64); // placeholder — not validated in IT assertions
+        jdbc.update(
+                "INSERT INTO generated_files"
+                        + " (ticket_id, storage_type, storage_path, checksum_sha256, file_size_bytes)"
+                        + " VALUES (?, 'LOCAL', ?, ?, ?)",
+                ticketId, sourcePath.toAbsolutePath().toString(), checksum, content.length);
+        return jdbc.queryForObject(
+                "SELECT id FROM generated_files WHERE ticket_id = ?", Long.class, ticketId);
+    }
+
+    private BatchStatus runJob(long eventId) throws Exception {
+        TicketBundleJobPlugin plugin = new TicketBundleJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("DATE", "2024-06-15")
+                .addString("OUTPUT_DIR", outputDir.toAbsolutePath().toString())
+                .addString("EVENT_ID", String.valueOf(eventId))
+                .addLong("run.id", System.nanoTime())
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        return execution.getStatus();
+    }
+
+    // ── Scenarios ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void happyPath_bundlesAllPdfsForEvent() throws Exception {
+        long eventId = 10L;
+        long t1 = insertTicket("BUNDLE-001", eventId);
+        long t2 = insertTicket("BUNDLE-002", eventId);
+        long t3 = insertTicket("BUNDLE-003", eventId);
+
+        Path pdf1 = createSourcePdf("ticket-" + t1 + ".pdf");
+        Path pdf2 = createSourcePdf("ticket-" + t2 + ".pdf");
+        Path pdf3 = createSourcePdf("ticket-" + t3 + ".pdf");
+
+        insertGeneratedFile(t1, pdf1);
+        insertGeneratedFile(t2, pdf2);
+        insertGeneratedFile(t3, pdf3);
+
+        BatchStatus status = runJob(eventId);
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // ZIP file exists at deterministic path
+        Path bundleZip = outputDir.resolve("bundles/event-" + eventId + ".zip");
+        assertThat(bundleZip).exists();
+
+        // ZIP contains exactly 3 entries
+        List<String> entryNames = extractEntryNames(bundleZip);
+        assertThat(entryNames).hasSize(3);
+
+        // DB row exists with correct fields
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT * FROM generated_bundles WHERE event_id = ?", eventId);
+        assertThat(rows).hasSize(1);
+
+        Map<String, Object> row = rows.get(0);
+        assertThat(row.get("ticket_count")).isEqualTo(3);
+        assertThat(row.get("status")).isEqualTo("COMPLETED");
+        assertThat((String) row.get("storage_path")).isNotBlank();
+        assertThat((String) row.get("checksum_sha256")).hasSize(64);
+        assertThat((Long) row.get("file_size_bytes")).isGreaterThan(0L);
+    }
+
+    @Test
+    void eventScope_onlyBundlesMatchingEvent() throws Exception {
+        // Seed 2 tickets for event 20, 2 for event 21
+        long t20a = insertTicket("EVT20-001", 20L);
+        long t20b = insertTicket("EVT20-002", 20L);
+        long t21a = insertTicket("EVT21-001", 21L);
+        long t21b = insertTicket("EVT21-002", 21L);
+
+        insertGeneratedFile(t20a, createSourcePdf("20a.pdf"));
+        insertGeneratedFile(t20b, createSourcePdf("20b.pdf"));
+        insertGeneratedFile(t21a, createSourcePdf("21a.pdf"));
+        insertGeneratedFile(t21b, createSourcePdf("21b.pdf"));
+
+        BatchStatus status = runJob(20L);
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        Path bundleZip = outputDir.resolve("bundles/event-20.zip");
+        assertThat(bundleZip).exists();
+
+        List<String> entries = extractEntryNames(bundleZip);
+        assertThat(entries).hasSize(2);
+        // No event-21 entries
+        assertThat(entries).noneMatch(n -> n.contains("21a") || n.contains("21b"));
+
+        // No row for event 21
+        Integer count21 = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = 21", Integer.class);
+        assertThat(count21).isZero();
+    }
+
+    @Test
+    void emptyEvent_completesNoOp() throws Exception {
+        // No rows for event 999
+        BatchStatus status = runJob(999L);
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // ZIP file must NOT exist
+        Path bundleZip = outputDir.resolve("bundles/event-999.zip");
+        assertThat(bundleZip).doesNotExist();
+
+        // No DB row
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = 999", Integer.class);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void missingSourceFile_failsFast() throws Exception {
+        long eventId = 888L;
+        long ticket = insertTicket("MISSING-001", eventId);
+
+        // generated_files row points to a non-existent path
+        Path nonExistent = outputDir.resolve("does-not-exist-" + System.nanoTime() + ".pdf");
+        jdbc.update(
+                "INSERT INTO generated_files"
+                        + " (ticket_id, storage_type, storage_path, checksum_sha256, file_size_bytes)"
+                        + " VALUES (?, 'LOCAL', ?, ?, ?)",
+                ticket, nonExistent.toAbsolutePath().toString(), "a".repeat(64), 0L);
+
+        BatchStatus status = runJob(eventId);
+        assertThat(status).isEqualTo(BatchStatus.FAILED);
+
+        // No bundle row inserted
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = ?", Integer.class, eventId);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void reRun_idempotent() throws Exception {
+        long eventId = 10L;
+        long t1 = insertTicket("IDEM-001", eventId);
+        long t2 = insertTicket("IDEM-002", eventId);
+
+        Path pdf1 = createSourcePdf("idem1.pdf");
+        Path pdf2 = createSourcePdf("idem2.pdf");
+        insertGeneratedFile(t1, pdf1);
+        insertGeneratedFile(t2, pdf2);
+
+        // First run
+        BatchStatus status1 = runJob(eventId);
+        assertThat(status1).isEqualTo(BatchStatus.COMPLETED);
+
+        // Second run (same event, new run.id)
+        BatchStatus status2 = runJob(eventId);
+        assertThat(status2).isEqualTo(BatchStatus.COMPLETED);
+
+        // Still exactly one row after second run
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM generated_bundles WHERE event_id = ?", Integer.class, eventId);
+        assertThat(count).isEqualTo(1);
+
+        // ZIP exists
+        Path bundleZip = outputDir.resolve("bundles/event-" + eventId + ".zip");
+        assertThat(bundleZip).exists();
+        assertThat(extractEntryNames(bundleZip)).hasSize(2);
+    }
+
+    // ── Utilities ────────────────────────────────────────────────────────────────────────────
+
+    private List<String> extractEntryNames(Path zipFile) throws Exception {
+        List<String> names = new ArrayList<>();
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(zipFile.toFile()))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                names.add(entry.getName());
+                zis.closeEntry();
+            }
+        }
+        return names;
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulatorTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/ZipAccumulatorTest.java
@@ -1,0 +1,72 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for {@link ZipAccumulator}, covering the reset/reuse lifecycle (FIX #6).
+ */
+class ZipAccumulatorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void reset_afterOpenAddClose_clearsAllState() throws Exception {
+        ZipAccumulator accumulator = new ZipAccumulator();
+
+        // Simulate a first execution: open, add an entry, close.
+        Path sourceFile = tempDir.resolve("ticket.pdf");
+        Files.writeString(sourceFile, "%PDF-content");
+
+        accumulator.lazyOpen(1L);
+        accumulator.addEntry("1-ticket.pdf", sourceFile);
+        Path firstPath = accumulator.zipPath();
+        accumulator.close();
+
+        assertThat(accumulator.isOpened()).isTrue();
+        assertThat(accumulator.ticketCount()).isEqualTo(1);
+        assertThat(firstPath).isNotNull();
+
+        // Reset — simulates what BundleStepListener.beforeStep() does before each new execution.
+        accumulator.reset();
+
+        assertThat(accumulator.isOpened()).isFalse();
+        assertThat(accumulator.ticketCount()).isEqualTo(0);
+        assertThat(accumulator.zipPath()).isNull();
+    }
+
+    @Test
+    void reset_thenLazyOpen_opensNewTempFile() throws Exception {
+        ZipAccumulator accumulator = new ZipAccumulator();
+
+        // First execution
+        Path sourceFile = tempDir.resolve("first.pdf");
+        Files.writeString(sourceFile, "%PDF-1");
+        accumulator.lazyOpen(10L);
+        accumulator.addEntry("1-first.pdf", sourceFile);
+        Path firstPath = accumulator.zipPath();
+        accumulator.close();
+
+        // Reset and simulate a second execution
+        accumulator.reset();
+
+        Path sourceFile2 = tempDir.resolve("second.pdf");
+        Files.writeString(sourceFile2, "%PDF-2");
+        accumulator.lazyOpen(20L);
+        accumulator.addEntry("1-second.pdf", sourceFile2);
+        Path secondPath = accumulator.zipPath();
+        accumulator.close();
+
+        // The second run opened a distinct temp file — not the closed one from run 1.
+        assertThat(secondPath).isNotNull();
+        assertThat(secondPath).isNotEqualTo(firstPath);
+        assertThat(accumulator.ticketCount()).isEqualTo(1);
+        assertThat(accumulator.isOpened()).isTrue();
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/ZipBundleItemWriterTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/batch/ZipBundleItemWriterTest.java
@@ -1,0 +1,152 @@
+package com.fronzec.plugins.ticketbundle.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.batch.infrastructure.item.Chunk;
+
+/**
+ * Unit tests for {@link ZipBundleItemWriter}.
+ *
+ * <p>Uses real temp files on disk (no mocks) and a real {@link ZipAccumulator}.
+ */
+class ZipBundleItemWriterTest {
+
+    @TempDir Path tempDir;
+
+    private static final long EVENT_ID = 99L;
+
+    private Path createSourceFile(String name, String content) throws Exception {
+        Path file = tempDir.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+
+    @Test
+    void write_zipsAllItems_correctEntries() throws Exception {
+        // Create 3 real source PDF-like files on disk
+        Path file1 = createSourceFile("ticket1.pdf", "%PDF-content-1");
+        Path file2 = createSourceFile("ticket2.pdf", "%PDF-content-2");
+        Path file3 = createSourceFile("ticket3.pdf", "%PDF-content-3");
+
+        ZipAccumulator accumulator = new ZipAccumulator();
+        ZipBundleItemWriter writer = new ZipBundleItemWriter(accumulator);
+        writer.setEventId(EVENT_ID);
+
+        List<GeneratedFileRow> items = List.of(
+                new GeneratedFileRow(1L, 10L, file1.toString()),
+                new GeneratedFileRow(2L, 20L, file2.toString()),
+                new GeneratedFileRow(3L, 30L, file3.toString()));
+
+        writer.write(new Chunk<>(items));
+        accumulator.close();
+
+        assertThat(accumulator.ticketCount()).isEqualTo(3);
+        assertThat(accumulator.zipPath()).isNotNull();
+
+        // Open the produced zip and verify entries
+        List<String> entryNames;
+        try (ZipInputStream zis = new ZipInputStream(
+                new FileInputStream(accumulator.zipPath().toFile()))) {
+            entryNames = new java.util.ArrayList<>();
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                entryNames.add(entry.getName());
+                zis.closeEntry();
+            }
+        }
+
+        assertThat(entryNames).containsExactlyInAnyOrder(
+                "10-ticket1.pdf",
+                "20-ticket2.pdf",
+                "30-ticket3.pdf");
+    }
+
+    @Test
+    void write_missingSourceFile_throwsIllegalStateException() throws Exception {
+        Path nonExistent = tempDir.resolve("ghost.pdf");
+
+        ZipAccumulator accumulator = new ZipAccumulator();
+        ZipBundleItemWriter writer = new ZipBundleItemWriter(accumulator);
+        writer.setEventId(EVENT_ID);
+
+        List<GeneratedFileRow> items = List.of(
+                new GeneratedFileRow(5L, 55L, nonExistent.toString()));
+
+        assertThatThrownBy(() -> writer.write(new Chunk<>(items)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("source PDF missing")
+                .hasMessageContaining("55"); // ticketId in message
+    }
+
+    @Test
+    void write_alwaysPrefixesTicketId_inEntryName() throws Exception {
+        // Two source files with the SAME filename — entry names must be distinct via ticketId prefix
+        Path file1 = createSourceFile("same-name.pdf", "%PDF-A");
+        Path file2 = tempDir.resolve("subdir");
+        Files.createDirectories(file2);
+        Path file2Path = file2.resolve("same-name.pdf");
+        Files.writeString(file2Path, "%PDF-B");
+
+        ZipAccumulator accumulator = new ZipAccumulator();
+        ZipBundleItemWriter writer = new ZipBundleItemWriter(accumulator);
+        writer.setEventId(EVENT_ID);
+
+        List<GeneratedFileRow> items = List.of(
+                new GeneratedFileRow(1L, 100L, file1.toString()),
+                new GeneratedFileRow(2L, 200L, file2Path.toString()));
+
+        writer.write(new Chunk<>(items));
+        accumulator.close();
+
+        List<String> entryNames;
+        try (ZipInputStream zis = new ZipInputStream(
+                new FileInputStream(accumulator.zipPath().toFile()))) {
+            entryNames = new java.util.ArrayList<>();
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                entryNames.add(entry.getName());
+                zis.closeEntry();
+            }
+        }
+
+        // Both entries present, each with a distinct ticketId prefix
+        assertThat(entryNames).containsExactlyInAnyOrder(
+                "100-same-name.pdf",
+                "200-same-name.pdf");
+    }
+
+    @Test
+    void write_preservesSourceFileContent_inZipEntry() throws Exception {
+        byte[] originalContent = "%PDF-hello-world".getBytes(StandardCharsets.UTF_8);
+        Path sourceFile = tempDir.resolve("content-check.pdf");
+        Files.write(sourceFile, originalContent);
+
+        ZipAccumulator accumulator = new ZipAccumulator();
+        ZipBundleItemWriter writer = new ZipBundleItemWriter(accumulator);
+        writer.setEventId(EVENT_ID);
+
+        writer.write(new Chunk<>(List.of(new GeneratedFileRow(1L, 77L, sourceFile.toString()))));
+        accumulator.close();
+
+        // Extract the entry bytes and compare
+        byte[] entryBytes;
+        try (ZipInputStream zis = new ZipInputStream(
+                new FileInputStream(accumulator.zipPath().toFile()))) {
+            ZipEntry entry = zis.getNextEntry();
+            assertThat(entry).isNotNull();
+            entryBytes = zis.readAllBytes();
+        }
+
+        assertThat(entryBytes).isEqualTo(originalContent);
+    }
+}

--- a/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/storage/LocalFileStorageTest.java
+++ b/ticket-bundle-job/src/test/java/com/fronzec/plugins/ticketbundle/storage/LocalFileStorageTest.java
@@ -1,0 +1,111 @@
+package com.fronzec.plugins.ticketbundle.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LocalFileStorageTest {
+
+    @TempDir Path tempDir;
+
+    private String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(bytes);
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void write_returnsStoredFile_withLocalTypeAndChecksum() throws IOException {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = "hello bundle zip".getBytes(StandardCharsets.UTF_8);
+        String key = "bundle-test.zip";
+
+        StoredFile result = storage.write(key, content);
+
+        Path expectedPath = tempDir.resolve(key);
+        assertThat(expectedPath).exists();
+        assertThat(Files.readAllBytes(expectedPath)).isEqualTo(content);
+
+        // storageType must be LOCAL
+        assertThat(result.storageType()).isEqualTo("LOCAL");
+
+        // path must end with the key filename
+        assertThat(result.path()).endsWith(key);
+
+        // checksum must be a valid 64-char hex string matching the content
+        assertThat(result.checksum()).hasSize(64);
+        assertThat(result.checksum()).isEqualTo(sha256Hex(content));
+
+        // sizeBytes must match content length
+        assertThat(result.sizeBytes()).isEqualTo(content.length);
+    }
+
+    @Test
+    void write_createsSubdirectory() throws IOException {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = "sub dir content".getBytes(StandardCharsets.UTF_8);
+
+        StoredFile result = storage.write("sub/file.zip", content);
+
+        assertThat(Path.of(result.path())).exists();
+        assertThat(Files.readAllBytes(Path.of(result.path()))).isEqualTo(content);
+    }
+
+    @Test
+    void resolveSafePath_rejectsTraversal() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        assertThatThrownBy(
+                () -> storage.write("../escape.zip", "x".getBytes(StandardCharsets.UTF_8)))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("path traversal");
+    }
+
+    @Test
+    void delete_removesFile() throws IOException {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+        byte[] content = "to be deleted".getBytes(StandardCharsets.UTF_8);
+        storage.write("remove-me.zip", content);
+
+        Path filePath = tempDir.resolve("remove-me.zip");
+        assertThat(filePath).exists();
+
+        storage.delete("remove-me.zip");
+
+        assertThat(filePath).doesNotExist();
+    }
+
+    @Test
+    void delete_onNonExistentKey_doesNotThrow() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        assertThatCode(() -> storage.delete("ghost.zip")).doesNotThrowAnyException();
+    }
+
+    @Test
+    void write_rejectsAbsoluteKey() {
+        LocalFileStorage storage = new LocalFileStorage(tempDir);
+
+        // An absolute key that starts outside baseDir must be rejected
+        assertThatThrownBy(
+                () -> storage.write("/etc/passwd", "x".getBytes(StandardCharsets.UTF_8)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## What

New external dynamic plugin **`ticket-bundle-job`** (`com.fronzec.plugins:ticket-bundle-job`) — a multi-step Spring Batch job that, for a given `EVENT_ID`, zips all already-generated ticket PDFs into a single bundle, uploads it via the inline `FileStorage` seam, and records it in a new `generated_bundles` table.

This is idea #2 of the Spring Batch practice series. It exercises **chunk-vs-tasklet steps**, **multi-step jobs**, and **state handoff via the Job `ExecutionContext`** — concepts not covered by the earlier `ticket-pdf-job`. It proves again that the **v1 `BatchJobPlugin` API suffices with zero API changes**.

## How

Two-step job wired entirely inside `configureJob` (no `@Bean`/`@StepScope`, plugin instantiated via `newInstance()`):

- **Step 1 (chunk)** — `JdbcCursorItemReader` over `generated_files gf JOIN event_tickets et ON gf.ticket_id = et.id WHERE et.event_id = ?`. The writer reads each PDF from its absolute `storage_path` and streams it into a `ZipOutputStream` over a **temp file** (safe for large events). Entry names are prefixed `<ticketId>-<filename>` to avoid collisions. The temp zip path + ticket count are handed to Step 2 via the Job `ExecutionContext`.
- **Step 2 (tasklet)** — uploads the temp zip via `FileStorage` to `bundles/event-{EVENT_ID}.zip`, performs a portable `DELETE`+`INSERT` upsert into `generated_bundles` (idempotent per event), and deletes the temp file.

### Schema
- `V6__ticket_bundle_tables.sql` adds `generated_bundles(id, event_id UNIQUE, storage_path, ticket_count, checksum_sha256, status, created_at)`. `checksum_sha256` is sourced from `LocalFileStorage.write()`. Mirrored in the H2 test `schema.sql`.

### Policies
- `EVENT_ID` (positive long) and `OUTPUT_DIR` (non-blank) validated **fail-fast** before steps run.
- Missing source file for an existing row → **fail-fast** (job FAILED, no bundle row).
- Empty event (no rows) → **no-op success** (no bundle row written).
- Re-run for the same event → idempotent (overwrites prior bundle row + zip).

## Tests
- `ticket-bundle-job`: **30 tests** (unit per component + an integration test on isolated in-module H2 with real temp PDF files: happy path, scope isolation, no-op, fail-fast, idempotent re-run).
- `fr-batch-service`: **123 tests** still green (V6 H2 mirror added).

## Notes
- No PDF/QR deps — zip is pure `java.util.zip`. Shaded fat JAR mirrors `ticket-pdf-job`.
- `FileStorage` seam replicated inline, ready to iterate to S3 in a future v2.
- Delivery: single PR (`size:exception`) — ~1k lines, but fully greenfield in a new module with no conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added event ticket PDF bundling functionality that automatically creates ZIP archives per event with deterministic filenames
  * Integrated batch processing job with two-step workflow: PDF assembly into archives and metadata persistence (checksums, file sizes)
  * Supports idempotent re-runs ensuring safe re-execution with automatic overwrite for duplicate events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->