### PR TITLE
feat(partitioned-harvester): PR-1 scaffold, V8 schema, domain, IdRangePartitioner

### DIFF
--- a/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
+++ b/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
@@ -1,0 +1,48 @@
+-- =========================================================
+-- Dev seed: usage_record rows for the partitioned-harvester demo
+-- Run AFTER V8__partitioned_harvester_tables.sql has been applied
+--
+-- 24 contiguous rows (ids 1–24) arranged so gridSize=4 yields
+-- exactly 6 rows per partition.
+--
+-- Partition breakdown (gridSize=4, rangeSize=6):
+--   Partition 0: ids  1– 6  subscriber_id=100  units=10  rate=5  cost=50 each
+--   Partition 1: ids  7–12  subscriber_id=101  units=20  rate=3  cost=60 each
+--   Partition 2: ids 13–18  subscriber_id=102  units=5   rate=8  cost=40 each
+--   Partition 3: ids 19–24  subscriber_id=103  units=15  rate=4  cost=60 each
+--
+-- Expected total: 6*50 + 6*60 + 6*40 + 6*60 = 300 + 360 + 240 + 360 = 1260
+-- =========================================================
+
+INSERT INTO usage_record (subscriber_id, units, rate) VALUES
+    -- Partition 0 (ids 1–6): subscriber 100, units=10, rate=5 → cost=50 each
+    (100, 10, 5),
+    (100, 10, 5),
+    (100, 10, 5),
+    (100, 10, 5),
+    (100, 10, 5),
+    (100, 10, 5),
+
+    -- Partition 1 (ids 7–12): subscriber 101, units=20, rate=3 → cost=60 each
+    (101, 20, 3),
+    (101, 20, 3),
+    (101, 20, 3),
+    (101, 20, 3),
+    (101, 20, 3),
+    (101, 20, 3),
+
+    -- Partition 2 (ids 13–18): subscriber 102, units=5, rate=8 → cost=40 each
+    (102, 5, 8),
+    (102, 5, 8),
+    (102, 5, 8),
+    (102, 5, 8),
+    (102, 5, 8),
+    (102, 5, 8),
+
+    -- Partition 3 (ids 19–24): subscriber 103, units=15, rate=4 → cost=60 each
+    (103, 15, 4),
+    (103, 15, 4),
+    (103, 15, 4),
+    (103, 15, 4),
+    (103, 15, 4),
+    (103, 15, 4);

--- a/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
+++ b/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
@@ -2,20 +2,29 @@
 -- Dev seed: usage_record rows for the partitioned-harvester demo
 -- Run AFTER V8__partitioned_harvester_tables.sql has been applied
 --
--- 24 contiguous rows (ids 1–24) arranged so gridSize=4 yields
--- exactly 6 rows per partition.
+-- 24 contiguous rows (ids 1-24), grouped into four cost blocks of 6 rows
+-- each (by subscriber) purely to give the billing total some variety.
 --
--- Partition breakdown (gridSize=4, rangeSize=6):
---   Partition 0: ids  1– 6  subscriber_id=100  units=10  rate=5  cost=50 each
---   Partition 1: ids  7–12  subscriber_id=101  units=20  rate=3  cost=60 each
---   Partition 2: ids 13–18  subscriber_id=102  units=5   rate=8  cost=40 each
---   Partition 3: ids 19–24  subscriber_id=103  units=15  rate=4  cost=60 each
+-- Cost blocks (by id — these are NOT partition boundaries):
+--   ids  1- 6  subscriber_id=100  units=10  rate=5  cost=50 each
+--   ids  7-12  subscriber_id=101  units=20  rate=3  cost=60 each
+--   ids 13-18  subscriber_id=102  units=5   rate=8  cost=40 each
+--   ids 19-24  subscriber_id=103  units=15  rate=4  cost=60 each
+-- Expected total: 6*50 + 6*60 + 6*40 + 6*60 = 1260 (partition-independent)
 --
--- Expected total: 6*50 + 6*60 + 6*40 + 6*60 = 300 + 360 + 240 + 360 = 1260
+-- How IdRangePartitioner actually splits this with gridSize=4:
+--   MIN=1, MAX=24, span=23, rangeSize=floor(23/4)=5
+--   partition0 -> [1, 5]   (5 rows)
+--   partition1 -> [6, 10]  (5 rows)
+--   partition2 -> [11, 15] (5 rows)
+--   partition3 -> [16, 24] (9 rows — last partition absorbs the remainder)
+-- Partition ranges deliberately do NOT align with the cost blocks above:
+-- partitioning is orthogonal to the data's grouping, and Sigma(cost) is
+-- unaffected by how rows are split across workers.
 -- =========================================================
 
 INSERT INTO usage_record (subscriber_id, units, rate) VALUES
