### PR TITLE
feat(fault-tolerant-harvester): restartability demo + README (PR 3/3)

### DIFF
--- a/fault-tolerant-harvester-job/README.md
+++ b/fault-tolerant-harvester-job/README.md
@@ -1,0 +1,225 @@
+# fault-tolerant-harvester-job
+
+Spring Batch plugin demonstrating a fault-tolerant chunk step: skip-to-dead-letter,
+retry with exponential backoff, transaction-independent dead-letter auditing
+(`PROPAGATION_REQUIRES_NEW`), and true job restart. Delivered as a standalone shaded JAR
+and loaded dynamically by the `fr-batch-service` host.
+
+## Purpose
+
+This module is a pedagogical showcase of Spring Batch 6 fault-tolerance primitives:
+
+| Scenario | Mechanism |
+|---|---|
+| Poison input (permanent failure) | `skip()` → `HarvestSkipListener` writes dead-letter row |
+| Transient failure (recoverable) | `retry()` with `ExponentialBackOffPolicy` |
+| Retry exhaustion | Item becomes a skip → dead-letter with `failure_type='RETRY_EXHAUSTED'` |
+| Skip budget overflow | `skipLimit` breached → `BatchStatus.FAILED` |
+| Abort (non-skippable) | `AbortJobException` → `noSkip()` + `noRetry()` → immediate step failure |
+| Dead-letter isolation | `PROPAGATION_REQUIRES_NEW` → audit row survives chunk rollback |
+| Restart | `setSaveState(true)` on reader → cursor fast-forwards on identical-param relaunch |
+
+## Job parameters
+
+| Parameter        | Required | Identifying | Description |
+|------------------|----------|-------------|-------------|
+| `DATE`           | Yes      | Yes         | Processing date in `yyyy-MM-dd` format. Validated fail-fast by `HarvestJobParametersValidator` before any step runs. |
+| `ATTEMPT_NUMBER` | No       | Yes         | Attempt counter supplied by the host. **See the restart pitfall below.** |
+| `DESCRIPTION`    | No       | No          | Informational only; not validated. |
+
+Parameters are validated fail-fast by `HarvestJobParametersValidator` (implements
+`JobParametersValidator`). Missing or unparseable `DATE` throws
+`InvalidJobParametersException` before any step executes.
+
+## Fault-tolerant step configuration
+
+Single chunk step `harvestStep` (chunk size = 5):
+
+```
+Reader   : JdbcCursorItemReader on harvest_source ORDER BY id
+           setSaveState(true) — persists currentItemCount to BATCH_STEP_EXECUTION_CONTEXT
+Processor: HarvestItemProcessor — abort / poison / transient threshold logic
+Writer   : HarvestItemWriter — idempotent UPDATE ... WHERE processed = FALSE
+```
+
+Fault-tolerance parameters:
+
+| Setting | Value |
+|---|---|
+| `skipLimit` | 5 |
+| Skippable | `PoisonItemException`, `TransientProcessingException` (after retry exhaustion) |
+| Non-skippable | `AbortJobException` |
+| `retryLimit` | 3 |
+| Retryable | `TransientProcessingException` |
+| Non-retryable | `PoisonItemException` |
+| Backoff | `ExponentialBackOffPolicy` (initial 10 ms, multiplier 2.0, max 100 ms) |
+
+Listeners:
+
+- `HarvestSkipListener` — writes `harvest_dead_letter` rows under `PROPAGATION_REQUIRES_NEW`
+- `HarvestRetryListener` — logs each retry attempt for pedagogical backoff visibility
+
+## How rows drive behaviour
+
+Rows in `harvest_source` control which fault-tolerance path is exercised:
+
+| Column | Value | Effect |
+|---|---|---|
+| `poison_flag` | `TRUE` | Processor throws `PoisonItemException` → skipped, dead-lettered (`failure_type='SKIP'`) |
+| `transient_fail_until_attempt` | `N > 0` | Processor throws `TransientProcessingException` while retry count < N; succeeds at N |
+| `abort_flag` | `TRUE` | Processor throws `AbortJobException` → non-skippable, non-retryable → step FAILS |
+| All flags | `FALSE`, threshold `0` | Normal row: passes processor, writer marks `processed=TRUE` |
+
+`transient_fail_until_attempt` is a **read-only threshold** — it is never mutated at runtime.
+The processor reads the in-flight Spring Batch retry count (via
+`RetrySynchronizationManager.getContext().getRetryCount()`) and compares it to the threshold.
+Chunk rollbacks cannot corrupt this value because the source row is never written.
+
+## Schema
+
+### `harvest_source`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT AUTO_INCREMENT PK` | |
+| `payload` | `VARCHAR(2048) NOT NULL` | Arbitrary payload string |
+| `poison_flag` | `BOOLEAN NOT NULL DEFAULT FALSE` | Permanent failure trigger |
+| `transient_fail_until_attempt` | `INT NOT NULL DEFAULT 0` | Retry threshold (read-only) |
+| `abort_flag` | `BOOLEAN NOT NULL DEFAULT FALSE` | Non-skippable abort trigger for restart demo |
+| `processed` | `BOOLEAN NOT NULL DEFAULT FALSE` | Set to `TRUE` by the writer (idempotent) |
+| `created_at` | `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` | |
+
+### `harvest_dead_letter`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT AUTO_INCREMENT PK` | |
+| `source_id` | `BIGINT NULL` | Soft reference to `harvest_source.id` (no FK — audit rows survive source purge) |
+| `raw_payload` | `VARCHAR(2048) NULL` | Payload at skip time (`NULL` for read-skips) |
+| `failure_phase` | `VARCHAR(16) NOT NULL` | `READ`, `PROCESS`, or `WRITE` |
+| `failure_type` | `VARCHAR(16) NOT NULL` | `SKIP` or `RETRY_EXHAUSTED` |
+| `exception_class` | `VARCHAR(512) NOT NULL` | Fully-qualified exception class name |
+| `exception_msg` | `VARCHAR(2048) NULL` | Exception message, truncated to 2048 chars |
+| `attempt_count` | `INT NOT NULL DEFAULT 1` | See "attempt_count semantics" below |
+| `job_execution_id` | `BIGINT NOT NULL` | `BATCH_JOB_EXECUTION.id` for the run that produced the record |
+| `recorded_at` | `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` | |
+
+Created by Flyway migration `V7__fault_tolerant_harvester_tables.sql`.
+
+### attempt_count semantics
+
+For `SKIP` items the value is always `1` (a single attempt was made).
+
+For `RETRY_EXHAUSTED` items the value is `retryLimit + 1 = 4` — this represents the TOTAL
+number of processing calls: 1 initial attempt plus 3 retries. The stored value is greater by 1
+than the raw `retryLimit` constant because total-calls is a more useful diagnostic than the
+configuration value alone.
+
+## Restart pitfall — ATTEMPT_NUMBER is identifying
+
+> **CRITICAL**: the host (`JobsManagerService`) launches with `DATE` + `ATTEMPT_NUMBER` as
+> identifying parameters and uses **no `RunIdIncrementer`**.
+
+This means:
+
+- `DATE=2026-01-01, ATTEMPT_NUMBER=1` → creates `JobInstance #A`
+- Re-submitting `DATE=2026-01-01, ATTEMPT_NUMBER=1` (IDENTICAL) → Spring Batch finds the
+  existing `FAILED` `JobExecution` for `JobInstance #A` and **restarts** it from the last
+  committed chunk offset.
+- **Incrementing** `ATTEMPT_NUMBER`: `DATE=2026-01-01, ATTEMPT_NUMBER=2` → creates a brand-new
+  `JobInstance #B` and runs from row 1 — this is a **fresh run, NOT a restart**.
+
+A true restart requires submitting the **same `DATE` and the same `ATTEMPT_NUMBER`** that the
+failed run used. The host operator must know which attempt number failed and resubmit that
+exact number. Incrementing the attempt counter to "try again" defeats the restart mechanism
+entirely.
+
+The restart mechanism itself is driven by `setSaveState(true)` on the reader: after each chunk
+commit, Spring Batch serialises the cursor's `currentItemCount` into
+`BATCH_STEP_EXECUTION_CONTEXT`. On restart, the reader reopens the cursor from row 1 and
+fast-forwards by skipping the first `currentItemCount` rows — so only uncommitted rows are
+reprocessed. The writer's `WHERE processed = FALSE` guard provides additional idempotency in
+case a boundary row is redelivered.
+
+Note: the reader SQL reads **all** rows (`SELECT … FROM harvest_source ORDER BY id` with no
+`processed = FALSE` filter). Filtering by `processed` would shrink the result set on restart
+and cause the count-based skip-ahead to land on the wrong row.
+
+## Building the fat JAR
+
+Requires Maven and a GitHub Packages token (the `batch-job-api` dependency is hosted there).
+
+Configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then build:
+
+```bash
+mvn -B package -f fault-tolerant-harvester-job/pom.xml
+```
+
+The shaded JAR is produced at
+`fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar`. The shaded JAR
+includes only plugin classes and `spring-retry`; all Spring Batch / Spring Framework / SLF4J
+dependencies are `provided` and excluded from the shade. Approximate JAR size: < 100 KB.
+
+## Running via the REST API
+
+### 1. Upload the JAR
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/upload \
+  -F "file=@fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar" \
+  -F "jobName=fault-tolerant-harvester-job" \
+  -F "version=1.0.0" \
+  -F "mainClassName=com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin"
+```
+
+### 2. Run the job
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "fault-tolerant-harvester-job",
+    "params": {
+      "DATE": "2026-01-01",
+      "ATTEMPT_NUMBER": "1"
+    }
+  }'
+```
+
+### 3. Restart after a failure (identical params)
+
+```bash
+# Use the SAME DATE and ATTEMPT_NUMBER as the failed run:
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "fault-tolerant-harvester-job",
+    "params": {
+      "DATE": "2026-01-01",
+      "ATTEMPT_NUMBER": "1"
+    }
+  }'
+```
+
+Spring Batch will detect the existing `FAILED` execution, resume from the last committed
+chunk, and complete without reprocessing already-committed rows.
+
+## Schema dependency
+
+This plugin requires the `harvest_source` and `harvest_dead_letter` tables from Flyway
+migration `V7__fault_tolerant_harvester_tables.sql`. Ensure the host has run at least V7
+before loading this plugin.

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/FaultTolerantHarvesterJobPlugin.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/FaultTolerantHarvesterJobPlugin.java
@@ -75,15 +75,24 @@ public class FaultTolerantHarvesterJobPlugin implements BatchJobPlugin {
     static final int RETRY_LIMIT = 3;
 
     /**
-     * Reader SQL: selects unprocessed rows in id order.
-     * The {@code WHERE processed = FALSE} filter is belt-and-suspenders idempotency;
-     * restart resumption is driven by the saved {@code currentItemCount} in
-     * {@code BATCH_STEP_EXECUTION_CONTEXT} (enabled by {@code setSaveState(true)}).
+     * Reader SQL: selects ALL rows in id order (no {@code processed = FALSE} filter).
+     *
+     * <p><b>Why no processed filter:</b> {@code JdbcCursorItemReader} with
+     * {@code setSaveState(true)} persists {@code currentItemCount} to
+     * {@code BATCH_STEP_EXECUTION_CONTEXT} on every chunk commit. On restart, the reader
+     * re-opens the cursor and fast-forwards by skipping the first {@code currentItemCount}
+     * rows. If the SQL filtered by {@code processed = FALSE}, the result set on restart
+     * would be smaller (already-committed rows disappeared), and the cursor skip-ahead would
+     * land on the wrong row — effectively skipping unprocessed rows. Reading ALL rows means
+     * the result set is stable across both launches and the count-based skip-ahead works
+     * correctly.
+     *
+     * <p>Idempotency for already-processed rows on restart is handled entirely by the writer's
+     * {@code UPDATE … WHERE processed = FALSE} guard — a no-op for rows already committed.
      */
     private static final String READER_SQL =
             "SELECT id, payload, poison_flag, transient_fail_until_attempt, abort_flag"
                     + " FROM harvest_source"
-                    + " WHERE processed = FALSE"
                     + " ORDER BY id";
 
     @Override

--- a/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestSkipListener.java
+++ b/fault-tolerant-harvester-job/src/main/java/com/fronzec/plugins/harvester/batch/HarvestSkipListener.java
@@ -33,8 +33,18 @@ import org.springframework.transaction.support.TransactionTemplate;
  * </ul>
  *
  * <h3>attempt_count</h3>
- * <p>For {@code RETRY_EXHAUSTED} the attempt count is set to {@code retryLimit + 1}
- * (representing the total calls: initial + retries). For skips without retry the count is 1.
+ * <p>For {@code RETRY_EXHAUSTED} the stored {@code attempt_count} is {@code RETRY_LIMIT + 1 = 4},
+ * representing the TOTAL number of processing calls: 1 initial attempt + 3 retries = 4 total.
+ * This is intentional — total calls is more useful for diagnostics than the raw retry-limit constant.
+ * For {@code SKIP} items (no retry) the count is always 1.
+ * See also the README "attempt_count semantics" note.
+ *
+ * <h3>exception_msg truncation</h3>
+ * <p>The {@code exception_msg} value is truncated to 2048 characters before insertion to guard
+ * against column overflow on MySQL (VARCHAR(2048)) when non-domain exceptions (e.g. JDBC errors
+ * with verbose messages) reach the skip listener via {@code onSkipInRead}. Domain exceptions
+ * ({@link PoisonItemException}, {@link TransientProcessingException}) have bounded messages and
+ * will never approach the limit, but defensive truncation is applied uniformly.
  *
  * <h3>job_execution_id</h3>
  * <p>Captured via {@link #setJobExecutionId(long)} called from
@@ -47,9 +57,17 @@ public class HarvestSkipListener implements SkipListener<HarvestRow, HarvestRow>
 
     /**
      * Number of retries configured on the step (retryLimit=3). Used to compute attempt_count
-     * for RETRY_EXHAUSTED entries (total calls = retryLimit + 1).
+     * for RETRY_EXHAUSTED entries (total calls = retryLimit + 1 = 4).
      */
     private static final int RETRY_LIMIT = 3;
+
+    /**
+     * Maximum length of {@code exception_msg} stored in harvest_dead_letter.
+     * Matches the MySQL column definition (VARCHAR(2048)). Messages longer than this are
+     * truncated to avoid column-overflow exceptions on verbose non-domain exceptions
+     * (e.g. JDBC errors in onSkipInRead).
+     */
+    private static final int MAX_MSG_LENGTH = 2048;
 
     private static final String INSERT_SQL =
             "INSERT INTO harvest_dead_letter"
@@ -145,7 +163,7 @@ public class HarvestSkipListener implements SkipListener<HarvestRow, HarvestRow>
                     "READ",
                     failureType,
                     cause.getClass().getName(),
-                    cause.getMessage(),
+                    truncateMsg(cause.getMessage()),         // guard: VARCHAR(2048)
                     attemptCount,
                     jobExecutionId,
                     Timestamp.from(Instant.now()));
@@ -195,7 +213,7 @@ public class HarvestSkipListener implements SkipListener<HarvestRow, HarvestRow>
                     failurePhase,
                     failureType,
                     cause.getClass().getName(),
-                    cause.getMessage(),
+                    truncateMsg(cause.getMessage()),         // guard: VARCHAR(2048)
                     attemptCount,
                     jobExecutionId,
                     Timestamp.from(Instant.now()));
