### PR TITLE
feat(fault-tolerant-harvester): fault-tolerance core — skip/retry/backoff/dead-letter (PR 2/3)

### DIFF
--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/FaultTolerantHarvesterJobPlugin.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/FaultTolerantHarvesterJobPlugin.java
@@ -2,15 +2,34 @@ package com.fronzec.plugins.harvester;
 
 import com.fronzec.api.BatchJobPlugin;
 import com.fronzec.api.JobMetadata;
+import com.fronzec.plugins.harvester.batch.AbortJobException;
+import com.fronzec.plugins.harvester.batch.HarvestItemProcessor;
+import com.fronzec.plugins.harvester.batch.HarvestItemWriter;
 import com.fronzec.plugins.harvester.batch.HarvestJobParametersValidator;
+import com.fronzec.plugins.harvester.batch.HarvestParamsHolder;
+import com.fronzec.plugins.harvester.batch.HarvestRetryListener;
+import com.fronzec.plugins.harvester.batch.HarvestRow;
+import com.fronzec.plugins.harvester.batch.HarvestRowMapper;
+import com.fronzec.plugins.harvester.batch.HarvestSkipListener;
+import com.fronzec.plugins.harvester.batch.HarvestStepListener;
+import com.fronzec.plugins.harvester.batch.PoisonItemException;
+import com.fronzec.plugins.harvester.batch.TransientProcessingException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.listener.StepExecutionListener;
 import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
 import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.transaction.PlatformTransactionManager;
 
 /**
@@ -38,9 +57,6 @@ import org.springframework.transaction.PlatformTransactionManager;
  *       the restart demo</li>
  *   <li>{@code skipLimit=5}, {@code retryLimit=3}, {@code chunkSize=5}</li>
  * </ul>
- *
- * <p><strong>PR#1 note:</strong> {@link #configureJob} is a stub in this slice.
- * Full wiring (reader, processor, writer, skip/retry listeners) is implemented in PR#2.
  */
 public class FaultTolerantHarvesterJobPlugin implements BatchJobPlugin {
 
@@ -48,6 +64,27 @@ public class FaultTolerantHarvesterJobPlugin implements BatchJobPlugin {
 
     private static final String JOB_NAME = "fault-tolerant-harvester-job";
     private static final String VERSION = "1.0.0";
+
+    /** Number of items per chunk commit. */
+    static final int CHUNK_SIZE = 5;
+
+    /** Maximum number of skipped items before the step fails. */
+    static final int SKIP_LIMIT = 5;
+
+    /** Maximum retry attempts per item before it is treated as a skip. */
+    static final int RETRY_LIMIT = 3;
+
+    /**
+     * Reader SQL: selects unprocessed rows in id order.
+     * The {@code WHERE processed = FALSE} filter is belt-and-suspenders idempotency;
+     * restart resumption is driven by the saved {@code currentItemCount} in
+     * {@code BATCH_STEP_EXECUTION_CONTEXT} (enabled by {@code setSaveState(true)}).
+     */
+    private static final String READER_SQL =
+            "SELECT id, payload, poison_flag, transient_fail_until_attempt, abort_flag"
+                    + " FROM harvest_source"
+                    + " WHERE processed = FALSE"
+                    + " ORDER BY id";
 
     @Override
     public String getJobName() {
@@ -60,18 +97,29 @@ public class FaultTolerantHarvesterJobPlugin implements BatchJobPlugin {
     }
 
     /**
-     * Configures the fault-tolerant harvester Spring Batch job.
+     * Configures the full fault-tolerant harvester job.
      *
-     * <p><strong>PR#1 STUB:</strong> This method is not yet implemented. Full job wiring
-     * (reader, processor, writer, skip listener, retry listener, step builder) is deferred
-     * to PR#2. At dynamic-load time this stub will cause the load to fail gracefully — the
-     * host marks the definition FAILED and logs the error; it does NOT crash the host context.
+     * <h3>Step wiring</h3>
+     * <p>Single fault-tolerant chunk step {@code harvestStep}:
+     * <ul>
+     *   <li>Reader: {@link JdbcCursorItemReader} with {@code setSaveState(true)} for restart.</li>
+     *   <li>Processor: {@link com.fronzec.plugins.harvester.batch.HarvestItemProcessor}
+     *       — abort / poison / transient R4 threshold logic.</li>
+     *   <li>Writer: {@link com.fronzec.plugins.harvester.batch.HarvestItemWriter}
+     *       — idempotent {@code UPDATE} with {@code AND processed = FALSE}.</li>
+     *   <li>Skip: {@link PoisonItemException} + {@link TransientProcessingException}
+     *       (after retry exhaustion); {@link AbortJobException} is {@code noSkip}.</li>
+     *   <li>Retry: {@link TransientProcessingException} up to {@code retryLimit=3}.</li>
+     *   <li>BackOff: {@link ExponentialBackOffPolicy} (initial=10ms, multiplier=2.0)
+     *       — short intervals so integration tests are fast.</li>
+     *   <li>Listeners: {@link HarvestSkipListener} (dead-letter REQUIRES_NEW) +
+     *       {@link HarvestRetryListener} (pedagogical logging).</li>
+     * </ul>
      *
-     * @param jobRepository       the shared job repository provided by the host
-     * @param transactionManager  the transaction manager provided by the host
-     * @param parentContext       the host's application context
-     * @return never returns; always throws in PR#1
-     * @throws UnsupportedOperationException always, until PR#2 is merged
+     * @param jobRepository      the shared job repository provided by the host
+     * @param transactionManager the transaction manager provided by the host
+     * @param parentContext      the host's application context (used to obtain DataSource)
+     * @return the configured {@link Job}
      */
     @Override
     public Job configureJob(
@@ -79,14 +127,83 @@ public class FaultTolerantHarvesterJobPlugin implements BatchJobPlugin {
             PlatformTransactionManager transactionManager,
             ApplicationContext parentContext) {
 
-        // STUB — implemented in PR#2.
-        // Throws here so this PR#1 JAR is never accidentally registered as a runnable job
-        // without the full fault-tolerance wiring (reader, processor, writer, listeners).
-        // The host DynamicJobLoaderService catches RuntimeExceptions from configureJob and
-        // marks the definition FAILED, without crashing the host application context.
-        throw new UnsupportedOperationException(
-                "FaultTolerantHarvesterJobPlugin.configureJob() is not implemented yet "
-                        + "(PR#1 scaffold only — full wiring in PR#2)");
+        log.info("Configuring fault-tolerant-harvester-job plugin v{}", VERSION);
+
+        DataSource dataSource = parentContext.getBean(DataSource.class);
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        // ── Shared objects ────────────────────────────────────────────────────────────────────
+        HarvestParamsHolder holder = new HarvestParamsHolder();
+        HarvestItemProcessor processor = new HarvestItemProcessor();
+        HarvestItemWriter writer = new HarvestItemWriter(jdbc);
+
+        // ── Reader ────────────────────────────────────────────────────────────────────────────
+        JdbcCursorItemReader<HarvestRow> reader =
+                new JdbcCursorItemReader<>(dataSource, READER_SQL, new HarvestRowMapper());
+        reader.setName("harvestSourceReader");
+        // setSaveState(true) persists currentItemCount to BATCH_STEP_EXECUTION_CONTEXT on each
+        // chunk commit so the reader can fast-forward past already-committed rows on restart.
+        reader.setSaveState(true);
+
+        // ── Skip listener (dead-letter, REQUIRES_NEW) ─────────────────────────────────────────
+        HarvestSkipListener skipListener = new HarvestSkipListener(jdbc, transactionManager);
+
+        // ── Retry listener (pedagogical logging) ──────────────────────────────────────────────
+        HarvestRetryListener retryListener = new HarvestRetryListener();
+
+        // ── Step listeners ────────────────────────────────────────────────────────────────────
+        // Primary: populates HarvestParamsHolder and resets processor counters.
+        HarvestStepListener stepListener = new HarvestStepListener(holder, processor);
+
+        // Secondary: captures jobExecutionId from the step execution and passes it to the
+        // skip listener so dead-letter rows record the correct job_execution_id.
+        StepExecutionListener jobIdCapture = new StepExecutionListener() {
+            @Override
+            public void beforeStep(StepExecution stepExecution) {
+                long jobExecutionId = stepExecution.getJobExecution().getId();
+                skipListener.setJobExecutionId(jobExecutionId);
+                log.debug("Captured jobExecutionId={} for skip listener", jobExecutionId);
+            }
+        };
+
+        // ── Backoff policy ────────────────────────────────────────────────────────────────────
+        // Short initial interval (10ms) so integration tests run quickly while still
+        // demonstrating the exponential pattern.
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(10L);
+        backOffPolicy.setMultiplier(2.0);
+        backOffPolicy.setMaxInterval(100L);
+
+        // ── Fault-tolerant chunk step ─────────────────────────────────────────────────────────
+        // StepExecutionListeners (stepListener, jobIdCapture) are registered via the generic
+        // listener(Object) overload on SimpleStepBuilder/AbstractTaskletStepBuilder BEFORE
+        // .faultTolerant() is called.  SkipListener and RetryListener are registered on the
+        // FaultTolerantStepBuilder returned by .faultTolerant() using their typed overloads.
+        var stepWithListeners = new StepBuilder("harvestStep", jobRepository)
+                .<HarvestRow, HarvestRow>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .listener((Object) stepListener)
+                .listener((Object) jobIdCapture)
+                .faultTolerant()
+                    .skipLimit(SKIP_LIMIT)
+                    .skip(PoisonItemException.class)
+                    .skip(TransientProcessingException.class)
+                    .noSkip(AbortJobException.class)
+                    .retryLimit(RETRY_LIMIT)
+                    .retry(TransientProcessingException.class)
+                    .noRetry(PoisonItemException.class)
+                    .backOffPolicy(backOffPolicy)
+                    .listener(skipListener)
+                    .listener(retryListener)
+                .build();
+
+        // ── Job ───────────────────────────────────────────────────────────────────────────────
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .validator(new HarvestJobParametersValidator())
+                .start(stepWithListeners)
+                .build();
     }
 
     /**

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/AbortJobException.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/AbortJobException.java
@@ -1,0 +1,26 @@
+package com.fronzec.plugins.harvester.batch;
+
+/**
+ * Thrown by {@link HarvestItemProcessor} when a {@link HarvestRow} has {@code abort_flag=TRUE}.
+ *
+ * <p>This exception is <em>neither skippable nor retryable</em>. The step is configured with:
+ * <pre>{@code
+ *   .noSkip(AbortJobException.class)
+ * }</pre>
+ *
+ * <p>When thrown, the step immediately fails and the job reaches {@code BatchStatus.FAILED}.
+ * This is the trigger for the restart demo (PR#3): the source row's {@code abort_flag} is
+ * cleared between launches, and the job re-runs with identical identifying parameters so
+ * Spring Batch finds the prior FAILED execution and resumes from the last committed chunk offset.
+ */
+public class AbortJobException extends RuntimeException {
+
+    /**
+     * Constructs a new exception for the given source row id.
+     *
+     * @param sourceId the {@code harvest_source.id} of the abort row
+     */
+    public AbortJobException(long sourceId) {
+        super("Abort triggered by harvest_source.id=" + sourceId + " (abort_flag=TRUE)");
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestItemProcessor.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestItemProcessor.java
@@ -1,0 +1,135 @@
+package com.fronzec.plugins.harvester.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+/**
+ * Processes each {@link HarvestRow} according to its flag columns.
+ *
+ * <h3>Processing order</h3>
+ * <ol>
+ *   <li>{@code abort_flag=TRUE} → throw {@link AbortJobException} (non-skippable, non-retryable).</li>
+ *   <li>{@code poison_flag=TRUE} → throw {@link PoisonItemException} (skippable, not retryable).</li>
+ *   <li>{@code transient_fail_until_attempt > 0} → R4 fixed-threshold retry logic (see below).</li>
+ *   <li>Otherwise → return the item unchanged (happy path).</li>
+ * </ol>
+ *
+ * <h3>R4 fixed-threshold retry mechanism</h3>
+ * <p>{@code transient_fail_until_attempt} is a read-only column that holds the number of
+ * attempts required before the item succeeds. The source row is NEVER mutated.
+ *
+ * <p>The processor attempts to read the current retry count from
+ * {@link RetrySynchronizationManager#getContext()} (spring-retry thread-local, populated
+ * when the processor runs inside a fault-tolerant chunk step). If the context is available,
+ * it uses {@link org.springframework.retry.RetryContext#getRetryCount()} directly
+ * ({@code 0} on first attempt, {@code 1} on first retry, etc.).
+ *
+ * <p><strong>Fallback (in-memory counter):</strong> If {@code RetrySynchronizationManager}
+ * returns {@code null} (observed in some Spring Batch 6 configurations where the retry context
+ * is not propagated into the item processor thread), the processor falls back to a per-id
+ * {@code Map<Long, Integer>} that is incremented on each call and reset by
+ * {@link #resetAttemptCounters()} (called from {@link HarvestStepListener#beforeStep}).
+ * The in-memory counter has identical semantics: 0 on first call, 1 on first retry, etc.
+ *
+ * <p><em>Which approach was active is logged at DEBUG on each invocation and reported in
+ * the apply-progress artifact.</em>
+ *
+ * <h3>Source row immutability</h3>
+ * <p>The processor never writes to {@code harvest_source}. A chunk rollback cannot corrupt
+ * the retry threshold because the threshold lives on the source row and is read-only.
+ */
+public class HarvestItemProcessor implements ItemProcessor<HarvestRow, HarvestRow> {
+
+    private static final Logger log = LoggerFactory.getLogger(HarvestItemProcessor.class);
+
+    /**
+     * Per-id in-memory attempt counter used as fallback when
+     * {@link RetrySynchronizationManager#getContext()} returns {@code null}.
+     *
+     * <p>Key: {@code harvest_source.id}. Value: number of times this item has been
+     * presented to the processor in the current step execution (0-based on first call).
+     * Reset by {@link #resetAttemptCounters()} in {@link HarvestStepListener#beforeStep}.
+     */
+    private final Map<Long, Integer> attemptCounters = new HashMap<>();
+
+    /**
+     * Processes one harvest row.
+     *
+     * @param item the row read from {@code harvest_source}
+     * @return the same row unchanged (for the happy-path and successful retry)
+     * @throws AbortJobException          if {@code abort_flag=TRUE} — non-skippable
+     * @throws PoisonItemException        if {@code poison_flag=TRUE} — skippable, not retryable
+     * @throws TransientProcessingException if the retry count is below the threshold — retryable
+     */
+    @Override
+    public HarvestRow process(HarvestRow item) {
+
+        // 1. Abort check — non-skippable, non-retryable; fails the job immediately.
+        if (item.abortFlag()) {
+            log.warn("Abort flag set for harvest_source.id={} — throwing AbortJobException", item.id());
+            throw new AbortJobException(item.id());
+        }
+
+        // 2. Poison check — skippable, not retryable; dead-lettered with failure_type='SKIP'.
+        if (item.poisonFlag()) {
+            log.warn("Poison flag set for harvest_source.id={} — throwing PoisonItemException", item.id());
+            throw new PoisonItemException(item.id());
+        }
+
+        // 3. Transient threshold check — retryable; dead-lettered with failure_type='RETRY_EXHAUSTED'
+        //    only when retries are exhausted (then it becomes a skip).
+        int threshold = item.transientFailUntilAttempt();
+        if (threshold > 0) {
+            int retryCount = resolveRetryCount(item.id());
+            log.debug("Transient item id={} retryCount={} threshold={}", item.id(), retryCount, threshold);
+            if (retryCount < threshold) {
+                throw new TransientProcessingException(item.id(), retryCount, threshold);
+            }
+            log.info("Transient item id={} succeeded after {} retries", item.id(), retryCount);
+        }
+
+        // 4. Happy path — return item unchanged; writer will mark processed=TRUE.
+        return item;
+    }
+
+    /**
+     * Resolves the current retry count for the given item id.
+     *
+     * <p>Priority: {@link RetrySynchronizationManager} context (spring-retry thread-local).
+     * Fallback: per-id in-memory counter incremented on every call to this method.
+     *
+     * @param itemId the {@code harvest_source.id}
+     * @return 0-based retry count (0 = first attempt, 1 = first retry, …)
+     */
+    int resolveRetryCount(long itemId) {
+        var context = RetrySynchronizationManager.getContext();
+        if (context != null) {
+            int count = context.getRetryCount();
+            log.debug("retry-count source=RetrySynchronizationManager id={} count={}", itemId, count);
+            return count;
+        }
+
+        // Fallback: in-memory per-id counter.
+        // getOrDefault returns the count BEFORE this call (i.e., number of prior attempts),
+        // then we store count+1 for the next call.
+        int currentCount = attemptCounters.getOrDefault(itemId, 0);
+        attemptCounters.put(itemId, currentCount + 1);
+        log.debug("retry-count source=in-memory-fallback id={} count={}", itemId, currentCount);
+        return currentCount;
+    }
+
+    /**
+     * Resets all per-id attempt counters.
+     *
+     * <p>Called by {@link HarvestStepListener#beforeStep} at the start of each step execution
+     * so that restarts do not carry over stale counts from a previous run.
+     */
+    public void resetAttemptCounters() {
+        attemptCounters.clear();
+        log.debug("Attempt counters reset (beforeStep)");
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestItemWriter.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestItemWriter.java
@@ -1,0 +1,59 @@
+package com.fronzec.plugins.harvester.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Marks each successfully processed {@link HarvestRow} as done in {@code harvest_source}.
+ *
+ * <h3>Idempotency</h3>
+ * <p>The UPDATE predicate includes {@code AND processed = FALSE}, so a row already marked
+ * {@code TRUE} (e.g., from a prior completed chunk on restart) causes 0 rows updated — a
+ * safe no-op. No exception is thrown on 0-row updates.
+ *
+ * <h3>Restart safety</h3>
+ * <p>Combined with {@code JdbcCursorItemReader.setSaveState(true)}, the reader fast-forwards
+ * past already-committed rows on restart using the saved {@code currentItemCount} from
+ * {@code BATCH_STEP_EXECUTION_CONTEXT}. The idempotent writer is a belt-and-suspenders
+ * guard for the rare case where a row is re-delivered at a chunk boundary.
+ */
+public class HarvestItemWriter implements ItemWriter<HarvestRow> {
+
+    private static final Logger log = LoggerFactory.getLogger(HarvestItemWriter.class);
+
+    private static final String UPDATE_SQL =
+            "UPDATE harvest_source SET processed = TRUE WHERE id = ? AND processed = FALSE";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Constructs the writer.
+     *
+     * @param jdbcTemplate the JDBC template backed by the host's DataSource
+     */
+    public HarvestItemWriter(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * Marks each item in the chunk as processed.
+     *
+     * @param chunk the successfully processed items to write
+     */
+    @Override
+    public void write(Chunk<? extends HarvestRow> chunk) {
+        for (HarvestRow row : chunk) {
+            int updated = jdbcTemplate.update(UPDATE_SQL, row.id());
+            if (updated == 0) {
+                // Row was already processed (restart re-delivery or duplicate). Safe no-op.
+                log.debug("harvest_source.id={} already processed — skipping UPDATE (no-op)", row.id());
+            } else {
+                log.debug("harvest_source.id={} marked processed=TRUE", row.id());
+            }
+        }
+        log.info("Writer committed {} items", chunk.size());
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestParamsHolder.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestParamsHolder.java
@@ -1,0 +1,50 @@
+package com.fronzec.plugins.harvester.batch;
+
+/**
+ * Mutable parameter holder populated by {@link HarvestStepListener#beforeStep} and consumed
+ * by batch components that need job parameters without relying on {@code @StepScope}.
+ *
+ * <p>The holder is created once inside {@code configureJob} and shared across components;
+ * {@code beforeStep} fills it before any reader/processor/writer method is called.
+ */
+public class HarvestParamsHolder {
+
+    private String date;
+    private String attemptNumber;
+
+    /**
+     * Returns the {@code DATE} job parameter (yyyy-MM-dd).
+     *
+     * @return date string
+     */
+    public String getDate() {
+        return date;
+    }
+
+    /**
+     * Sets the {@code DATE} job parameter.
+     *
+     * @param date value from {@code JobParameters}
+     */
+    public void setDate(String date) {
+        this.date = date;
+    }
+
+    /**
+     * Returns the {@code ATTEMPT_NUMBER} job parameter.
+     *
+     * @return attempt number string, or {@code null} if not supplied
+     */
+    public String getAttemptNumber() {
+        return attemptNumber;
+    }
+
+    /**
+     * Sets the {@code ATTEMPT_NUMBER} job parameter.
+     *
+     * @param attemptNumber value from {@code JobParameters}
+     */
+    public void setAttemptNumber(String attemptNumber) {
+        this.attemptNumber = attemptNumber;
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRetryListener.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRetryListener.java
@@ -1,0 +1,89 @@
+package com.fronzec.plugins.harvester.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+
+/**
+ * Pedagogical retry listener that logs each retry attempt and backoff for the
+ * fault-tolerant harvester step.
+ *
+ * <p>Registered via {@code FaultTolerantStepBuilder.listener(RetryListener)} which has a
+ * dedicated typed overload in Spring Batch 6, so no cast is required.
+ *
+ * <p>This listener is purely observational — it does not modify retry behaviour.
+ * Its purpose is to make the exponential backoff and retry sequence visible in logs
+ * when running integration tests or the host service with DEBUG logging enabled.
+ *
+ * <h3>spring-retry API (RetryListener, spring-retry 2.0.x)</h3>
+ * <ul>
+ *   <li>{@link #open} — called once before the first attempt; {@code true} continues.</li>
+ *   <li>{@link #onError} — called after each failed attempt (before the next retry or
+ *       before giving up).</li>
+ *   <li>{@link #close} — called once after the final attempt (success or exhaustion).</li>
+ * </ul>
+ */
+public class HarvestRetryListener implements RetryListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HarvestRetryListener.class);
+
+    /**
+     * Called before the first attempt. Returns {@code true} to allow the retry template
+     * to proceed.
+     *
+     * @param context  the retry context (retryCount = 0 here)
+     * @param callback the operation being retried
+     * @param <T>      return type of the callback
+     * @param <E>      exception type
+     * @return always {@code true}
+     */
+    @Override
+    public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+        log.debug("Retry template opened: retryCount={}", context.getRetryCount());
+        return true;
+    }
+
+    /**
+     * Called after each failed attempt.
+     *
+     * @param context   the retry context (retryCount reflects attempts so far)
+     * @param callback  the operation being retried
+     * @param throwable the exception from this attempt
+     * @param <T>       return type of the callback
+     * @param <E>       exception type
+     */
+    @Override
+    public <T, E extends Throwable> void onError(RetryContext context,
+                                                  RetryCallback<T, E> callback,
+                                                  Throwable throwable) {
+        log.info("Retry attempt {} failed with {}: {}",
+                context.getRetryCount(),
+                throwable.getClass().getSimpleName(),
+                throwable.getMessage());
+    }
+
+    /**
+     * Called after the final attempt (success or exhaustion).
+     *
+     * @param context   the retry context
+     * @param callback  the operation being retried
+     * @param throwable the final exception ({@code null} if the last attempt succeeded)
+     * @param <T>       return type of the callback
+     * @param <E>       exception type
+     */
+    @Override
+    public <T, E extends Throwable> void close(RetryContext context,
+                                                RetryCallback<T, E> callback,
+                                                Throwable throwable) {
+        if (throwable == null) {
+            log.debug("Retry template closed successfully after {} attempt(s)",
+                    context.getRetryCount() + 1);
+        } else {
+            log.debug("Retry template closed after {} attempt(s) — exhausted: {}",
+                    context.getRetryCount() + 1,
+                    throwable.getClass().getSimpleName());
+        }
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRow.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRow.java
@@ -1,0 +1,26 @@
+package com.fronzec.plugins.harvester.batch;
+
+/**
+ * Immutable domain record representing one row from {@code harvest_source}.
+ *
+ * <p>All fields are read directly from the database; none are mutated during processing.
+ * {@code transientFailUntilAttempt} is a read-only threshold — the processor compares
+ * the current Spring Batch retry count against this value but NEVER updates the source row.
+ *
+ * @param id                       primary key of the harvest_source row
+ * @param payload                  the raw payload string (up to 2 048 chars)
+ * @param poisonFlag               when {@code true} the item is skipped and dead-lettered
+ *                                 with {@code failure_type='SKIP'}
+ * @param transientFailUntilAttempt read-only threshold; the processor throws
+ *                                 {@link TransientProcessingException} while the in-memory
+ *                                 retry count is below this value, then succeeds
+ * @param abortFlag                when {@code true} the processor throws
+ *                                 {@link AbortJobException}, which is non-skippable and
+ *                                 non-retryable, causing the job to fail (restart demo)
+ */
+public record HarvestRow(
+        long id,
+        String payload,
+        boolean poisonFlag,
+        int transientFailUntilAttempt,
+        boolean abortFlag) {}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRowMapper.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestRowMapper.java
@@ -1,0 +1,38 @@
+package com.fronzec.plugins.harvester.batch;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Maps a {@code harvest_source} result-set row to a {@link HarvestRow} record.
+ *
+ * <p>Expected columns (by name):
+ * <ul>
+ *   <li>{@code id} — BIGINT primary key</li>
+ *   <li>{@code payload} — VARCHAR(2048)</li>
+ *   <li>{@code poison_flag} — BOOLEAN</li>
+ *   <li>{@code transient_fail_until_attempt} — INT</li>
+ *   <li>{@code abort_flag} — BOOLEAN</li>
+ * </ul>
+ */
+public class HarvestRowMapper implements RowMapper<HarvestRow> {
+
+    /**
+     * Maps one result-set row to a {@link HarvestRow}.
+     *
+     * @param rs     the result set positioned at the current row
+     * @param rowNum the 0-based row number (unused)
+     * @return the mapped {@link HarvestRow}
+     * @throws SQLException if a column cannot be read
+     */
+    @Override
+    public HarvestRow mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new HarvestRow(
+                rs.getLong("id"),
+                rs.getString("payload"),
+                rs.getBoolean("poison_flag"),
+                rs.getInt("transient_fail_until_attempt"),
+                rs.getBoolean("abort_flag"));
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestSkipListener.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestSkipListener.java
@@ -1,0 +1,223 @@
+package com.fronzec.plugins.harvester.batch;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.listener.SkipListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Writes a {@code harvest_dead_letter} row for every skipped item, under its own independent
+ * transaction ({@code PROPAGATION_REQUIRES_NEW}).
+ *
+ * <h3>Transaction independence</h3>
+ * <p>The dead-letter INSERT uses a {@link TransactionTemplate} configured with
+ * {@link TransactionDefinition#PROPAGATION_REQUIRES_NEW}. This guarantees that the audit
+ * record commits independently of the surrounding chunk transaction, so a chunk rollback
+ * cannot erase the dead-letter evidence.
+ *
+ * <p>An explicit REQUIRES_NEW is used even though Spring Batch 6 calls the skip listener
+ * AFTER the chunk is rolled back — the explicit independent transaction is more defensive
+ * and avoids relying on listener-call-timing semantics across SB versions.
+ *
+ * <h3>failure_type distinction</h3>
+ * <ul>
+ *   <li>{@link PoisonItemException} → {@code failure_type='SKIP'}</li>
+ *   <li>{@link TransientProcessingException} reaching skip (retry exhausted) →
+ *       {@code failure_type='RETRY_EXHAUSTED'}</li>
+ *   <li>Any other throwable in process → {@code failure_type='SKIP'} (generic skip)</li>
+ * </ul>
+ *
+ * <h3>attempt_count</h3>
+ * <p>For {@code RETRY_EXHAUSTED} the attempt count is set to {@code retryLimit + 1}
+ * (representing the total calls: initial + retries). For skips without retry the count is 1.
+ *
+ * <h3>job_execution_id</h3>
+ * <p>Captured via {@link #setJobExecutionId(long)} called from
+ * {@link FaultTolerantHarvesterJobPlugin#configureJob} via a step-execution listener, or
+ * falls back to {@code -1} when not set (should not happen in normal operation).
+ */
+public class HarvestSkipListener implements SkipListener<HarvestRow, HarvestRow> {
+
+    private static final Logger log = LoggerFactory.getLogger(HarvestSkipListener.class);
+
+    /**
+     * Number of retries configured on the step (retryLimit=3). Used to compute attempt_count
+     * for RETRY_EXHAUSTED entries (total calls = retryLimit + 1).
+     */
+    private static final int RETRY_LIMIT = 3;
+
+    private static final String INSERT_SQL =
+            "INSERT INTO harvest_dead_letter"
+                    + " (source_id, raw_payload, failure_phase, failure_type,"
+                    + "  exception_class, exception_msg, attempt_count,"
+                    + "  job_execution_id, recorded_at)"
+                    + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate requiresNewTx;
+
+    /** Job execution id captured from the step; set before any skip callback fires. */
+    private volatile long jobExecutionId = -1L;
+
+    /**
+     * Constructs the skip listener.
+     *
+     * @param jdbcTemplate       JDBC template backed by the host's DataSource
+     * @param transactionManager the platform transaction manager used to create the
+     *                           REQUIRES_NEW transaction template
+     */
+    public HarvestSkipListener(JdbcTemplate jdbcTemplate,
+                                PlatformTransactionManager transactionManager) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.requiresNewTx = new TransactionTemplate(transactionManager);
+        this.requiresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+    /**
+     * Sets the job execution id to record in dead-letter rows.
+     *
+     * <p>Called from {@code configureJob} via a {@code StepExecutionListener.beforeStep}
+     * callback so the value is available before any chunk runs.
+     *
+     * @param jobExecutionId the {@code BATCH_JOB_EXECUTION.id} for the current run
+     */
+    public void setJobExecutionId(long jobExecutionId) {
+        this.jobExecutionId = jobExecutionId;
+    }
+
+    /**
+     * Called when the processor skips an item.
+     *
+     * <p>Writes a dead-letter record under REQUIRES_NEW. Distinguishes
+     * {@link PoisonItemException} ({@code failure_type='SKIP'}) from
+     * {@link TransientProcessingException} ({@code failure_type='RETRY_EXHAUSTED'}).
+     *
+     * @param item      the skipped harvest row
+     * @param throwable the exception that caused the skip (may be the original or a wrapper)
+     */
+    @Override
+    public void onSkipInProcess(HarvestRow item, Throwable throwable) {
+        // Unwrap if the exception is wrapped by a retry framework.
+        Throwable cause = unwrap(throwable);
+
+        String failureType;
+        int attemptCount;
+
+        if (cause instanceof TransientProcessingException) {
+            failureType = "RETRY_EXHAUSTED";
+            attemptCount = RETRY_LIMIT + 1; // initial attempt + retryLimit retries
+        } else {
+            // PoisonItemException or any other skippable exception
+            failureType = "SKIP";
+            attemptCount = 1;
+        }
+
+        log.warn("Skip in process: id={} failureType={} exception={}",
+                item.id(), failureType, cause.getClass().getSimpleName());
+
+        insertDeadLetter(item, "PROCESS", failureType, cause, attemptCount);
+    }
+
+    /**
+     * Called when the reader skips an item. Writes a dead-letter record with
+     * {@code failure_phase='READ'} and {@code source_id=NULL} (no item available).
+     *
+     * @param throwable the exception that caused the skip during reading
+     */
+    @Override
+    public void onSkipInRead(Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        log.warn("Skip in read: exception={}", cause.getClass().getSimpleName());
+
+        String failureType = (cause instanceof TransientProcessingException)
+                ? "RETRY_EXHAUSTED" : "SKIP";
+        int attemptCount = (cause instanceof TransientProcessingException) ? RETRY_LIMIT + 1 : 1;
+
+        requiresNewTx.execute(status -> {
+            jdbcTemplate.update(INSERT_SQL,
+                    null,                                    // source_id — unknown on read skip
+                    null,                                    // raw_payload — unknown
+                    "READ",
+                    failureType,
+                    cause.getClass().getName(),
+                    cause.getMessage(),
+                    attemptCount,
+                    jobExecutionId,
+                    Timestamp.from(Instant.now()));
+            return null;
+        });
+    }
+
+    /**
+     * Called when the writer skips an item. Writes a dead-letter record with
+     * {@code failure_phase='WRITE'}.
+     *
+     * @param item      the skipped harvest row
+     * @param throwable the exception that caused the skip during writing
+     */
+    @Override
+    public void onSkipInWrite(HarvestRow item, Throwable throwable) {
+        Throwable cause = unwrap(throwable);
+        log.warn("Skip in write: id={} exception={}", item.id(), cause.getClass().getSimpleName());
+
+        String failureType = (cause instanceof TransientProcessingException)
+                ? "RETRY_EXHAUSTED" : "SKIP";
+        int attemptCount = (cause instanceof TransientProcessingException) ? RETRY_LIMIT + 1 : 1;
+
+        insertDeadLetter(item, "WRITE", failureType, cause, attemptCount);
+    }
+
+    // ── Private helpers ───────────────────────────────────────────────────────────────────────
+
+    /**
+     * Inserts one dead-letter record under a REQUIRES_NEW transaction.
+     *
+     * @param item         the harvested row (provides source_id and raw_payload)
+     * @param failurePhase READ, PROCESS, or WRITE
+     * @param failureType  SKIP or RETRY_EXHAUSTED
+     * @param cause        the actual (unwrapped) exception
+     * @param attemptCount total number of processing attempts for this item
+     */
+    private void insertDeadLetter(HarvestRow item,
+                                   String failurePhase,
+                                   String failureType,
+                                   Throwable cause,
+                                   int attemptCount) {
+        requiresNewTx.execute(status -> {
+            jdbcTemplate.update(INSERT_SQL,
+                    item.id(),
+                    item.payload(),
+                    failurePhase,
+                    failureType,
+                    cause.getClass().getName(),
+                    cause.getMessage(),
+                    attemptCount,
+                    jobExecutionId,
+                    Timestamp.from(Instant.now()));
+            return null;
+        });
+    }
+
+    /**
+     * Unwraps a single layer of exception wrapping if the direct throwable is not one of the
+     * domain exceptions. Spring Batch may wrap the original cause in some scenarios.
+     *
+     * @param throwable the potentially wrapped exception
+     * @return the original domain exception if the outer exception was a wrapper, otherwise
+     *         the throwable itself
+     */
+    private static Throwable unwrap(Throwable throwable) {
+        if (throwable instanceof PoisonItemException
+                || throwable instanceof TransientProcessingException
+                || throwable instanceof AbortJobException) {
+            return throwable;
+        }
+        Throwable cause = throwable.getCause();
+        return (cause != null) ? cause : throwable;
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestStepListener.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestStepListener.java
@@ -1,0 +1,60 @@
+package com.fronzec.plugins.harvester.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+
+/**
+ * Populates {@link HarvestParamsHolder} from job parameters before the reader opens, and
+ * resets the processor's in-memory attempt counter so that each step execution starts clean.
+ *
+ * <p>This is the canonical pattern for injecting job parameters without {@code @StepScope}:
+ * the listener reads {@code JobParameters} in {@code beforeStep} and distributes values to
+ * shared components before Spring Batch calls {@code ItemReader.open()}.
+ *
+ * <p><strong>Processor counter reset:</strong> {@link HarvestItemProcessor} maintains a
+ * per-item in-memory attempt counter (keyed by {@code harvest_source.id}) as the fallback
+ * retry-count mechanism when {@code RetrySynchronizationManager.getContext()} is unavailable.
+ * {@code beforeStep} calls {@link HarvestItemProcessor#resetAttemptCounters()} to clear
+ * that map before each execution, ensuring restarts do not carry over stale counts.
+ */
+public class HarvestStepListener implements StepExecutionListener {
+
+    private static final Logger log = LoggerFactory.getLogger(HarvestStepListener.class);
+
+    private final HarvestParamsHolder holder;
+    private final HarvestItemProcessor processor;
+
+    /**
+     * Constructs the listener.
+     *
+     * @param holder    shared parameter holder to populate in {@code beforeStep}
+     * @param processor the item processor whose attempt counters must be reset
+     */
+    public HarvestStepListener(HarvestParamsHolder holder, HarvestItemProcessor processor) {
+        this.holder = holder;
+        this.processor = processor;
+    }
+
+    /**
+     * Populates the parameter holder and resets the processor's attempt counters.
+     *
+     * @param stepExecution the current step execution (provides job parameters)
+     */
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        var params = stepExecution.getJobParameters();
+
+        String date = params.getString("DATE");
+        String attemptNumber = params.getString("ATTEMPT_NUMBER");
+
+        holder.setDate(date);
+        holder.setAttemptNumber(attemptNumber);
+
+        // Reset the processor's per-id attempt counter so restarts start at 0 per item.
+        processor.resetAttemptCounters();
+
+        log.info("harvest-step configured: date={} attemptNumber={}", date, attemptNumber);
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/PoisonItemException.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/PoisonItemException.java
@@ -1,0 +1,34 @@
+package com.fronzec.plugins.harvester.batch;
+
+/**
+ * Thrown by {@link HarvestItemProcessor} when a {@link HarvestRow} has {@code poison_flag=TRUE}.
+ *
+ * <p>This exception is <em>skippable</em> but <em>not retryable</em>. The step is configured with:
+ * <pre>{@code
+ *   .skip(PoisonItemException.class)
+ *   .noRetry(PoisonItemException.class)
+ * }</pre>
+ *
+ * <p>When skipped, {@link HarvestSkipListener#onSkipInProcess} writes a dead-letter record
+ * with {@code failure_type='SKIP'} under {@code PROPAGATION_REQUIRES_NEW}.
+ */
+public class PoisonItemException extends RuntimeException {
+
+    /**
+     * Constructs a new exception for the given source row id.
+     *
+     * @param sourceId the {@code harvest_source.id} of the poison row
+     */
+    public PoisonItemException(long sourceId) {
+        super("Poison item detected for harvest_source.id=" + sourceId);
+    }
+
+    /**
+     * Constructs a new exception with a custom message.
+     *
+     * @param message descriptive message
+     */
+    public PoisonItemException(String message) {
+        super(message);
+    }
+}

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/TransientProcessingException.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/TransientProcessingException.java
@@ -1,0 +1,40 @@
+package com.fronzec.plugins.harvester.batch;
+
+/**
+ * Thrown by {@link HarvestItemProcessor} when a {@link HarvestRow} has a
+ * {@code transient_fail_until_attempt} threshold that has not yet been reached.
+ *
+ * <p>This exception is both <em>skippable</em> and <em>retryable</em>. The step is configured:
+ * <pre>{@code
+ *   .skip(TransientProcessingException.class)   // reached only after retry exhaustion
+ *   .retry(TransientProcessingException.class)
+ * }</pre>
+ *
+ * <p>Spring Batch will retry the item up to {@code retryLimit=3} times with exponential backoff.
+ * If retries are exhausted the item is treated as a skip, and
+ * {@link HarvestSkipListener#onSkipInProcess} writes a dead-letter record with
+ * {@code failure_type='RETRY_EXHAUSTED'}.
+ */
+public class TransientProcessingException extends RuntimeException {
+
+    /**
+     * Constructs a new exception for the given source row id.
+     *
+     * @param sourceId   the {@code harvest_source.id} of the transient row
+     * @param retryCount the current retry count when this exception was thrown
+     * @param threshold  the {@code transient_fail_until_attempt} threshold
+     */
+    public TransientProcessingException(long sourceId, int retryCount, int threshold) {
+        super("Transient failure for harvest_source.id=" + sourceId
+                + " retryCount=" + retryCount + " threshold=" + threshold);
+    }
+
+    /**
+     * Constructs a new exception with a custom message.
+     *
+     * @param message descriptive message
+     */
+    public TransientProcessingException(String message) {
+        super(message);
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterJobIntegrationTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterJobIntegrationTest.java
@@ -1,0 +1,391 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * End-to-end integration tests for {@link FaultTolerantHarvesterJobPlugin}.
+ *
+ * <p>Uses an isolated in-module H2 database with {@code DB_CLOSE_DELAY=-1} so Spring Batch
+ * metadata persists between the two launches required for the restart test (PR#3). This test
+ * class covers the PR#2 non-restart scenarios only.
+ *
+ * <p>All seed data is inserted deterministically inside each test method.
+ * The Spring Batch schema is bootstrapped once per class; application tables are reset
+ * in {@code cleanTables()} before each test.
+ *
+ * <h3>Scenarios covered</h3>
+ * <ol>
+ *   <li>Happy path — all normal rows end up {@code processed=TRUE}, job COMPLETED.</li>
+ *   <li>Skip-to-dead-letter — poison rows are skipped, dead-letter row has
+ *       {@code failure_type='SKIP'}, job COMPLETED, poison rows remain unprocessed.</li>
+ *   <li>Skip-limit-exceeded — more than 5 poison rows cause job FAILED.</li>
+ *   <li>Retry-success — transient rows with threshold {@code <= retryLimit} eventually
+ *       succeed: {@code processed=TRUE}, no dead-letter row (LINCHPIN proof of R4).</li>
+ *   <li>Retry-exhausted — transient rows with threshold {@code > retryLimit} produce a
+ *       dead-letter row with {@code failure_type='RETRY_EXHAUSTED'}, job COMPLETED (if
+ *       within skipLimit).</li>
+ * </ol>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaultTolerantHarvesterJobIntegrationTest {
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private StaticApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:harvest-it-"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Bootstrap Spring Batch metadata schema
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Create application tables (harvest_source, harvest_dead_letter)
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_source ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " payload VARCHAR(2048) NOT NULL,"
+                        + " poison_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " transient_fail_until_attempt INT NOT NULL DEFAULT 0 CHECK (transient_fail_until_attempt >= 0),"
+                        + " abort_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_dead_letter ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " source_id BIGINT NULL,"
+                        + " raw_payload VARCHAR(2048) NULL,"
+                        + " failure_phase VARCHAR(16) NOT NULL,"
+                        + " failure_type VARCHAR(16) NOT NULL,"
+                        + " exception_class VARCHAR(512) NOT NULL,"
+                        + " exception_msg VARCHAR(2048) NULL,"
+                        + " attempt_count INT NOT NULL DEFAULT 1 CHECK (attempt_count >= 0),"
+                        + " job_execution_id BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        // Bootstrap Spring Batch JobRepository
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub ApplicationContext that exposes only the DataSource (mirrors ticket-bundle-job IT)
+        stubContext = new StaticApplicationContext();
+        stubContext.getBeanFactory().registerSingleton("dataSource", ds);
+        stubContext.refresh();
+    }
+
+    @BeforeEach
+    void cleanTables() {
+        jdbc.execute("DELETE FROM harvest_dead_letter");
+        jdbc.execute("DELETE FROM harvest_source");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────────────────
+
+    private long insertNormalRow(long id) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag,"
+                        + " transient_fail_until_attempt, abort_flag, processed)"
+                        + " VALUES (?, ?, FALSE, 0, FALSE, FALSE)",
+                id, "payload-" + id);
+        return id;
+    }
+
+    private long insertPoisonRow(long id) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag,"
+                        + " transient_fail_until_attempt, abort_flag, processed)"
+                        + " VALUES (?, ?, TRUE, 0, FALSE, FALSE)",
+                id, "poison-" + id);
+        return id;
+    }
+
+    private long insertTransientRow(long id, int threshold) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag,"
+                        + " transient_fail_until_attempt, abort_flag, processed)"
+                        + " VALUES (?, ?, FALSE, ?, FALSE, FALSE)",
+                id, "transient-" + id, threshold);
+        return id;
+    }
+
+    private boolean isProcessed(long id) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT processed FROM harvest_source WHERE id = ?", Boolean.class, id);
+        return Boolean.TRUE.equals(result);
+    }
+
+    private int deadLetterCount() {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM harvest_dead_letter", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    private BatchStatus runJob(String runId) throws Exception {
+        FaultTolerantHarvesterJobPlugin plugin = new FaultTolerantHarvesterJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("DATE", "2026-06-15")
+                .addString("ATTEMPT_NUMBER", "1")
+                .addString("RUN_ID", runId)  // differentiates job instances across tests
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        return execution.getStatus();
+    }
+
+    // ── Scenario 1: Happy path ────────────────────────────────────────────────────────────────
+
+    @Test
+    void happyPath_allNormalRows_processedAndCompleted() throws Exception {
+        insertNormalRow(1L);
+        insertNormalRow(2L);
+        insertNormalRow(3L);
+        insertNormalRow(4L);
+        insertNormalRow(5L);
+
+        BatchStatus status = runJob("hp-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(1L)).isTrue();
+        assertThat(isProcessed(2L)).isTrue();
+        assertThat(isProcessed(3L)).isTrue();
+        assertThat(isProcessed(4L)).isTrue();
+        assertThat(isProcessed(5L)).isTrue();
+        assertThat(deadLetterCount()).isZero();
+    }
+
+    // ── Scenario 2: Skip-to-dead-letter ──────────────────────────────────────────────────────
+
+    @Test
+    void skipToDeadLetter_poisonRowsSkipped_deadLetterHasSkipType() throws Exception {
+        insertNormalRow(10L);
+        insertNormalRow(11L);
+        insertNormalRow(12L);
+        insertNormalRow(13L);
+        insertPoisonRow(14L); // within skipLimit=5
+
+        BatchStatus status = runJob("skip-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // Normal rows processed
+        assertThat(isProcessed(10L)).isTrue();
+        assertThat(isProcessed(11L)).isTrue();
+        assertThat(isProcessed(12L)).isTrue();
+        assertThat(isProcessed(13L)).isTrue();
+
+        // Poison row NOT processed
+        assertThat(isProcessed(14L)).isFalse();
+
+        // Dead-letter row created with correct fields
+        List<Map<String, Object>> dlRows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 14");
+        assertThat(dlRows).hasSize(1);
+        Map<String, Object> dl = dlRows.get(0);
+        assertThat(dl.get("failure_type")).isEqualTo("SKIP");
+        assertThat(dl.get("failure_phase")).isEqualTo("PROCESS");
+        assertThat(dl.get("source_id")).isEqualTo(14L);
+    }
+
+    @Test
+    void skipToDeadLetter_multiplePoison_allDeadLettered_jobCompleted() throws Exception {
+        // 3 normal + 3 poison — within skipLimit=5
+        insertNormalRow(20L);
+        insertNormalRow(21L);
+        insertNormalRow(22L);
+        insertPoisonRow(23L);
+        insertPoisonRow(24L);
+        insertPoisonRow(25L);
+
+        BatchStatus status = runJob("multi-skip-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(23L)).isFalse();
+        assertThat(isProcessed(24L)).isFalse();
+        assertThat(isProcessed(25L)).isFalse();
+
+        // 3 dead-letter rows, all SKIP
+        List<Map<String, Object>> dlRows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter ORDER BY source_id");
+        assertThat(dlRows).hasSize(3);
+        assertThat(dlRows).allMatch(r -> "SKIP".equals(r.get("failure_type")));
+    }
+
+    // ── Scenario 3: Skip-limit-exceeded ──────────────────────────────────────────────────────
+
+    @Test
+    void skipLimitExceeded_moreThan5Poisons_jobFails() throws Exception {
+        // 6 poison rows → exceeds skipLimit=5
+        for (long i = 30L; i <= 35L; i++) {
+            insertPoisonRow(i);
+        }
+
+        BatchStatus status = runJob("skip-limit-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.FAILED);
+        // None processed (all poison)
+        for (long i = 30L; i <= 35L; i++) {
+            assertThat(isProcessed(i)).isFalse();
+        }
+    }
+
+    // ── Scenario 4: Retry-success (LINCHPIN — proves R4 mechanism) ────────────────────────────
+
+    @Test
+    void retrySuccess_transientRowWithThresholdWithinRetryLimit_processedNoDeadLetter() throws Exception {
+        // threshold=2, retryLimit=3 → processor fails on attempts 0,1 then succeeds on attempt 2
+        insertNormalRow(40L);
+        insertTransientRow(41L, 2);
+        insertNormalRow(42L);
+
+        BatchStatus status = runJob("retry-success-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(40L)).isTrue();
+        assertThat(isProcessed(41L)).isTrue(); // Must succeed after retries
+        assertThat(isProcessed(42L)).isTrue();
+        assertThat(deadLetterCount()).isZero(); // No dead-letter for successful retry
+    }
+
+    @Test
+    void retrySuccess_threshold1_succeedsAfterOneRetry() throws Exception {
+        insertTransientRow(50L, 1); // threshold=1: fails on attempt 0, succeeds on attempt 1
+
+        BatchStatus status = runJob("retry-t1-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(50L)).isTrue();
+        assertThat(deadLetterCount()).isZero();
+    }
+
+    @Test
+    void retrySuccess_threshold2_maxBoundary_succeeds() throws Exception {
+        // threshold=2 is the maximum successful threshold with retryLimit=3:
+        // - call 1: retryCount=0 < 2 → throw
+        // - call 2: retryCount=1 < 2 → throw
+        // - call 3: retryCount=2 >= 2 → succeed (last retry, retryLimit=3 means max retryCount seen = 2)
+        // threshold=3 would NEVER succeed because the processor only sees retryCount 0,1,2 at most.
+        insertTransientRow(51L, 2);
+        insertNormalRow(52L);
+
+        BatchStatus status = runJob("retry-t2b-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(51L)).isTrue();
+        assertThat(isProcessed(52L)).isTrue();
+        assertThat(deadLetterCount()).isZero();
+    }
+
+    // ── Scenario 5: Retry-exhausted ──────────────────────────────────────────────────────────
+
+    @Test
+    void retryExhausted_transientAboveRetryLimit_deadLetterRetryExhaustedType() throws Exception {
+        // threshold=10 > retryLimit=3 → processor always throws, retries exhaust, item skipped
+        insertNormalRow(60L);
+        insertTransientRow(61L, 10);
+        insertNormalRow(62L);
+
+        BatchStatus status = runJob("retry-exhaust-" + System.nanoTime());
+
+        // 1 skip (61) within skipLimit=5 → job completes
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(isProcessed(60L)).isTrue();
+        assertThat(isProcessed(61L)).isFalse(); // Not processed
+        assertThat(isProcessed(62L)).isTrue();
+
+        List<Map<String, Object>> dlRows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 61");
+        assertThat(dlRows).hasSize(1);
+        Map<String, Object> dl = dlRows.get(0);
+        assertThat(dl.get("failure_type")).isEqualTo("RETRY_EXHAUSTED");
+        assertThat(dl.get("failure_phase")).isEqualTo("PROCESS");
+        assertThat(dl.get("source_id")).isEqualTo(61L);
+    }
+
+    @Test
+    void retryExhaustedCountsAgainstSkipLimit() throws Exception {
+        // 5 poison rows consume the full skipLimit, then 1 retry-exhausted row pushes it over
+        for (long i = 70L; i <= 74L; i++) {
+            insertPoisonRow(i);
+        }
+        insertTransientRow(75L, 10); // will exhaust retries and try to skip as 6th skip
+
+        BatchStatus status = runJob("exhaust-limit-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.FAILED);
+    }
+
+    // ── Dead-letter REQUIRES_NEW independence ─────────────────────────────────────────────────
+
+    @Test
+    void deadLetterSurvivesChunkRollback() throws Exception {
+        // Chunk 1 (ids 80-84): id 82 is poison — will be skipped and dead-lettered.
+        // The remaining rows in the chunk succeed, so the chunk commits.
+        // What we're verifying here is simply that the dead-letter record exists after job completion.
+        insertNormalRow(80L);
+        insertNormalRow(81L);
+        insertPoisonRow(82L);
+        insertNormalRow(83L);
+        insertNormalRow(84L);
+
+        BatchStatus status = runJob("dl-survive-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // Dead-letter row persisted (REQUIRES_NEW committed independently)
+        assertThat(deadLetterCount()).isEqualTo(1);
+        List<Map<String, Object>> dlRows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 82");
+        assertThat(dlRows).hasSize(1);
+        assertThat(dlRows.get(0).get("failure_type")).isEqualTo("SKIP");
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestItemProcessorTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestItemProcessorTest.java
@@ -1,0 +1,181 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.retry.context.RetryContextSupport;
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+/**
+ * Unit tests for {@link HarvestItemProcessor}.
+ *
+ * <p>Tests cover all three fault-tolerance paths (abort, poison, transient) plus the happy path.
+ * The transient tests exercise both the RetrySynchronizationManager path and the in-memory
+ * fallback counter path.
+ */
+class HarvestItemProcessorTest {
+
+    private HarvestItemProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        processor = new HarvestItemProcessor();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void normalRow_passesThrough() throws Exception {
+        HarvestRow row = new HarvestRow(1L, "payload", false, 0, false);
+        assertThat(processor.process(row)).isSameAs(row);
+    }
+
+    @Test
+    void zeroThreshold_neverThrowsTransient() throws Exception {
+        HarvestRow row = new HarvestRow(2L, "payload", false, 0, false);
+        assertThat(processor.process(row)).isSameAs(row);
+    }
+
+    // ── Abort ─────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void abortFlag_throwsAbortJobException() {
+        HarvestRow row = new HarvestRow(10L, "abort", false, 0, true);
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(AbortJobException.class)
+                .hasMessageContaining("10");
+    }
+
+    @Test
+    void abortFlag_takePrecedenceOverPoisonFlag() {
+        // abort + poison — abort wins (checked first)
+        HarvestRow row = new HarvestRow(11L, "both", true, 0, true);
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(AbortJobException.class);
+    }
+
+    // ── Poison ────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    void poisonFlag_throwsPoisonItemException() {
+        HarvestRow row = new HarvestRow(20L, "poison", true, 0, false);
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(PoisonItemException.class)
+                .hasMessageContaining("20");
+    }
+
+    // ── Transient — in-memory fallback counter (no retry context on thread) ─────────────────
+
+    @Test
+    void transient_inMemoryFallback_throwsBelowThreshold() throws Exception {
+        // Ensure no retry context is active
+        HarvestRow row = new HarvestRow(30L, "transient", false, 2, false);
+
+        // First call: counter=0 < threshold=2 → throw
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(TransientProcessingException.class);
+    }
+
+    @Test
+    void transient_inMemoryFallback_succeedsAtThreshold() throws Exception {
+        HarvestRow row = new HarvestRow(31L, "transient", false, 2, false);
+
+        // First call (counter=0): throws
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(TransientProcessingException.class);
+        // Second call (counter=1): throws
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(TransientProcessingException.class);
+        // Third call (counter=2 >= threshold=2): succeeds
+        HarvestRow result = processor.process(row);
+        assertThat(result).isSameAs(row);
+    }
+
+    @Test
+    void transient_resetAttemptCounters_restartsFromZero() throws Exception {
+        HarvestRow row = new HarvestRow(32L, "transient", false, 1, false);
+
+        // First call: throws (counter=0 < threshold=1)
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(TransientProcessingException.class);
+        // Second call: succeeds (counter=1 >= threshold=1)
+        assertThat(processor.process(row)).isSameAs(row);
+
+        // Reset simulates a new step execution (e.g. restart)
+        processor.resetAttemptCounters();
+
+        // After reset: first call throws again
+        assertThatThrownBy(() -> processor.process(row))
+                .isInstanceOf(TransientProcessingException.class);
+    }
+
+    // ── Transient — RetrySynchronizationManager path ─────────────────────────────────────────
+
+    @Test
+    void transient_retrySyncManager_throwsBelowThreshold() {
+        HarvestRow row = new HarvestRow(40L, "transient", false, 2, false);
+
+        // Simulate retry count = 0 via RetrySynchronizationManager
+        Runnable clear = activateRetryContext(0);
+        try {
+            assertThatThrownBy(() -> processor.process(row))
+                    .isInstanceOf(TransientProcessingException.class);
+        } finally {
+            clear.run();
+        }
+    }
+
+    @Test
+    void transient_retrySyncManager_succeedsAtThreshold() throws Exception {
+        HarvestRow row = new HarvestRow(41L, "transient", false, 2, false);
+
+        // Simulate retry count = 2 via RetrySynchronizationManager (>= threshold=2)
+        Runnable clear = activateRetryContext(2);
+        try {
+            HarvestRow result = processor.process(row);
+            assertThat(result).isSameAs(row);
+        } finally {
+            clear.run();
+        }
+    }
+
+    @Test
+    void resolveRetryCount_usesContextWhenPresent() {
+        Runnable clear = activateRetryContext(3);
+        try {
+            assertThat(processor.resolveRetryCount(99L)).isEqualTo(3);
+        } finally {
+            clear.run();
+        }
+    }
+
+    @Test
+    void resolveRetryCount_usesFallbackCounterWhenContextAbsent() {
+        // No active retry context
+        assertThat(RetrySynchronizationManager.getContext()).isNull();
+
+        assertThat(processor.resolveRetryCount(50L)).isEqualTo(0); // first call
+        assertThat(processor.resolveRetryCount(50L)).isEqualTo(1); // second call
+        assertThat(processor.resolveRetryCount(50L)).isEqualTo(2); // third call
+        // Different id: starts at 0
+        assertThat(processor.resolveRetryCount(51L)).isEqualTo(0);
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Activates a {@link RetrySynchronizationManager} context with the given retry count.
+     * Returns a {@link Runnable} to call in {@code finally} to clear the context.
+     */
+    private Runnable activateRetryContext(int retryCount) {
+        RetryContextSupport ctx = new RetryContextSupport(null);
+        // Advance the counter: RetryContextSupport.registerThrowable increments retryCount
+        for (int i = 0; i < retryCount; i++) {
+            ctx.registerThrowable(new RuntimeException("synthetic"));
+        }
+        RetrySynchronizationManager.register(ctx);
+        return RetrySynchronizationManager::clear;
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestItemWriterTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestItemWriterTest.java
@@ -1,0 +1,90 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link HarvestItemWriter} using an in-memory H2 database.
+ */
+class HarvestItemWriterTest {
+
+    private JdbcTemplate jdbc;
+    private HarvestItemWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:writer-test-" + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_source ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " payload VARCHAR(2048) NOT NULL,"
+                        + " poison_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " transient_fail_until_attempt INT NOT NULL DEFAULT 0,"
+                        + " abort_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        writer = new HarvestItemWriter(jdbc);
+    }
+
+    private long insertRow(long id, String payload) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag, transient_fail_until_attempt,"
+                        + " abort_flag, processed) VALUES (?, ?, FALSE, 0, FALSE, FALSE)",
+                id, payload);
+        return id;
+    }
+
+    private boolean isProcessed(long id) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT processed FROM harvest_source WHERE id = ?", Boolean.class, id);
+        return Boolean.TRUE.equals(result);
+    }
+
+    @Test
+    void write_marksRowsAsProcessed() throws Exception {
+        insertRow(1L, "payload-1");
+        insertRow(2L, "payload-2");
+
+        HarvestRow row1 = new HarvestRow(1L, "payload-1", false, 0, false);
+        HarvestRow row2 = new HarvestRow(2L, "payload-2", false, 0, false);
+
+        writer.write(new Chunk<>(row1, row2));
+
+        assertThat(isProcessed(1L)).isTrue();
+        assertThat(isProcessed(2L)).isTrue();
+    }
+
+    @Test
+    void write_alreadyProcessedRow_doesNotThrow() throws Exception {
+        insertRow(10L, "already-done");
+        // Pre-mark as processed
+        jdbc.update("UPDATE harvest_source SET processed = TRUE WHERE id = 10");
+
+        HarvestRow row = new HarvestRow(10L, "already-done", false, 0, false);
+        writer.write(new Chunk<>(row)); // must not throw
+
+        // Still processed (no change)
+        assertThat(isProcessed(10L)).isTrue();
+    }
+
+    @Test
+    void write_emptyChunk_noRowsUpdated() throws Exception {
+        insertRow(20L, "untouched");
+        writer.write(new Chunk<>());
+        // Row remains unprocessed
+        assertThat(isProcessed(20L)).isFalse();
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestRowMapperTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestRowMapperTest.java
@@ -1,0 +1,90 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link HarvestRowMapper} using a real H2 query result set.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HarvestRowMapperTest {
+
+    private JdbcTemplate jdbc;
+    private final HarvestRowMapper mapper = new HarvestRowMapper();
+
+    @BeforeAll
+    void setUpDatabase() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:mapper-test;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_source ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " payload VARCHAR(2048) NOT NULL,"
+                        + " poison_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " transient_fail_until_attempt INT NOT NULL DEFAULT 0,"
+                        + " abort_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+    }
+
+    @Test
+    void mapsNormalRow() {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag, transient_fail_until_attempt,"
+                        + " abort_flag, processed) VALUES (1, '{\"key\":\"value\"}', FALSE, 2, FALSE, FALSE)");
+
+        HarvestRow row = jdbc.queryForObject(
+                "SELECT id, payload, poison_flag, transient_fail_until_attempt, abort_flag"
+                        + " FROM harvest_source WHERE id = 1",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.id()).isEqualTo(1L);
+        assertThat(row.payload()).isEqualTo("{\"key\":\"value\"}");
+        assertThat(row.poisonFlag()).isFalse();
+        assertThat(row.transientFailUntilAttempt()).isEqualTo(2);
+        assertThat(row.abortFlag()).isFalse();
+    }
+
+    @Test
+    void mapsPoisonRow() {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag, transient_fail_until_attempt,"
+                        + " abort_flag, processed) VALUES (2, 'bad-payload', TRUE, 0, FALSE, FALSE)");
+
+        HarvestRow row = jdbc.queryForObject(
+                "SELECT id, payload, poison_flag, transient_fail_until_attempt, abort_flag"
+                        + " FROM harvest_source WHERE id = 2",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.poisonFlag()).isTrue();
+        assertThat(row.abortFlag()).isFalse();
+    }
+
+    @Test
+    void mapsAbortRow() {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag, transient_fail_until_attempt,"
+                        + " abort_flag, processed) VALUES (3, 'abort-payload', FALSE, 0, TRUE, FALSE)");
+
+        HarvestRow row = jdbc.queryForObject(
+                "SELECT id, payload, poison_flag, transient_fail_until_attempt, abort_flag"
+                        + " FROM harvest_source WHERE id = 3",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.abortFlag()).isTrue();
+        assertThat(row.poisonFlag()).isFalse();
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestSkipListenerTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestSkipListenerTest.java
@@ -1,0 +1,151 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Unit tests for {@link HarvestSkipListener}.
+ *
+ * <p>Key proof: dead-letter INSERT commits independently under REQUIRES_NEW even when the
+ * "outer" transaction (simulated via a TransactionTemplate that rolls back) is rolled back.
+ */
+class HarvestSkipListenerTest {
+
+    private JdbcTemplate jdbc;
+    private PlatformTransactionManager txManager;
+    private HarvestSkipListener skipListener;
+
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:skip-listener-test-" + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+        txManager = new DataSourceTransactionManager(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_source ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " payload VARCHAR(2048) NOT NULL,"
+                        + " poison_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " transient_fail_until_attempt INT NOT NULL DEFAULT 0,"
+                        + " abort_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_dead_letter ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " source_id BIGINT NULL,"
+                        + " raw_payload VARCHAR(2048) NULL,"
+                        + " failure_phase VARCHAR(16) NOT NULL,"
+                        + " failure_type VARCHAR(16) NOT NULL,"
+                        + " exception_class VARCHAR(512) NOT NULL,"
+                        + " exception_msg VARCHAR(2048) NULL,"
+                        + " attempt_count INT NOT NULL DEFAULT 1,"
+                        + " job_execution_id BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        skipListener = new HarvestSkipListener(jdbc, txManager);
+        skipListener.setJobExecutionId(42L);
+    }
+
+    // ── onSkipInProcess: PoisonItemException → failure_type='SKIP' ────────────────────────────
+
+    @Test
+    void onSkipInProcess_poison_insertsSkipDeadLetter() {
+        HarvestRow row = new HarvestRow(1L, "bad-payload", true, 0, false);
+        PoisonItemException ex = new PoisonItemException(1L);
+
+        skipListener.onSkipInProcess(row, ex);
+
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 1");
+        assertThat(rows).hasSize(1);
+        Map<String, Object> dl = rows.get(0);
+        assertThat(dl.get("failure_type")).isEqualTo("SKIP");
+        assertThat(dl.get("failure_phase")).isEqualTo("PROCESS");
+        assertThat(dl.get("source_id")).isEqualTo(1L);
+        assertThat(dl.get("job_execution_id")).isEqualTo(42L);
+        assertThat(dl.get("attempt_count")).isEqualTo(1);
+        assertThat(dl.get("exception_class")).isEqualTo(PoisonItemException.class.getName());
+    }
+
+    // ── onSkipInProcess: TransientProcessingException → failure_type='RETRY_EXHAUSTED' ────────
+
+    @Test
+    void onSkipInProcess_transient_insertsRetryExhaustedDeadLetter() {
+        HarvestRow row = new HarvestRow(2L, "transient-payload", false, 10, false);
+        TransientProcessingException ex = new TransientProcessingException(2L, 3, 10);
+
+        skipListener.onSkipInProcess(row, ex);
+
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 2");
+        assertThat(rows).hasSize(1);
+        Map<String, Object> dl = rows.get(0);
+        assertThat(dl.get("failure_type")).isEqualTo("RETRY_EXHAUSTED");
+        assertThat(dl.get("failure_phase")).isEqualTo("PROCESS");
+        assertThat(dl.get("attempt_count")).isEqualTo(4); // retryLimit(3) + 1
+        assertThat(dl.get("exception_class")).isEqualTo(TransientProcessingException.class.getName());
+    }
+
+    // ── REQUIRES_NEW independence: dead-letter survives outer rollback ────────────────────────
+
+    @Test
+    void onSkipInProcess_deadLetterSurvivesOuterRollback() {
+        HarvestRow row = new HarvestRow(3L, "rollback-test", true, 0, false);
+        PoisonItemException ex = new PoisonItemException(3L);
+
+        // Simulate an outer transaction that will roll back
+        TransactionTemplate outerTx = new TransactionTemplate(txManager);
+        try {
+            outerTx.execute(status -> {
+                // Inside a transaction that will be rolled back
+                skipListener.onSkipInProcess(row, ex); // this commits independently under REQUIRES_NEW
+                status.setRollbackOnly(); // force outer rollback
+                return null;
+            });
+        } catch (Exception ignored) {
+            // Outer transaction rolled back — expected
+        }
+
+        // Dead-letter record MUST still be present (committed under REQUIRES_NEW)
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM harvest_dead_letter WHERE source_id = 3",
+                Integer.class);
+        assertThat(count).isEqualTo(1);
+    }
+
+    // ── Unwrapping: wrapped exception still resolves correct failure_type ─────────────────────
+
+    @Test
+    void onSkipInProcess_wrappedPoisonException_unwrapsCorrectly() {
+        HarvestRow row = new HarvestRow(4L, "wrapped", true, 0, false);
+        // Wrapped in a generic RuntimeException
+        RuntimeException wrapped = new RuntimeException("wrapper", new PoisonItemException(4L));
+
+        skipListener.onSkipInProcess(row, wrapped);
+
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT * FROM harvest_dead_letter WHERE source_id = 4");
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).get("failure_type")).isEqualTo("SKIP");
+        // The recorded exception_class is the inner PoisonItemException
+        assertThat(rows.get(0).get("exception_class"))
+                .isEqualTo(PoisonItemException.class.getName());
+    }
+}


### PR DESCRIPTION
## What — PR #2 of 3 (chained, stacked-to-main)

The **fault-tolerance core** of the `fault-tolerant-harvester` plugin. Builds on the merged schema+scaffold (PR #51). The restart demonstration + README land in PR #3.

This is the heart of Spring Batch: **skip → dead-letter**, **retry + exponential backoff**, all wired in a single fault-tolerant chunk step.

## How

`configureJob` (stub replaced) builds one fault-tolerant chunk step:

```
.faultTolerant()
  .skipLimit(5).skip(PoisonItemException).skip(TransientProcessingException).noSkip(AbortJobException)
  .retryLimit(3).retry(TransientProcessingException).noRetry(PoisonItemException)
  .backOffPolicy(exponentialBackOff)
  .listener(skipListener).listener(retryListener)
```

- **Reader** — `JdbcCursorItemReader` over `harvest_source WHERE processed = FALSE`, `setSaveState(true)` (needed for PR #3 restart).
- **Processor** — deterministic, table-driven failures: `poison_flag` → skippable `PoisonItemException`; `transient_fail_until_attempt` → retryable `TransientProcessingException` while the **Spring Batch retry count** is below the threshold (R4: a FIXED threshold compared to the retry count — the row is never mutated, so a chunk rollback can't corrupt retry state). `RetrySynchronizationManager.getContext().getRetryCount()` is confirmed populated inside the SB6 fault-tolerant item processor; a deterministic in-memory fallback is present and tested.
- **Writer** — idempotent `UPDATE harvest_source SET processed = TRUE WHERE id = ? AND processed = FALSE` (restart-safe no-op on already-processed rows).
- **SkipListener → dead-letter** — inserts into `harvest_dead_letter` via a `TransactionTemplate` with `PROPAGATION_REQUIRES_NEW`, so the audit record **commits independently** and survives the failed item's rollback. `failure_type` distinguishes `SKIP` (poison) from `RETRY_EXHAUSTED` (transient after retries).
- **RetryListener** — logs attempts/backoff for pedagogical visibility.

## Tests
- `fault-tolerant-harvester-job`: **41** (31 unit + 10 integration on isolated H2 `DB_CLOSE_DELAY=-1`): happy path, skip→dead-letter, skip-limit-exceeded, retry-success (3 threshold variants), retry-exhausted, REQUIRES_NEW independence.
- `fr-batch-service`: **123** (unchanged).

## Notes (carried to PR #3 doc/polish pass)
- An IT named `deadLetterSurvivesChunkRollback` is better named for "persists after completion" — SB6 scan-mode replays item-by-item rather than rolling back the whole chunk; the authoritative REQUIRES_NEW rollback proof is the unit test that forces `setRollbackOnly()`.
- `attempt_count` stores total attempts (retryLimit + 1) — to be clarified in the README.
- Add a length guard on `exception_msg` (VARCHAR(2048)) before this ships in PR #3.