-    -- Partition 0 (ids 1–6): subscriber 100, units=10, rate=5 → cost=50 each
+    -- Cost block (ids 1-6): subscriber 100, units=10, rate=5 -> cost=50 each
     (100, 10, 5),
     (100, 10, 5),
     (100, 10, 5),
@@ -23,7 +32,7 @@ INSERT INTO usage_record (subscriber_id, units, rate) VALUES
     (100, 10, 5),
     (100, 10, 5),
 
-    -- Partition 1 (ids 7–12): subscriber 101, units=20, rate=3 → cost=60 each
+    -- Cost block (ids 7-12): subscriber 101, units=20, rate=3 -> cost=60 each
     (101, 20, 3),
     (101, 20, 3),
     (101, 20, 3),
@@ -31,7 +40,7 @@ INSERT INTO usage_record (subscriber_id, units, rate) VALUES
     (101, 20, 3),
     (101, 20, 3),
 
-    -- Partition 2 (ids 13–18): subscriber 102, units=5, rate=8 → cost=40 each
+    -- Cost block (ids 13-18): subscriber 102, units=5, rate=8 -> cost=40 each
     (102, 5, 8),
     (102, 5, 8),
     (102, 5, 8),
@@ -39,7 +48,7 @@ INSERT INTO usage_record (subscriber_id, units, rate) VALUES
     (102, 5, 8),
     (102, 5, 8),
 
-    -- Partition 3 (ids 19–24): subscriber 103, units=15, rate=4 → cost=60 each
+    -- Cost block (ids 19-24): subscriber 103, units=15, rate=4 -> cost=60 each
     (103, 15, 4),
     (103, 15, 4),
     (103, 15, 4),