@@ -219,5 +237,20 @@ public class HarvestSkipListener implements SkipListener<HarvestRow, HarvestRow>
         }
         Throwable cause = throwable.getCause();
         return (cause != null) ? cause : throwable;
+    }
+
+    /**
+     * Truncates a string to {@link #MAX_MSG_LENGTH} to prevent column-overflow on MySQL
+     * VARCHAR(2048) when verbose non-domain exception messages reach the dead-letter insert.
+     *
+     * @param msg the raw message string; may be null
+     * @return the original string if its length is within the limit, a truncated substring
+     *         otherwise; null is returned unchanged
+     */
+    static String truncateMsg(String msg) {
+        if (msg == null || msg.length() <= MAX_MSG_LENGTH) {
+            return msg;
+        }
+        return msg.substring(0, MAX_MSG_LENGTH);
     }
 }

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterJobIntegrationTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterJobIntegrationTest.java
@@ -366,11 +366,23 @@ class FaultTolerantHarvesterJobIntegrationTest {
 
     // ── Dead-letter REQUIRES_NEW independence ─────────────────────────────────────────────────
 
+    /**
+     * Verifies that the dead-letter record persists after job completion for a poison row.
+     *
+     * <p><b>Note on naming (W-01 / S-02 fix):</b> this test was originally named
+     * {@code deadLetterSurvivesChunkRollback}, but SB6 fault-tolerant scan mode processes
+     * items individually after a skip — it does NOT roll back the whole chunk for a single
+     * skipped item. What this test actually proves is that the dead-letter record committed
+     * independently via REQUIRES_NEW and is visible after job completion.
+     *
+     * <p>The authoritative proof that the REQUIRES_NEW transaction survives a FORCED outer
+     * rollback is in {@link HarvestSkipListenerTest#onSkipInProcess_deadLetterSurvivesOuterRollback}.
+     */
     @Test
-    void deadLetterSurvivesChunkRollback() throws Exception {
-        // Chunk 1 (ids 80-84): id 82 is poison — will be skipped and dead-lettered.
-        // The remaining rows in the chunk succeed, so the chunk commits.
-        // What we're verifying here is simply that the dead-letter record exists after job completion.
+    void deadLetterPersistsAfterJobCompletion() throws Exception {
+        // Chunk 1 (ids 80-84): id 82 is poison — will be skipped and dead-lettered via REQUIRES_NEW.
+        // SB6 scan mode processes this chunk item-by-item; the chunk itself does NOT roll back.
+        // This test verifies the dead-letter record is present after job completion.
         insertNormalRow(80L);
         insertNormalRow(81L);
         insertPoisonRow(82L);
@@ -381,7 +393,7 @@ class FaultTolerantHarvesterJobIntegrationTest {
 
         assertThat(status).isEqualTo(BatchStatus.COMPLETED);
 
-        // Dead-letter row persisted (REQUIRES_NEW committed independently)
+        // Dead-letter row committed independently under REQUIRES_NEW and visible after completion
         assertThat(deadLetterCount()).isEqualTo(1);
         List<Map<String, Object>> dlRows = jdbc.queryForList(
                 "SELECT * FROM harvest_dead_letter WHERE source_id = 82");

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterRestartIntegrationTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/FaultTolerantHarvesterRestartIntegrationTest.java
@@ -1,0 +1,344 @@
+package com.fronzec.plugins.harvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Integration test demonstrating Spring Batch true restart behaviour for
+ * {@link FaultTolerantHarvesterJobPlugin} (spec FTH-08).
+ *
+ * <h3>Restart scenario (FTH-08-A)</h3>
+ * <ol>
+ *   <li><b>Seed</b>: 10 rows in {@code harvest_source}. Rows 1–5 are normal. Row 6 has
+ *       {@code abort_flag=TRUE} — the "poison input" that aborts the job. Rows 7–10 are
+ *       normal.</li>
+ *   <li><b>Run 1</b>: launched with identifying params {@code DATE="2026-01-01"} and
+ *       {@code ATTEMPT_NUMBER="1"}. Chunk 1 (rows 1–5) commits successfully
+ *       ({@code processed=TRUE}). Row 6 triggers {@link AbortJobException} — non-skippable,
+ *       non-retryable — so the step fails and the job ends with {@code BatchStatus.FAILED}.
+ *       Rows 7–10 remain {@code processed=FALSE}.</li>
+ *   <li><b>Operator fix</b>: the abort row is "repaired" by clearing its
+ *       {@code abort_flag} to {@code FALSE}. This simulates the real-world workflow:
+ *       fix the bad input, then restart the job.</li>
+ *   <li><b>Run 2</b>: re-launched with <em>identical</em> params
+ *       ({@code DATE="2026-01-01"}, {@code ATTEMPT_NUMBER="1"}). Spring Batch detects the
+ *       existing {@code FAILED} execution for the same {@code JobInstance} and resumes from
+ *       the last committed chunk offset — the reader fast-forwards past rows 1–5 using the
+ *       saved {@code currentItemCount} in {@code BATCH_STEP_EXECUTION_CONTEXT}. Rows 6–10
+ *       are processed; the job ends with {@code BatchStatus.COMPLETED}.</li>
+ * </ol>
+ *
+ * <h3>Key assertions</h3>
+ * <ul>
+ *   <li>{@code BATCH_JOB_EXECUTION} has exactly 2 rows sharing one {@code JOB_INSTANCE_ID}.</li>
+ *   <li>Rows 1–5 are {@code processed=TRUE} after both runs (committed in chunk 1 of run 1).</li>
+ *   <li>Rows 1–5 are NOT reprocessed by run 2 (idempotent writer + reader fast-forward).</li>
+ *   <li>Rows 6–10 are {@code processed=TRUE} after run 2.</li>
+ *   <li>No dead-letter rows exist (row 6's abort was cleared before run 2).</li>
+ * </ul>
+ *
+ * <h3>Why same-JVM restart works here</h3>
+ * <p>The H2 URL uses {@code DB_CLOSE_DELAY=-1}, which keeps the in-memory database alive for
+ * the duration of the JVM process. Both launches share the same {@link DataSource},
+ * {@link JobRepository}, and {@link StaticApplicationContext}, so Spring Batch metadata
+ * persists between runs. Only the {@link Job} instance (returned by
+ * {@link FaultTolerantHarvesterJobPlugin#configureJob}) is re-created for each launch — this
+ * is the same pattern used in production where the same plugin JAR services multiple launches.
+ *
+ * <h3>Restart pitfall</h3>
+ * <p>A true restart requires IDENTICAL identifying parameters ({@code DATE} +
+ * {@code ATTEMPT_NUMBER}). Incrementing {@code ATTEMPT_NUMBER} would create a NEW
+ * {@code JobInstance}, triggering a fresh run from row 1 — not a restart. See also the
+ * module README for the full explanation of this pitfall.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FaultTolerantHarvesterRestartIntegrationTest {
+
+    /**
+     * Fixed identifying job parameters. Both launches use the same values so Spring Batch
+     * finds the existing FAILED JobExecution on the second launch and restarts rather than
+     * creating a new JobInstance.
+     */
+    private static final String DATE_PARAM = "2026-01-01";
+    private static final String ATTEMPT_PARAM = "1";
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private StaticApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        // DB_CLOSE_DELAY=-1 keeps the in-memory database alive for the entire JVM lifetime,
+        // which is required for Spring Batch metadata to survive BOTH launches in one JVM.
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:harvest-restart-it-"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Bootstrap Spring Batch metadata schema (BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION, …)
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Create application tables
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_source ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " payload VARCHAR(2048) NOT NULL,"
+                        + " poison_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " transient_fail_until_attempt INT NOT NULL DEFAULT 0,"
+                        + " abort_flag BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " processed BOOLEAN NOT NULL DEFAULT FALSE,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS harvest_dead_letter ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " source_id BIGINT NULL,"
+                        + " raw_payload VARCHAR(2048) NULL,"
+                        + " failure_phase VARCHAR(16) NOT NULL,"
+                        + " failure_type VARCHAR(16) NOT NULL,"
+                        + " exception_class VARCHAR(512) NOT NULL,"
+                        + " exception_msg VARCHAR(2048) NULL,"
+                        + " attempt_count INT NOT NULL DEFAULT 1,"
+                        + " job_execution_id BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        // Bootstrap a single shared JobRepository — metadata persists between both launches
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub application context exposing only the DataSource (mirrors existing IT pattern)
+        stubContext = new StaticApplicationContext();
+        stubContext.getBeanFactory().registerSingleton("dataSource", ds);
+        stubContext.refresh();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────────────────
+
+    private void insertNormalRow(long id) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag,"
+                        + " transient_fail_until_attempt, abort_flag, processed)"
+                        + " VALUES (?, ?, FALSE, 0, FALSE, FALSE)",
+                id, "payload-" + id);
+    }
+
+    private void insertAbortRow(long id) {
+        jdbc.update(
+                "INSERT INTO harvest_source (id, payload, poison_flag,"
+                        + " transient_fail_until_attempt, abort_flag, processed)"
+                        + " VALUES (?, ?, FALSE, 0, TRUE, FALSE)",
+                id, "abort-row-" + id);
+    }
+
+    private boolean isProcessed(long id) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT processed FROM harvest_source WHERE id = ?", Boolean.class, id);
+        return Boolean.TRUE.equals(result);
+    }
+
+    private int deadLetterCount() {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM harvest_dead_letter", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    /**
+     * Launches the job with the fixed identifying parameters.
+     *
+     * <p>A new {@link Job} instance is built each time (matching production behaviour where
+     * the plugin is re-loaded), but the {@link JobRepository} and {@link DataSource} are shared
+     * so Spring Batch can find the existing FAILED execution on the second call.
+     *
+     * @return the final {@link BatchStatus} of the execution
+     */
+    private BatchStatus launchJob() throws Exception {
+        FaultTolerantHarvesterJobPlugin plugin = new FaultTolerantHarvesterJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("DATE", DATE_PARAM)
+                .addString("ATTEMPT_NUMBER", ATTEMPT_PARAM)
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        return execution.getStatus();
+    }
+
+    // ── FTH-08-A: Resume after mid-job abort ──────────────────────────────────────────────────
+
+    /**
+     * Proves that re-launching with identical job parameters resumes from the last committed
+     * chunk rather than reprocessing the entire dataset from scratch.
+     *
+     * <p>Data layout:
+     * <pre>
+     *   id  1-5  : normal rows  → processed in chunk 1 of run 1
+     *   id  6    : abort_flag=TRUE → triggers AbortJobException → job FAILS (run 1)
+     *   id  7-10 : normal rows  → NOT reached in run 1
+     * </pre>
+     *
+     * <p>After clearing {@code abort_flag} on id 6, re-launching with the same params causes
+     * Spring Batch to detect the FAILED JobExecution and restart the step. The reader
+     * fast-forwards past rows 1-5 (saved {@code currentItemCount} in
+     * {@code BATCH_STEP_EXECUTION_CONTEXT}). Rows 6-10 are processed; job COMPLETES.
+     *
+     * <p>Idempotency is confirmed: rows 1-5 are already {@code processed=TRUE} from run 1 and
+     * the writer's {@code WHERE processed = FALSE} guard ensures they are not touched in run 2.
+     */
+    @Test
+    void restart_afterAbortOnRow6_resumesFromChunk2AndCompletes() throws Exception {
+        // ── Seed ──────────────────────────────────────────────────────────────────────────────
+        // Normal rows fill chunk 1 (ids 1-5, chunkSize=5)
+        for (long i = 1L; i <= 5L; i++) {
+            insertNormalRow(i);
+        }
+        // Row 6 has abort_flag=TRUE — positioned at the START of chunk 2 so chunk 1 always
+        // commits cleanly before the AbortJobException is thrown.
+        insertAbortRow(6L);
+        // Normal rows following the abort row
+        for (long i = 7L; i <= 10L; i++) {
+            insertNormalRow(i);
+        }
+
+        // ── Run 1: FAIL ───────────────────────────────────────────────────────────────────────
+        BatchStatus run1Status = launchJob();
+
+        assertThat(run1Status)
+                .as("Run 1 must fail because abort_flag=TRUE on row 6 throws AbortJobException")
+                .isEqualTo(BatchStatus.FAILED);
+
+        // Chunk 1 (rows 1-5) committed before the abort row was encountered
+        for (long i = 1L; i <= 5L; i++) {
+            assertThat(isProcessed(i))
+                    .as("Row %d should be processed=TRUE after chunk 1 committed in run 1", i)
+                    .isTrue();
+        }
+        // Row 6 itself was not written (AbortJobException prevented the writer from running)
+        assertThat(isProcessed(6L))
+                .as("Abort row 6 must not be processed=TRUE (step failed before writer)")
+                .isFalse();
+        // Rows 7-10 were never reached
+        for (long i = 7L; i <= 10L; i++) {
+            assertThat(isProcessed(i))
+                    .as("Row %d should not be processed=TRUE (not reached in run 1)", i)
+                    .isFalse();
+        }
+
+        // ── Operator fix: clear the abort trigger ─────────────────────────────────────────────
+        // In production this simulates the operator removing or correcting the bad input row
+        // before requesting a restart. The row is now a normal processable row.
+        jdbc.update("UPDATE harvest_source SET abort_flag = FALSE WHERE id = 6");
+
+        // Count how many times rows 1-5 were written before the restart (must stay at 1 each)
+        // We can verify this indirectly: processed=TRUE rows will not be re-updated by the
+        // idempotent writer (UPDATE ... WHERE processed = FALSE), so their count in the writer
+        // stays at exactly 1 across both runs.
+
+        // ── Run 2: RESTART with identical parameters ──────────────────────────────────────────
+        // Spring Batch sees the existing FAILED JobExecution for these exact params, finds
+        // the same JobInstance, and restarts the step from the saved reader offset.
+        BatchStatus run2Status = launchJob();
+
+        assertThat(run2Status)
+                .as("Run 2 must complete after the abort trigger is cleared")
+                .isEqualTo(BatchStatus.COMPLETED);
+
+        // All rows must be processed after run 2
+        for (long i = 1L; i <= 10L; i++) {
+            assertThat(isProcessed(i))
+                    .as("Row %d must be processed=TRUE after successful restart", i)
+                    .isTrue();
+        }
+
+        // No dead-letter rows — abort raises AbortJobException (not skippable), and row 6
+        // was fixed before run 2, so no skip/retry-exhaustion occurred.
+        assertThat(deadLetterCount())
+                .as("No dead-letter rows expected (AbortJobException is not skippable)")
+                .isZero();
+
+        // ── Spring Batch metadata: 2 executions, 1 JobInstance ───────────────────────────────
+        // This is the definitive proof that run 2 was a RESTART and not a fresh run.
+        List<Map<String, Object>> executions = jdbc.queryForList(
+                "SELECT * FROM BATCH_JOB_EXECUTION ORDER BY JOB_EXECUTION_ID");
+        assertThat(executions)
+                .as("Exactly 2 JobExecutions must exist (run 1 FAILED + run 2 COMPLETED)")
+                .hasSize(2);
+
+        Long instanceId1 = (Long) executions.get(0).get("JOB_INSTANCE_ID");
+        Long instanceId2 = (Long) executions.get(1).get("JOB_INSTANCE_ID");
+        assertThat(instanceId1)
+                .as("Both executions must share the same JobInstance (same identifying params)")
+                .isEqualTo(instanceId2);
+
+        // run 1 status is stored as 'FAILED' in the metadata
+        assertThat(executions.get(0).get("STATUS"))
+                .as("First execution status must be FAILED in BATCH_JOB_EXECUTION")
+                .isEqualTo("FAILED");
+
+        // run 2 status is stored as 'COMPLETED' in the metadata
+        assertThat(executions.get(1).get("STATUS"))
+                .as("Second execution status must be COMPLETED in BATCH_JOB_EXECUTION")
+                .isEqualTo("COMPLETED");
+
+        // ── Confirm rows 1-5 were NOT reprocessed by run 2 ───────────────────────────────────
+        // The write count for already-processed rows should be 0 in run 2.
+        // We verify this via the step execution context: the read count in run 2 should
+        // be <= 5 (rows 6-10) if the reader fast-forwarded past rows 1-5.
+        //
+        // Read the step execution for run 2 and check READ_COUNT.
+        // chunkSize=5, rows resumed from offset 5 → rows 6-10 = 5 rows read in run 2.
+        Long run2ExecutionId = (Long) executions.get(1).get("JOB_EXECUTION_ID");
+        List<Map<String, Object>> stepExecs = jdbc.queryForList(
+                "SELECT * FROM BATCH_STEP_EXECUTION WHERE JOB_EXECUTION_ID = ?",
+                run2ExecutionId);
+        assertThat(stepExecs).hasSize(1);
+        // READ_COUNT in run 2 must be 5 (rows 6-10), not 10 (all rows from scratch).
+        // This proves the reader fast-forwarded past the 5 already-committed rows.
+        Object readCount = stepExecs.get(0).get("READ_COUNT");
+        assertThat(((Number) readCount).intValue())
+                .as("Run 2 should read only rows 6-10 (5 items), not restart from row 1")
+                .isEqualTo(5);
+    }
+}

--- a/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestSkipListenerTest.java
+++ b/fault-tolerant-harvester-job/src/test/java/com/fronzec/plugins/harvester/batch/HarvestSkipListenerTest.java
@@ -130,6 +130,44 @@ class HarvestSkipListenerTest {
         assertThat(count).isEqualTo(1);
     }
 
+    // ── exception_msg truncation guard (S-01) ─────────────────────────────────────────────────
+
+    @Test
+    void truncateMsg_longMessage_isTruncatedTo2048Chars() {
+        // Build a string longer than 2048 chars
+        String overLong = "x".repeat(3000);
+        String result = HarvestSkipListener.truncateMsg(overLong);
+        assertThat(result).hasSize(2048);
+    }
+
+    @Test
+    void truncateMsg_shortMessage_isReturnedUnchanged() {
+        String msg = "short message";
+        assertThat(HarvestSkipListener.truncateMsg(msg)).isSameAs(msg);
+    }
+
+    @Test
+    void truncateMsg_null_isReturnedAsNull() {
+        assertThat(HarvestSkipListener.truncateMsg(null)).isNull();
+    }
+
+    @Test
+    void onSkipInProcess_longExceptionMessage_storedTruncated() {
+        // S-01: verify that a verbose exception message is truncated in the DB row
+        String overLong = "E".repeat(3000);
+        HarvestRow row = new HarvestRow(5L, "payload-5", true, 0, false);
+        // Craft a PoisonItemException that reports the over-long message
+        PoisonItemException ex = new PoisonItemException(overLong); // use String-message ctor
+
+        skipListener.onSkipInProcess(row, ex);
+
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT exception_msg FROM harvest_dead_letter WHERE source_id = 5");
+        assertThat(rows).hasSize(1);
+        String storedMsg = (String) rows.get(0).get("exception_msg");
+        assertThat(storedMsg).hasSize(2048);
+    }
+
     // ── Unwrapping: wrapped exception still resolves correct failure_type ─────────────────────
 
     @Test


### PR DESCRIPTION
## What — PR #3 of 3 (final; chained, stacked-to-main)

The headline pedagogical payoff of the `fault-tolerant-harvester` plugin: **restartability** — kill the job mid-run and resume from the last committed chunk. Builds on the merged schema+scaffold (#51) and fault-tolerance core (#52). Also folds in the four findings from the PR#2 verification pass.

## Restart demonstration (WU17)
New `FaultTolerantHarvesterRestartIntegrationTest` on isolated H2 (`DB_CLOSE_DELAY=-1` so Batch metadata survives both launches in one JVM):
1. Seed 10 rows: normal chunk-1 rows, an `abort_flag=TRUE` row at position 6, normal rows 7–10.
2. Launch with fixed identifying params → processor throws non-skippable `AbortJobException` on row 6 → step **FAILS** after chunk 1 committed (rows 1–5 `processed=TRUE`).
3. Operator clears `abort_flag` (fixes the bad input).
4. Re-launch with **identical** params → Spring Batch restarts the same `JobInstance`, the reader fast-forwards past the committed rows, the job **COMPLETES**, no row is reprocessed.

Proof asserted: run 2 `READ_COUNT=5` (reader skipped the 5 already-committed rows), 2 `BATCH_JOB_EXECUTION` rows sharing **one** `JOB_INSTANCE_ID`, all rows `processed=TRUE`, zero dead-letter rows.

## Restartable-reader correctness fix
Removed the `WHERE processed = FALSE` filter from the reader SQL. `JdbcCursorItemReader` with `setSaveState(true)` persists `currentItemCount` and, on restart, skips that many rows of the **same** query. A `processed = FALSE` filter shrinks the result set on restart (committed rows vanish), so the saved offset would land past unprocessed rows and silently skip work. Reading **all** rows keeps the result set stable; idempotency is handled entirely by the writer's `UPDATE … WHERE processed = FALSE` guard. Fully documented in the plugin Javadoc.

## README (WU18)
Module README mirroring the other plugins: purpose, fault-tolerant step config, job parameters, schema, how poison/transient/abort rows drive behaviour, and a **prominent restart pitfall** note — the host launches with identifying `DATE + ATTEMPT_NUMBER` and no `RunIdIncrementer`, so a true restart requires resubmitting identical parameters; incrementing `ATTEMPT_NUMBER` creates a new `JobInstance` (fresh run, not a restart).

## Verify findings folded in
- W-01/S-02: renamed `deadLetterSurvivesChunkRollback` → `deadLetterPersistsAfterJobCompletion`; added a comment pointing to the unit test that is the authoritative `REQUIRES_NEW` rollback proof (SB6 scan-mode replays item-by-item, it does not roll back the whole chunk for a skip).
- W-02: Javadoc clarifies `attempt_count` stores total attempts (`retryLimit + 1`) for `RETRY_EXHAUSTED`.
- S-01: `exception_msg` truncated to 2048 chars before INSERT (+ tests) to avoid column overflow on long messages.

## Tests
- `fault-tolerant-harvester-job`: **46** (was 41; +1 restart IT, +4 truncation).
- `fr-batch-service`: **123** (unchanged).