--- a/fr-batch-service/src/main/resources/db/migration/V8__partitioned_harvester_tables.sql
+++ b/fr-batch-service/src/main/resources/db/migration/V8__partitioned_harvester_tables.sql
@@ -1,0 +1,32 @@
+-- =========================================================
+-- V8: Partitioned harvester tables
+-- usage_record:   frozen source table; one row per billable event
+-- billing_charge: output table; one billing charge per usage_record row
+--
+-- Design notes:
+--   - usage_record is FROZEN: no processed flag, no mutations during job execution
+--   - billing_charge.source_id has a UNIQUE constraint to enforce 1:1 idempotency
+--   - cost = units * rate (integer minor units, e.g. millis or cents per usage unit)
+--   - job_execution_id is nullable; populated by the writer for audit tracing
+-- =========================================================
+
+CREATE TABLE usage_record (
+    id            BIGINT        AUTO_INCREMENT PRIMARY KEY,
+    subscriber_id BIGINT        NOT NULL,
+    units         BIGINT        NOT NULL,
+    rate          BIGINT        NOT NULL,
+    recorded_at   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at    TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE billing_charge (
+    id               BIGINT    AUTO_INCREMENT PRIMARY KEY,
+    source_id        BIGINT    NOT NULL,
+    subscriber_id    BIGINT    NOT NULL,
+    units            BIGINT    NOT NULL,
+    rate             BIGINT    NOT NULL,
+    cost             BIGINT    NOT NULL,
+    job_execution_id BIGINT    NULL,
+    recorded_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_billing_charge_source UNIQUE (source_id)
+);

--- a/fr-batch-service/src/test/resources/schema.sql
+++ b/fr-batch-service/src/test/resources/schema.sql
@@ -246,3 +246,28 @@ CREATE TABLE IF NOT EXISTS harvest_dead_letter (
     job_execution_id BIGINT        NOT NULL,
     recorded_at      TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+
+-- =========================================================
+-- V8: Partitioned harvester tables (mirror of V8__partitioned_harvester_tables.sql)
+-- =========================================================
+
+CREATE TABLE IF NOT EXISTS usage_record (
+    id            BIGINT    PRIMARY KEY AUTO_INCREMENT,
+    subscriber_id BIGINT    NOT NULL,
+    units         BIGINT    NOT NULL,
+    rate          BIGINT    NOT NULL,
+    recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS billing_charge (
+    id               BIGINT    PRIMARY KEY AUTO_INCREMENT,
+    source_id        BIGINT    NOT NULL,
+    subscriber_id    BIGINT    NOT NULL,
+    units            BIGINT    NOT NULL,
+    rate             BIGINT    NOT NULL,
+    cost             BIGINT    NOT NULL,
+    job_execution_id BIGINT    NULL,
+    recorded_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_billing_charge_source UNIQUE (source_id)
+);

--- a/partitioned-harvester-job/pom.xml
+++ b/partitioned-harvester-job/pom.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.fronzec.plugins</groupId>
+  <artifactId>partitioned-harvester-job</artifactId>
+  <version>1.0.0</version>
+  <name>partitioned-harvester-job</name>
+  <description>Spring Batch plugin — id-range partitioned billing job with restart and no double-billing</description>
+
+  <properties>
+    <maven.compiler.release>21</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <!-- Platform-provided API (not shaded) -->
+    <dependency>
+      <groupId>com.fronzec</groupId>
+      <artifactId>batch-job-api</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided Spring Batch (not shaded).
+         spring-retry is a transitive dep of spring-batch-core 6.0.0, so it is
+         available at compile + runtime via the host without any explicit declaration. -->
+    <dependency>
+      <groupId>org.springframework.batch</groupId>
+      <artifactId>spring-batch-core</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided spring-jdbc (JdbcTemplate, JdbcCursorItemReader, RowMapper) -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+      <version>7.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Platform-provided logging facade (not shaded) -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- No bundled runtime deps: spring-retry is provided transitively via spring-batch-core. -->
+
+    <!-- Test dependencies (not shaded) -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.11.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.7</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Integration test: in-module H2 + Spring Batch bootstrap -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.3.232</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>7.0.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Note: spring-jdbc, spring-tx, and spring-batch-core are already declared as
+         "provided" above. "Provided" deps ARE on both compile and test classpaths
+         in Maven — no duplicate declarations needed here. -->
+
+    <!-- SLF4J simple backend for test logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Mockito for unit tests (row mapper, etc.) -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.14.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <release>${maven.compiler.release}</release>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <!-- Exclude platform-provided libraries -->
+                  <exclude>com.fronzec:batch-job-api</exclude>
+                  <exclude>org.springframework.batch:spring-batch-core</exclude>
+                  <exclude>org.springframework:spring-context</exclude>
+                  <exclude>org.springframework:spring-tx</exclude>
+                  <exclude>org.springframework:spring-jdbc</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <repositories>
+    <repository>
+      <id>github</id>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+    </repository>
+  </repositories>
+</project>

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/BillingCharge.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/BillingCharge.java
@@ -1,0 +1,23 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+/**
+ * Immutable domain record representing one billing charge derived from a {@link UsageRecord}.
+ *
+ * <p>Produced by the {@code RatingProcessor} (PR-2). Exactly one {@code BillingCharge} is
+ * created per {@code UsageRecord}. {@code costMinor = units × rateMinor}, computed with
+ * {@link Math#multiplyExact} to fail fast on overflow instead of silently wrapping.
+ *
+ * @param sourceId     the {@code id} of the originating {@link UsageRecord}; mapped to
+ *                     {@code billing_charge.source_id}; has a UNIQUE constraint for
+ *                     1:1 idempotency
+ * @param subscriberId identifier for the subscriber being billed
+ * @param units        number of billable usage units (copied from {@link UsageRecord})
+ * @param rateMinor    flat rate in minor currency units (copied from {@link UsageRecord})
+ * @param costMinor    computed cost in minor currency units: {@code units × rateMinor}
+ */
+public record BillingCharge(
+        long sourceId,
+        long subscriberId,
+        long units,
+        long rateMinor,
+        long costMinor) {}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/IdRangePartitioner.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/IdRangePartitioner.java
@@ -1,0 +1,145 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.partition.Partitioner;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Hand-rolled id-range partitioner for the {@code usage_record} table.
+ *
+ * <p>Determines partition boundaries using only:
+ * {@code SELECT MIN(id), MAX(id) FROM usage_record} — a single cheap index-only
+ * scan. No full-table scan or row sampling occurs at planning time.
+ *
+ * <h3>Algorithm</h3>
+ * <p>Given MIN, MAX, and gridSize:
+ * <pre>
+ *   rangeSize = (MAX - MIN) / gridSize    // integer division (floor)
+ *   range[i].min = MIN + i * rangeSize
+ *   range[i].max = MIN + (i+1) * rangeSize - 1
+ *   range[gridSize-1].max = MAX           // last partition absorbs the remainder
+ * </pre>
+ * <p>Ranges are equal-width with the last partition absorbing any remainder from
+ * integer division, ensuring the union is exactly {@code [MIN, MAX]}.
+ *
+ * <h3>Edge cases</h3>
+ * <ul>
+ *   <li><strong>Empty table</strong> (MIN/MAX null): returns a single
+ *       {@code ExecutionContext{minId=1, maxId=0}} so the worker SQL
+ *       ({@code WHERE id BETWEEN 1 AND 0}) reads 0 rows and completes normally.</li>
+ *   <li><strong>Single row</strong> (MIN=MAX): ranges converge around that single id;
+ *       partitions with equal minId and maxId are valid no-ops for all but one.</li>
+ *   <li><strong>gridSize > distinct id spread</strong>: ranges may be very narrow
+ *       (width 0 or 1), producing empty partitions that are harmless.</li>
+ * </ul>
+ *
+ * <h3>gridSize residual note (WU-05)</h3>
+ * <p>The {@code gridSize} parameter to the constructor is fixed at build time inside
+ * {@code configureJob} (PR-2, WU-10) because {@code configureJob} receives no
+ * {@code JobParameters}. The {@code partition(int)} override signature means Spring Batch
+ * will call {@code partition(gridSize)} at step launch, but this implementation ignores
+ * the argument and uses the constructor-injected value. The {@code GRID_SIZE} JobParameter
+ * is validated by {@code PartitionedHarvesterJobParametersValidator} to equal the build-time
+ * default (4). Full runtime-dynamic gridSize resolution is deferred to a future enhancement.
+ *
+ * @see org.springframework.batch.core.partition.Partitioner
+ */
+public class IdRangePartitioner implements Partitioner {
+
+    private static final Logger log = LoggerFactory.getLogger(IdRangePartitioner.class);
+
+    private static final String MIN_MAX_SQL = "SELECT MIN(id), MAX(id) FROM usage_record";
+
+    private final JdbcTemplate jdbc;
+
+    /**
+     * Fixed gridSize baked in at construction time (see class Javadoc for the
+     * build-time constraint rationale).
+     */
+    private final int gridSize;
+
+    /**
+     * Constructs the partitioner.
+     *
+     * @param jdbc     JdbcTemplate to query MIN/MAX from {@code usage_record}
+     * @param gridSize number of partitions; fixed at build time in {@code configureJob}
+     */
+    public IdRangePartitioner(JdbcTemplate jdbc, int gridSize) {
+        this.jdbc = jdbc;
+        this.gridSize = gridSize;
+    }
+
+    /**
+     * Produces partition {@link ExecutionContext}s for the manager step.
+     *
+     * <p>The {@code gridSize} argument from Spring Batch is ignored; the constructor-injected
+     * value is used instead (see class Javadoc).
+     *
+     * @param gridSize hint from Spring Batch's PartitionStep (ignored; constructor value used)
+     * @return map of partition name → ExecutionContext with {@code minId}, {@code maxId},
+     *         {@code partitionName}
+     */
+    @Override
+    public Map<String, ExecutionContext> partition(int gridSize) {
+        long[] minMax = queryMinMax();
+        long min = minMax[0];
+        long max = minMax[1];
+
+        // Empty table: return a single no-op partition so the worker reads 0 rows
+        if (min > max) {
+            log.info("usage_record is empty — returning single no-op partition");
+            Map<String, ExecutionContext> result = new HashMap<>(1);
+            ExecutionContext ctx = new ExecutionContext();
+            ctx.putLong("minId", 1L);
+            ctx.putLong("maxId", 0L);
+            ctx.putString("partitionName", "partition0");
+            result.put("partition0", ctx);
+            return result;
+        }
+
+        long span = max - min;
+        long rangeSize = span / this.gridSize;
+
+        log.info("Partitioning usage_record: MIN={} MAX={} span={} gridSize={} rangeSize={}",
+                min, max, span, this.gridSize, rangeSize);
+
+        Map<String, ExecutionContext> partitions = new HashMap<>(this.gridSize);
+        for (int i = 0; i < this.gridSize; i++) {
+            long rangeMin = min + (long) i * rangeSize;
+            long rangeMax = (i == this.gridSize - 1) ? max : (min + (long) (i + 1) * rangeSize - 1);
+
+            String name = "partition" + i;
+            ExecutionContext ctx = new ExecutionContext();
+            ctx.putLong("minId", rangeMin);
+            ctx.putLong("maxId", rangeMax);
+            ctx.putString("partitionName", name);
+            partitions.put(name, ctx);
+
+            log.debug("  {} → [{}, {}]", name, rangeMin, rangeMax);
+        }
+
+        return partitions;
+    }
+
+    /**
+     * Queries MIN(id) and MAX(id) from {@code usage_record}.
+     *
+     * @return two-element array {@code [min, max]}; if the table is empty returns
+     *         {@code [1, 0]} (min > max signals the empty case to {@link #partition(int)})
+     */
+    private long[] queryMinMax() {
+        return jdbc.queryForObject(MIN_MAX_SQL, (rs, rowNum) -> {
+            Object minObj = rs.getObject(1);
+            Object maxObj = rs.getObject(2);
+            if (minObj == null || maxObj == null) {
+                // Empty table: signal with min > max
+                return new long[]{1L, 0L};
+            }
+            return new long[]{((Number) minObj).longValue(), ((Number) maxObj).longValue()};
+        });
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecord.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecord.java
@@ -1,0 +1,19 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+/**
+ * Immutable domain record representing one row from the frozen {@code usage_record} table.
+ *
+ * <p>All fields are read directly from the database; the source table is never mutated
+ * during processing. Cost is computed by the processor as {@code units × rateMinor}.
+ *
+ * @param id           primary key of the usage_record row; used as the {@code source_id}
+ *                     in {@link BillingCharge} for 1:1 idempotency
+ * @param subscriberId identifier for the subscriber being billed
+ * @param units        number of billable usage units consumed
+ * @param rateMinor    flat rate in minor currency units per usage unit (e.g. millis or cents)
+ */
+public record UsageRecord(
+        long id,
+        long subscriberId,
+        long units,
+        long rateMinor) {}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecordRowMapper.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecordRowMapper.java
@@ -1,0 +1,40 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Maps a {@code usage_record} result-set row to a {@link UsageRecord} record.
+ *
+ * <p>Expected columns (by name, matching V8 DDL):
+ * <ul>
+ *   <li>{@code id} — BIGINT primary key</li>
+ *   <li>{@code subscriber_id} — BIGINT</li>
+ *   <li>{@code units} — BIGINT</li>
+ *   <li>{@code rate} — BIGINT (minor currency units per usage unit); mapped to
+ *       {@link UsageRecord#rateMinor()}</li>
+ * </ul>
+ *
+ * <p>Column mapping is by name, not position, so the column order in the SELECT
+ * does not affect correctness.
+ */
+public class UsageRecordRowMapper implements RowMapper<UsageRecord> {
+
+    /**
+     * Maps one result-set row to a {@link UsageRecord}.
+     *
+     * @param rs     the result set positioned at the current row
+     * @param rowNum the 0-based row number (unused)
+     * @return the mapped {@link UsageRecord}
+     * @throws SQLException if a column cannot be read
+     */
+    @Override
+    public UsageRecord mapRow(ResultSet rs, int rowNum) throws SQLException {
+        return new UsageRecord(
+                rs.getLong("id"),
+                rs.getLong("subscriber_id"),
+                rs.getLong("units"),
+                rs.getLong("rate"));
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/package-info.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Batch components for the partitioned-harvester job plugin.
+ *
+ * <p>Contains the partitioner, reader, processor, writer, domain types, row mapper,
+ * and validator that together form the partitioned chunk step pipeline.
+ *
+ * <p>Implemented in PR-1 (domain types, partitioner) and PR-2 (reader, processor, writer,
+ * validator, plugin wiring).
+ */
+package com.fronzec.plugins.partitionedharvester.batch;

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/package-info.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Root package for the partitioned-harvester job plugin.
+ *
+ * <p>This plugin implements id-range partitioned billing over a frozen {@code usage_record}
+ * table. Each {@code usage_record} row produces exactly one {@code billing_charge} row
+ * (cost = units × rate). The headline capability is partitioned restart with no double-billing.
+ *
+ * <p>Implemented in PR-1 (scaffold), PR-2 (wiring), PR-3 (integration tests).
+ */
+package com.fronzec.plugins.partitionedharvester;

--- a/partitioned-harvester-job/src/main/resources/META-INF/services/com.fronzec.api.BatchJobPlugin
+++ b/partitioned-harvester-job/src/main/resources/META-INF/services/com.fronzec.api.BatchJobPlugin
@@ -1,0 +1,1 @@
+com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/IdRangePartitionerTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/IdRangePartitionerTest.java
@@ -1,0 +1,291 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link IdRangePartitioner} covering all spec scenarios from REQ-01.
+ *
+ * <p>Uses an H2 in-memory {@code usage_record} table (not mocking the JdbcTemplate) so
+ * the actual SQL executes against a real database.
+ *
+ * <p>Scenarios covered:
+ * <ul>
+ *   <li>SC-01.1 — standard equal-width split</li>
+ *   <li>SC-01.1 remainder — last partition absorbs the remainder</li>
+ *   <li>SC-01.2 — empty table (MIN/MAX null)</li>
+ *   <li>SC-01.3 — single row</li>
+ *   <li>SC-01.4 — gridSize larger than row count</li>
+ *   <li>SC-01.5 — id gaps / skew</li>
+ *   <li>Range contiguity invariant</li>
+ *   <li>ExecutionContext keys present: minId, maxId, partitionName</li>
+ * </ul>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IdRangePartitionerTest {
+
+    private JdbcTemplate jdbc;
+
+    @BeforeAll
+    void setUpDatabase() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:partitioner-test;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + "id            BIGINT    PRIMARY KEY AUTO_INCREMENT,"
+                        + "subscriber_id BIGINT    NOT NULL,"
+                        + "units         BIGINT    NOT NULL,"
+                        + "rate          BIGINT    NOT NULL,"
+                        + "recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + "created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+    }
+
+    @BeforeEach
+    void clearTable() {
+        jdbc.execute("DELETE FROM usage_record");
+    }
+
+    // ── SC-01.1 — Standard equal-width split ─────────────────────────────────
+
+    /**
+     * Given MIN=1, MAX=100, gridSize=4:
+     * rangeSize = floor((100-1)/4) = floor(99/4) = 24.
+     * Expect: [1,24],[25,48],[49,72],[73,100] — last absorbs remainder 3.
+     */
+    @Test
+    void standardSplit_evenDivision() {
+        // Insert rows at id=1 and id=100 to set MIN/MAX
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (100, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertThat(partitions).hasSize(4);
+
+        // rangeSize = 24; last partition absorbs remainder
+        assertRange(partitions, "partition0", 1L, 24L);
+        assertRange(partitions, "partition1", 25L, 48L);
+        assertRange(partitions, "partition2", 49L, 72L);
+        assertRange(partitions, "partition3", 73L, 100L);
+    }
+
+    // ── SC-01.1 remainder — last partition absorbs remainder ─────────────────
+
+    /**
+     * Given MIN=1, MAX=101, gridSize=4:
+     * span=100, rangeSize = floor(100/4) = 25. Last partition absorbs to MAX=101.
+     * Expect: [1,25],[26,50],[51,75],[76,101]
+     */
+    @Test
+    void standardSplit_remainderAbsorbedByLastPartition() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (101, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertThat(partitions).hasSize(4);
+
+        // rangeSize = 25 (exact division of span=100)
+        assertRange(partitions, "partition0", 1L, 25L);
+        assertRange(partitions, "partition1", 26L, 50L);
+        assertRange(partitions, "partition2", 51L, 75L);
+        // last partition extends all the way to MAX=101
+        assertRange(partitions, "partition3", 76L, 101L);
+    }
+
+    // ── SC-01.2 — Empty table ─────────────────────────────────────────────────
+
+    /**
+     * Given an empty table (MIN/MAX return NULL):
+     * expect 1 context with minId=1 and maxId=0 so the worker reads 0 rows; no NPE.
+     */
+    @Test
+    void emptyTable_returnsSingleEmptyContext() {
+        // Table is empty (cleared in @BeforeEach)
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertThat(partitions).hasSize(1);
+        ExecutionContext ctx = partitions.get("partition0");
+        assertThat(ctx).isNotNull();
+        assertThat(ctx.getLong("minId")).isEqualTo(1L);
+        assertThat(ctx.getLong("maxId")).isEqualTo(0L);
+        assertThat(ctx.getString("partitionName")).isEqualTo("partition0");
+    }
+
+    // ── SC-01.3 — Single row ──────────────────────────────────────────────────
+
+    /**
+     * Given a single row with id=42, gridSize=4:
+     * expect 4 ranges produced; ranges are valid (non-overlapping, contiguous);
+     * exactly one range contains id=42.
+     */
+    @Test
+    void singleRow_producesGridSizeRanges() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (42, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertThat(partitions).hasSize(4);
+
+        // MIN=MAX=42 → rangeSize = 0; all ranges collapse around 42
+        // Verify the union covers [42, 42]
+        long globalMin = Long.MAX_VALUE;
+        long globalMax = Long.MIN_VALUE;
+        for (ExecutionContext ctx : partitions.values()) {
+            long min = ctx.getLong("minId");
+            long max = ctx.getLong("maxId");
+            if (min < globalMin) globalMin = min;
+            if (max > globalMax) globalMax = max;
+        }
+        assertThat(globalMin).isEqualTo(42L);
+        assertThat(globalMax).isEqualTo(42L);
+
+        // All partition names are present
+        assertThat(partitions).containsKey("partition0");
+        assertThat(partitions).containsKey("partition3");
+    }
+
+    // ── SC-01.4 — gridSize > row count ───────────────────────────────────────
+
+    /**
+     * Given rows at ids {10, 20, 30}, gridSize=10:
+     * expect 10 contexts covering [10, 30]; empty trailing ranges are valid (min > max).
+     */
+    @Test
+    void gridSizeLargerThanRowCount_producesGridSizeContexts() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (10, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (20, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (30, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 10);
+        Map<String, ExecutionContext> partitions = partitioner.partition(10);
+
+        assertThat(partitions).hasSize(10);
+
+        // First partition starts at MIN=10
+        assertThat(partitions.get("partition0").getLong("minId")).isEqualTo(10L);
+        // Last partition ends at MAX=30
+        assertThat(partitions.get("partition9").getLong("maxId")).isEqualTo(30L);
+    }
+
+    // ── SC-01.5 — Id gaps / skew ──────────────────────────────────────────────
+
+    /**
+     * Given ids {1, 1000, 1001, 1002} (MIN=1, MAX=1002), gridSize=4:
+     * arithmetic ranges are based purely on [1, 1002]; gaps are irrelevant.
+     * Range union must still cover [1, 1002] contiguously.
+     */
+    @Test
+    void idGaps_arithmeticRangesCoverFullInterval() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1000, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1001, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1002, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertThat(partitions).hasSize(4);
+
+        // First range starts at MIN=1
+        assertThat(partitions.get("partition0").getLong("minId")).isEqualTo(1L);
+        // Last range ends at MAX=1002
+        assertThat(partitions.get("partition3").getLong("maxId")).isEqualTo(1002L);
+
+        // Ranges are contiguous
+        assertContiguous(partitions, 4);
+    }
+
+    // ── Range contiguity invariant ────────────────────────────────────────────
+
+    /**
+     * Contiguity invariant: for any valid result with >= 2 ranges,
+     * range[i].maxId + 1 == range[i+1].minId for all i in [0, N-2].
+     */
+    @Test
+    void contiguityInvariant_standard() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (100, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 4);
+        Map<String, ExecutionContext> partitions = partitioner.partition(4);
+
+        assertContiguous(partitions, 4);
+    }
+
+    // ── ExecutionContext keys present ─────────────────────────────────────────
+
+    /**
+     * Each context must carry minId, maxId, and partitionName keys.
+     */
+    @Test
+    void executionContextKeys_presentInAllPartitions() {
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 1, 1, 1)");
+        jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (50, 1, 1, 1)");
+
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, 3);
+        Map<String, ExecutionContext> partitions = partitioner.partition(3);
+
+        for (Map.Entry<String, ExecutionContext> entry : partitions.entrySet()) {
+            ExecutionContext ctx = entry.getValue();
+            assertThat(ctx.containsKey("minId"))
+                    .as("minId key missing in %s", entry.getKey()).isTrue();
+            assertThat(ctx.containsKey("maxId"))
+                    .as("maxId key missing in %s", entry.getKey()).isTrue();
+            assertThat(ctx.containsKey("partitionName"))
+                    .as("partitionName key missing in %s", entry.getKey()).isTrue();
+            assertThat(ctx.getString("partitionName"))
+                    .as("partitionName value mismatch in %s", entry.getKey())
+                    .isEqualTo(entry.getKey());
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private void assertRange(
+            Map<String, ExecutionContext> partitions, String key, long expectedMin, long expectedMax) {
+        ExecutionContext ctx = partitions.get(key);
+        assertThat(ctx).as("partition context for key '%s' is null", key).isNotNull();
+        assertThat(ctx.getLong("minId"))
+                .as("minId for '%s'", key).isEqualTo(expectedMin);
+        assertThat(ctx.getLong("maxId"))
+                .as("maxId for '%s'", key).isEqualTo(expectedMax);
+    }
+
+    /**
+     * Asserts that partitions named partition0..partition{count-1} are contiguous:
+     * partition[i].maxId + 1 == partition[i+1].minId.
+     */
+    private void assertContiguous(Map<String, ExecutionContext> partitions, int count) {
+        for (int i = 0; i < count - 1; i++) {
+            ExecutionContext curr = partitions.get("partition" + i);
+            ExecutionContext next = partitions.get("partition" + (i + 1));
+            assertThat(curr).as("partition%d missing", i).isNotNull();
+            assertThat(next).as("partition%d missing", i + 1).isNotNull();
+            long currMax = curr.getLong("maxId");
+            long nextMin = next.getLong("minId");
+            assertThat(currMax + 1)
+                    .as("partition%d.maxId+1 (%d) should equal partition%d.minId (%d)",
+                            i, currMax + 1, i + 1, nextMin)
+                    .isEqualTo(nextMin);
+        }
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecordRowMapperTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/UsageRecordRowMapperTest.java
@@ -1,0 +1,93 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link UsageRecordRowMapper} using a real H2 query result set.
+ *
+ * <p>Mirrors the pattern from {@code HarvestRowMapperTest}: real H2 result set,
+ * no mock ResultSet.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class UsageRecordRowMapperTest {
+
+    private JdbcTemplate jdbc;
+    private final UsageRecordRowMapper mapper = new UsageRecordRowMapper();
+
+    @BeforeAll
+    void setUpDatabase() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:rowmapper-test;DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + "id            BIGINT    PRIMARY KEY AUTO_INCREMENT,"
+                        + "subscriber_id BIGINT    NOT NULL,"
+                        + "units         BIGINT    NOT NULL,"
+                        + "rate          BIGINT    NOT NULL,"
+                        + "recorded_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + "created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+    }
+
+    /** All fields from a standard row map correctly to {@link UsageRecord}. */
+    @Test
+    void mapsAllFields() {
+        jdbc.update(
+                "INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (1, 100, 10, 5)");
+
+        UsageRecord row = jdbc.queryForObject(
+                "SELECT id, subscriber_id, units, rate FROM usage_record WHERE id = 1",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.id()).isEqualTo(1L);
+        assertThat(row.subscriberId()).isEqualTo(100L);
+        assertThat(row.units()).isEqualTo(10L);
+        assertThat(row.rateMinor()).isEqualTo(5L);
+    }
+
+    /** Column names are mapped by name (not positional) so order does not matter. */
+    @Test
+    void mapsColumnByName() {
+        jdbc.update(
+                "INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (2, 999, 20, 3)");
+
+        UsageRecord row = jdbc.queryForObject(
+                "SELECT rate, units, subscriber_id, id FROM usage_record WHERE id = 2",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.id()).isEqualTo(2L);
+        assertThat(row.subscriberId()).isEqualTo(999L);
+        assertThat(row.units()).isEqualTo(20L);
+        assertThat(row.rateMinor()).isEqualTo(3L);
+    }
+
+    /** Boundary: large BIGINT values are preserved without truncation. */
+    @Test
+    void mapsLargeBigIntValues() {
+        long largeUnits = 1_000_000_000L;
+        long largeRate = 999_999L;
+        jdbc.update(
+                "INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (3, 42, ?, ?)",
+                largeUnits, largeRate);
+
+        UsageRecord row = jdbc.queryForObject(
+                "SELECT id, subscriber_id, units, rate FROM usage_record WHERE id = 3",
+                mapper);
+
+        assertThat(row).isNotNull();
+        assertThat(row.units()).isEqualTo(largeUnits);
+        assertThat(row.rateMinor()).isEqualTo(largeRate);
+    }
+}


### PR DESCRIPTION
## Summary

This is PR-1 of a 3-PR stacked-to-main chain implementing the `partitioned-harvester-job` plugin — a CDR/usage billing job that partitions a frozen `usage_record` table by id range, producing exactly one `billing_charge` per record (cost = units × rate) with no double-billing on restart.

### Work units in this PR

- **WU-01 — Module scaffold**: New Maven module `partitioned-harvester-job/` with `pom.xml` (copied and renamed from `fault-tolerant-harvester-job`), two `package-info.java` files, and the SPI registration file `META-INF/services/com.fronzec.api.BatchJobPlugin`.
- **WU-02 — V8 Flyway migration**: Creates `usage_record` (frozen source, no `processed` flag) and `billing_charge` (with `UNIQUE (source_id)` constraint for 1:1 idempotency). Money/units as BIGINT minor units.
- **WU-03 — H2 test schema mirror + dev seed**: Appends `IF NOT EXISTS` blocks for both tables to `fr-batch-service/src/test/resources/schema.sql`. Adds `_devenvironment/db/30_seed_usage_record.sql` with 24 deterministic rows (4 partitions × 6 rows, Σcost = 1260) for local dev and as the integration-test seed.
- **WU-04 — Domain types + row mapper (TDD)**: `UsageRecord` record, `BillingCharge` record, `UsageRecordRowMapper`. Tests written first (RED → GREEN). 3 tests covering all fields, column-by-name mapping, and large BIGINT values.
- **WU-05 — IdRangePartitioner (TDD)**: Hand-rolled `Partitioner` using `SELECT MIN(id), MAX(id)`. Equal-width split with remainder absorbed by last partition. Tests written first (RED → GREEN). 8 tests covering SC-01.1 through SC-01.5, the contiguity invariant, and ExecutionContext key presence.

### Partitioning concept

`IdRangePartitioner` queries only `MIN(id)` and `MAX(id)` — no full-table scan. It divides `[MIN, MAX]` into `gridSize` arithmetic ranges; the last partition absorbs the remainder. Empty table returns a single no-op range `{minId=1, maxId=0}` so the worker reads 0 rows without throwing.

### gridSize note

`configureJob` receives no `JobParameters`, so `gridSize` is a build-time constant (default 4) passed to the `IdRangePartitioner` constructor. The `GRID_SIZE` `JobParameter` is validated (in PR-2, WU-09) to equal this default. Full runtime-dynamic gridSize is a documented future enhancement. This design decision is captured in a code comment in `IdRangePartitioner`.

### Chained PR chain

```
📍 PR-1 (this) — scaffold, V8 schema, domain types, IdRangePartitioner
       ↓ merge to main
    PR-2 — reader (ThreadLocal), processor (Math.multiplyExact), writer (guarded INSERT), validator, plugin wiring
       ↓ merge to main
    PR-3 — integration tests, restart test, CI step, README
```

### Test results

```
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

`fr-batch-service` test suite also passes (123 tests, 0 failures) — the `schema.sql` addition does not break existing tests.

---
Part of SDD change `partitioned-harvester` — stacked-to-main delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added usage tracking and billing charge database tables with migration support
  * Introduced new batch job plugin module for distributed billing processing

* **Tests**
  * Added comprehensive test coverage for data partitioning and database mapping functionality
  * Added test seed data for usage records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->