### PR TITLE
feat(partitioned-harvester): PR-2 ThreadLocal reader, rating processor, idempotent writer, validator, plugin wiring

### DIFF
--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/PartitionedHarvesterJobPlugin.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/PartitionedHarvesterJobPlugin.java
@@ -1,0 +1,260 @@
+package com.fronzec.plugins.partitionedharvester;
+
+import com.fronzec.api.BatchJobPlugin;
+import com.fronzec.api.JobMetadata;
+import com.fronzec.plugins.partitionedharvester.batch.BillingCharge;
+import com.fronzec.plugins.partitionedharvester.batch.BillingChargeWriter;
+import com.fronzec.plugins.partitionedharvester.batch.IdRangePartitioner;
+import com.fronzec.plugins.partitionedharvester.batch.PartitionedHarvesterJobParametersValidator;
+import com.fronzec.plugins.partitionedharvester.batch.PartitionedHarvesterReader;
+import com.fronzec.plugins.partitionedharvester.batch.RatingProcessor;
+import com.fronzec.plugins.partitionedharvester.batch.UsageRecord;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Spring Batch plugin that demonstrates id-range partitioned billing with
+ * partitioned restart and no double-billing.
+ *
+ * <p>Implemented as a shaded standalone JAR loaded dynamically by the host service.
+ * No Spring annotations — instantiated via {@code getDeclaredConstructor().newInstance()}.
+ *
+ * <h3>Job parameters</h3>
+ * <table border="1">
+ *   <tr><th>Parameter</th><th>Default</th><th>Description</th></tr>
+ *   <tr><td>{@code GRID_SIZE}</td><td>4</td><td>Number of partitions (parallelism)</td></tr>
+ *   <tr><td>{@code CHUNK_SIZE}</td><td>100</td><td>Items per commit</td></tr>
+ * </table>
+ *
+ * <h3>gridSize build-time constraint</h3>
+ * <p>{@code configureJob} receives no {@code JobParameters}, so the number of partitions
+ * and the thread-pool size are baked in at build time using {@code GRID_SIZE_DEFAULT = 4}.
+ * The {@code GRID_SIZE} and {@code CHUNK_SIZE} parameters are validated by
+ * {@link PartitionedHarvesterJobParametersValidator} but do NOT dynamically resize the
+ * partition grid in this single-JVM pedagogical implementation.
+ * Full runtime-dynamic gridSize resolution is deferred to a future enhancement requiring
+ * a {@code JobExecutionListener.beforeJob} → holder → partitioner wiring.
+ *
+ * <h3>ThreadLocal reader (no {@code @StepScope})</h3>
+ * <p>{@link PartitionedHarvesterReader} implements BOTH {@code ItemStreamReader} AND
+ * {@code StepExecutionListener}. It is registered as both {@code .reader(reader)} AND
+ * {@code .listener((Object) reader)} on the worker step so that {@code beforeStep} fires
+ * before {@code open}, populating the per-thread {@code JdbcCursorItemReader} delegate.
+ *
+ * <h3>Idempotency</h3>
+ * <p>The {@code billing_charge} table has a UNIQUE constraint on {@code source_id}.
+ * {@link BillingChargeWriter} uses a guarded {@code INSERT … WHERE NOT EXISTS} so
+ * re-running a partition is always a safe no-op for already-written charges.
+ */
+public class PartitionedHarvesterJobPlugin implements BatchJobPlugin {
+
+    private static final Logger log =
+            LoggerFactory.getLogger(PartitionedHarvesterJobPlugin.class);
+
+    /** Job name registered in the Spring Batch job repository. */
+    static final String JOB_NAME = "partitioned-harvester-job";
+
+    /** Plugin version. */
+    static final String VERSION = "1.0.0";
+
+    /**
+     * Build-time default number of partitions.
+     *
+     * <p>Both the {@link IdRangePartitioner} constructor and the
+     * {@link org.springframework.batch.core.step.builder.PartitionStepBuilder#gridSize(int)}
+     * call use this constant so they are always in sync — a required invariant because
+     * Spring Batch uses the gridSize argument to pre-size internal structures and the
+     * partitioner produces exactly this many ExecutionContexts.
+     */
+    static final int GRID_SIZE_DEFAULT = 4;
+
+    /** Default number of items per chunk commit. */
+    static final int CHUNK_SIZE_DEFAULT = 100;
+
+    /** Thread-pool queue capacity: 0 means synchronous hand-off to worker threads. */
+    private static final int POOL_QUEUE_CAPACITY = 0;
+
+    @Override
+    public String getJobName() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public String getVersion() {
+        return VERSION;
+    }
+
+    /**
+     * Configures the full partitioned harvester job.
+     *
+     * <h3>Step wiring</h3>
+     * <p>Manager step ({@code usageManagerStep}):
+     * <ul>
+     *   <li>Partitioner: {@link IdRangePartitioner} — splits {@code usage_record} by id range.</li>
+     *   <li>Worker step: {@code usageWorkerStep} — one chunk step reused across N threads.</li>
+     *   <li>Executor: {@link ThreadPoolTaskExecutor} with {@code core = max = GRID_SIZE_DEFAULT}.</li>
+     *   <li>Grid size: {@code GRID_SIZE_DEFAULT} — fixed at build time (see class Javadoc).</li>
+     * </ul>
+     * <p>Worker step ({@code usageWorkerStep}):
+     * <ul>
+     *   <li>Reader: {@link PartitionedHarvesterReader} — ThreadLocal JdbcCursorItemReader,
+     *       also registered as {@code StepExecutionListener} to populate the ThreadLocal in
+     *       {@code beforeStep}.</li>
+     *   <li>Processor: {@link RatingProcessor} — stateless flat-rate cost computation.</li>
+     *   <li>Writer: {@link BillingChargeWriter} — idempotent guarded INSERT.</li>
+     * </ul>
+     *
+     * @param jobRepository      the shared job repository provided by the host
+     * @param transactionManager the transaction manager provided by the host
+     * @param parentContext      the host application context (used to obtain DataSource)
+     * @return the configured {@link Job}
+     */
+    @Override
+    public Job configureJob(
+            JobRepository jobRepository,
+            PlatformTransactionManager transactionManager,
+            ApplicationContext parentContext) {
+
+        log.info("Configuring partitioned-harvester-job plugin v{}", VERSION);
+
+        DataSource dataSource = parentContext.getBean(DataSource.class);
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+
+        // ── Partitioner ───────────────────────────────────────────────────────
+        // gridSize is fixed at GRID_SIZE_DEFAULT (build-time constraint; see class Javadoc).
+        // The partitioner produces exactly GRID_SIZE_DEFAULT ExecutionContexts.
+        IdRangePartitioner partitioner = new IdRangePartitioner(jdbc, GRID_SIZE_DEFAULT);
+
+        // ── Batch components ──────────────────────────────────────────────────
+        // Reader implements both ItemStreamReader AND StepExecutionListener;
+        // registered as .reader(...) AND .listener((Object) reader) below.
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+        RatingProcessor processor = new RatingProcessor();
+        BillingChargeWriter writer = new BillingChargeWriter(jdbc);
+
+        // ── Thread pool ───────────────────────────────────────────────────────
+        // corePoolSize = maxPoolSize = GRID_SIZE_DEFAULT: one thread per partition,
+        // no growth and no queueing (queueCapacity=0 → synchronous hand-off).
+        // afterPropertiesSet() is mandatory — ThreadPoolTaskExecutor is an InitializingBean.
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(GRID_SIZE_DEFAULT);
+        executor.setMaxPoolSize(GRID_SIZE_DEFAULT);
+        executor.setQueueCapacity(POOL_QUEUE_CAPACITY);
+        executor.setThreadNamePrefix("usage-worker-");
+        executor.afterPropertiesSet();
+
+        // ── Worker step ───────────────────────────────────────────────────────
+        // .listener((Object) reader) registers the reader as a StepExecutionListener.
+        // beforeStep() populates the ThreadLocal delegate; afterStep() removes it.
+        // The cast to Object forces the generic .listener(Object) overload on
+        // SimpleStepBuilder/AbstractTaskletStepBuilder which performs annotation
+        // introspection and StepExecutionListener detection.
+        Step workerStep = new StepBuilder("usageWorkerStep", jobRepository)
+                .<UsageRecord, BillingCharge>chunk(CHUNK_SIZE_DEFAULT, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .listener((Object) reader)   // reader IS the StepExecutionListener
+                .build();
+
+        // ── Manager (partition) step ──────────────────────────────────────────
+        // gridSize(GRID_SIZE_DEFAULT) MUST match the IdRangePartitioner constructor arg.
+        // Spring Batch uses this value to size the internal StepExecutionSplitter; if the
+        // partitioner returns more contexts than gridSize, the extras are silently ignored.
+        Step managerStep = new StepBuilder("usageManagerStep", jobRepository)
+                .partitioner("usageWorkerStep", partitioner)
+                .step(workerStep)
+                .gridSize(GRID_SIZE_DEFAULT)
+                .taskExecutor(executor)
+                .build();
+
+        // ── Job ───────────────────────────────────────────────────────────────
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .validator(new PartitionedHarvesterJobParametersValidator())
+                .start(managerStep)
+                .build();
+    }
+
+    /**
+     * Returns the default job parameters.
+     *
+     * <p>Both parameters are optional at launch; missing ones fall back to these defaults.
+     * {@code GRID_SIZE} is also the build-time partition count used in {@link #configureJob}.
+     *
+     * @return default parameter map
+     */
+    @Override
+    public Map<String, String> getDefaultParameters() {
+        return Map.of(
+                "GRID_SIZE", String.valueOf(GRID_SIZE_DEFAULT),
+                "CHUNK_SIZE", String.valueOf(CHUNK_SIZE_DEFAULT));
+    }
+
+    /**
+     * Returns required runtime dependencies.
+     *
+     * <p>All needed libraries are provided transitively by the host (spring-batch-core,
+     * spring-jdbc, spring-scheduling).
+     *
+     * @return empty list
+     */
+    @Override
+    public List<String> getRequiredDependencies() {
+        return List.of();
+    }
+
+    /**
+     * Returns the plugin metadata.
+     *
+     * @return a {@link PartitionedHarvesterJobMetadata} instance
+     */
+    @Override
+    public JobMetadata getMetadata() {
+        return new PartitionedHarvesterJobMetadata();
+    }
+
+    /** Named static inner class so the compiled {@code .class} file is discoverable. */
+    public static class PartitionedHarvesterJobMetadata implements JobMetadata {
+
+        @Override
+        public String getDisplayName() {
+            return "Partitioned Harvester";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Demonstrates a partitioned Spring Batch job: id-range partitioning over a "
+                    + "frozen usage_record table, flat-rate billing (cost = units × rate), "
+                    + "parallel execution via ThreadPoolTaskExecutor, idempotent guarded INSERT "
+                    + "on billing_charge, and partitioned restart with no double-billing.";
+        }
+
+        @Override
+        public String getAuthor() {
+            return "fronzec";
+        }
+
+        @Override
+        public List<String> getTags() {
+            return List.of("partitioned", "billing", "cdr");
+        }
+
+        @Override
+        public Duration getEstimatedRuntime() {
+            return Duration.ofSeconds(30);
+        }
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/PartitionedHarvesterJobPlugin.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/PartitionedHarvesterJobPlugin.java
@@ -42,9 +42,10 @@ import org.springframework.transaction.PlatformTransactionManager;
  * <h3>gridSize build-time constraint</h3>
  * <p>{@code configureJob} receives no {@code JobParameters}, so the number of partitions
  * and the thread-pool size are baked in at build time using {@code GRID_SIZE_DEFAULT = 4}.
- * The {@code GRID_SIZE} and {@code CHUNK_SIZE} parameters are validated by
- * {@link PartitionedHarvesterJobParametersValidator} but do NOT dynamically resize the
- * partition grid in this single-JVM pedagogical implementation.
+ * Because a launch-time {@code GRID_SIZE} or {@code CHUNK_SIZE} override cannot take effect,
+ * {@link PartitionedHarvesterJobParametersValidator} REJECTS any value that differs from the
+ * build-time constant rather than silently ignoring it — the constraint is made explicit
+ * instead of becoming a footgun.
  * Full runtime-dynamic gridSize resolution is deferred to a future enhancement requiring
  * a {@code JobExecutionListener.beforeJob} → holder → partitioner wiring.
  *
@@ -183,7 +184,8 @@ public class PartitionedHarvesterJobPlugin implements BatchJobPlugin {
 
         // ── Job ───────────────────────────────────────────────────────────────
         return new JobBuilder(JOB_NAME, jobRepository)
-                .validator(new PartitionedHarvesterJobParametersValidator())
+                .validator(new PartitionedHarvesterJobParametersValidator(
+                        GRID_SIZE_DEFAULT, CHUNK_SIZE_DEFAULT))
                 .start(managerStep)
                 .build();
     }

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/BillingChargeWriter.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/BillingChargeWriter.java
@@ -1,0 +1,92 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.batch.infrastructure.item.ItemWriter;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Writes {@link BillingCharge} records to the {@code billing_charge} table using a guarded
+ * {@code INSERT … WHERE NOT EXISTS} pattern for idempotency.
+ *
+ * <h3>Idempotency design</h3>
+ * <p>The {@code billing_charge} table has a UNIQUE constraint on {@code source_id}
+ * (the primary key of the originating {@code usage_record}). The INSERT guard:
+ * <pre>{@code
+ *   INSERT INTO billing_charge (source_id, subscriber_id, units, rate, cost)
+ *   SELECT ?, ?, ?, ?, ?
+ *   WHERE NOT EXISTS (SELECT 1 FROM billing_charge WHERE source_id = ?)
+ * }</pre>
+ * returns 0 rows affected when a charge for that {@code source_id} already exists.
+ * This is a silent no-op — no exception, no mutation of the existing row.
+ *
+ * <h3>Why {@code WHERE NOT EXISTS} instead of INSERT IGNORE</h3>
+ * <p>{@code INSERT IGNORE} is MySQL-specific. The {@code WHERE NOT EXISTS} pattern is
+ * portable across H2 ({@code MODE=MySQL}) and MySQL — required for unit tests against H2
+ * and production deployment against MySQL.
+ *
+ * <h3>Frozen source</h3>
+ * <p>This writer NEVER touches {@code usage_record}. The source table is read-only from
+ * the job's perspective; idempotency is achieved by checking/writing {@code billing_charge}
+ * only.
+ *
+ * @see BillingCharge
+ */
+public class BillingChargeWriter implements ItemWriter<BillingCharge> {
+
+    private static final Logger log = LoggerFactory.getLogger(BillingChargeWriter.class);
+
+    /**
+     * Guarded INSERT: inserts a row only when no existing row has the same {@code source_id}.
+     * Portable across H2 (MODE=MySQL) and MySQL.
+     */
+    private static final String GUARDED_INSERT_SQL =
+            "INSERT INTO billing_charge (source_id, subscriber_id, units, rate, cost)"
+                    + " SELECT ?, ?, ?, ?, ?"
+                    + " WHERE NOT EXISTS (SELECT 1 FROM billing_charge WHERE source_id = ?)";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Constructs the writer.
+     *
+     * @param jdbcTemplate the JDBC template backed by the host's DataSource
+     */
+    public BillingChargeWriter(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * Writes each {@link BillingCharge} in the chunk using an idempotent guarded INSERT.
+     *
+     * <p>A charge whose {@code source_id} already exists in {@code billing_charge} is
+     * silently skipped (0 rows affected). A charge being written for the first time
+     * produces exactly 1 row.
+     *
+     * @param chunk the batch of billing charges to persist
+     */
+    @Override
+    public void write(Chunk<? extends BillingCharge> chunk) {
+        for (BillingCharge charge : chunk) {
+            int updated = jdbcTemplate.update(
+                    GUARDED_INSERT_SQL,
+                    charge.sourceId(),
+                    charge.subscriberId(),
+                    charge.units(),
+                    charge.rateMinor(),
+                    charge.costMinor(),
+                    charge.sourceId());   // WHERE NOT EXISTS lookup key
+
+            if (updated == 0) {
+                log.debug(
+                        "billing_charge source_id={} already exists — skipping INSERT (no-op)",
+                        charge.sourceId());
+            } else {
+                log.debug("billing_charge source_id={} inserted cost={}",
+                        charge.sourceId(), charge.costMinor());
+            }
+        }
+        log.info("Writer committed {} items", chunk.size());
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidator.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidator.java
@@ -1,0 +1,61 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersValidator;
+
+/**
+ * Fail-fast pre-flight validation of job parameters for {@code partitioned-harvester-job}.
+ *
+ * <p>Registered on the {@code JobBuilder}, so it runs at job launch <strong>before any step
+ * starts</strong>. Invalid or zero/negative parameter values produce a clean
+ * {@link InvalidJobParametersException} rather than a mid-step failure.
+ *
+ * <h3>Validations performed</h3>
+ * <ol>
+ *   <li>{@code GRID_SIZE}, if present, must be a positive long (≥ 1).</li>
+ *   <li>{@code CHUNK_SIZE}, if present, must be a positive long (≥ 1).</li>
+ * </ol>
+ *
+ * <h3>Missing parameters</h3>
+ * <p>Missing parameters are treated as valid — the plugin's {@code getDefaultParameters()}
+ * provides the defaults, which are applied at job launch time by the host framework.
+ *
+ * <h3>gridSize build-time constraint note</h3>
+ * <p>{@code configureJob} receives no {@code JobParameters}, so the partition count and
+ * thread-pool size are baked in at construction time using {@code GRID_SIZE_DEFAULT = 4}.
+ * If {@code GRID_SIZE} is supplied at launch, it controls validator acceptance but does NOT
+ * change the number of physical partitions — this is a single-JVM pedagogical constraint.
+ * For a future enhancement that reads gridSize dynamically, the partitioner and step builder
+ * would need a holder populated by a {@code JobExecutionListener.beforeJob}.
+ *
+ * @see com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin
+ */
+public class PartitionedHarvesterJobParametersValidator implements JobParametersValidator {
+
+    /**
+     * Validates the job parameters.
+     *
+     * @param parameters the parameters to validate; may be empty but must not be null
+     * @throws InvalidJobParametersException if {@code GRID_SIZE} or {@code CHUNK_SIZE}
+     *         is present and not a positive value (zero or negative)
+     */
+    @Override
+    public void validate(JobParameters parameters) throws InvalidJobParametersException {
+        if (parameters == null) {
+            throw new InvalidJobParametersException("Job parameters must not be null");
+        }
+
+        Long gridSize = parameters.getLong("GRID_SIZE");
+        if (gridSize != null && gridSize <= 0) {
+            throw new InvalidJobParametersException(
+                    "GRID_SIZE must be a positive value (>= 1), got: " + gridSize);
+        }
+
+        Long chunkSize = parameters.getLong("CHUNK_SIZE");
+        if (chunkSize != null && chunkSize <= 0) {
+            throw new InvalidJobParametersException(
+                    "CHUNK_SIZE must be a positive value (>= 1), got: " + chunkSize);
+        }
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidator.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidator.java
@@ -8,37 +8,59 @@ import org.springframework.batch.core.job.parameters.JobParametersValidator;
  * Fail-fast pre-flight validation of job parameters for {@code partitioned-harvester-job}.
  *
  * <p>Registered on the {@code JobBuilder}, so it runs at job launch <strong>before any step
- * starts</strong>. Invalid or zero/negative parameter values produce a clean
- * {@link InvalidJobParametersException} rather than a mid-step failure.
+ * starts</strong>. Invalid parameter values produce a clean
+ * {@link InvalidJobParametersException} rather than a mid-step failure or a silently ignored
+ * override.
+ *
+ * <h3>Build-time constraint (why values are pinned, not range-checked)</h3>
+ * <p>{@code configureJob} receives no {@code JobParameters}, so the partition count
+ * ({@code GRID_SIZE}) and the chunk commit size ({@code CHUNK_SIZE}) are baked in at
+ * construction time. A {@code GRID_SIZE} or {@code CHUNK_SIZE} supplied at launch therefore
+ * <strong>cannot take effect</strong>. Rather than silently ignore such an override (a
+ * footgun: the caller asks for 8 partitions and silently gets 4), this validator rejects any
+ * value that differs from the build-time constant, with a message that explains the
+ * constraint. This makes the single-JVM pedagogical limitation impossible to miss.
  *
  * <h3>Validations performed</h3>
  * <ol>
- *   <li>{@code GRID_SIZE}, if present, must be a positive long (≥ 1).</li>
- *   <li>{@code CHUNK_SIZE}, if present, must be a positive long (≥ 1).</li>
+ *   <li>Parameters object must not be null.</li>
+ *   <li>{@code GRID_SIZE}, if present, must equal the build-time grid size.</li>
+ *   <li>{@code CHUNK_SIZE}, if present, must equal the build-time chunk size.</li>
  * </ol>
  *
  * <h3>Missing parameters</h3>
- * <p>Missing parameters are treated as valid — the plugin's {@code getDefaultParameters()}
- * provides the defaults, which are applied at job launch time by the host framework.
+ * <p>Missing parameters are valid — the plugin's {@code getDefaultParameters()} supplies the
+ * defaults, which equal the build-time constants.
  *
- * <h3>gridSize build-time constraint note</h3>
- * <p>{@code configureJob} receives no {@code JobParameters}, so the partition count and
- * thread-pool size are baked in at construction time using {@code GRID_SIZE_DEFAULT = 4}.
- * If {@code GRID_SIZE} is supplied at launch, it controls validator acceptance but does NOT
- * change the number of physical partitions — this is a single-JVM pedagogical constraint.
- * For a future enhancement that reads gridSize dynamically, the partitioner and step builder
- * would need a holder populated by a {@code JobExecutionListener.beforeJob}.
+ * <p>A future enhancement that reads {@code GRID_SIZE} dynamically (via a
+ * {@code JobExecutionListener.beforeJob} → holder → partitioner wiring) would replace the
+ * equality checks here with positivity range checks.
  *
  * @see com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin
  */
 public class PartitionedHarvesterJobParametersValidator implements JobParametersValidator {
 
+    private final long expectedGridSize;
+    private final long expectedChunkSize;
+
+    /**
+     * Constructs the validator with the build-time constants it must enforce.
+     *
+     * @param expectedGridSize  the build-time partition count baked into {@code configureJob}
+     * @param expectedChunkSize the build-time chunk commit size baked into {@code configureJob}
+     */
+    public PartitionedHarvesterJobParametersValidator(long expectedGridSize, long expectedChunkSize) {
+        this.expectedGridSize = expectedGridSize;
+        this.expectedChunkSize = expectedChunkSize;
+    }
+
     /**
      * Validates the job parameters.
      *
-     * @param parameters the parameters to validate; may be empty but must not be null
-     * @throws InvalidJobParametersException if {@code GRID_SIZE} or {@code CHUNK_SIZE}
-     *         is present and not a positive value (zero or negative)
+     * @param parameters the parameters to validate; must not be null (may be empty)
+     * @throws InvalidJobParametersException if {@code parameters} is null, or if
+     *         {@code GRID_SIZE}/{@code CHUNK_SIZE} is present and differs from its build-time
+     *         constant (overrides cannot take effect in this single-JVM plugin)
      */
     @Override
     public void validate(JobParameters parameters) throws InvalidJobParametersException {
@@ -47,15 +69,19 @@ public class PartitionedHarvesterJobParametersValidator implements JobParameters
         }
 
         Long gridSize = parameters.getLong("GRID_SIZE");
-        if (gridSize != null && gridSize <= 0) {
+        if (gridSize != null && gridSize != expectedGridSize) {
             throw new InvalidJobParametersException(
-                    "GRID_SIZE must be a positive value (>= 1), got: " + gridSize);
+                    "GRID_SIZE is fixed at " + expectedGridSize + " at build time in this "
+                            + "single-JVM plugin and cannot be overridden at launch (got: "
+                            + gridSize + "). Omit it to use the build-time default.");
         }
 
         Long chunkSize = parameters.getLong("CHUNK_SIZE");
-        if (chunkSize != null && chunkSize <= 0) {
+        if (chunkSize != null && chunkSize != expectedChunkSize) {
             throw new InvalidJobParametersException(
-                    "CHUNK_SIZE must be a positive value (>= 1), got: " + chunkSize);
+                    "CHUNK_SIZE is fixed at " + expectedChunkSize + " at build time in this "
+                            + "single-JVM plugin and cannot be overridden at launch (got: "
+                            + chunkSize + "). Omit it to use the build-time default.");
         }
     }
 }

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterReader.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterReader.java
@@ -1,0 +1,184 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.listener.StepExecutionListener;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.batch.infrastructure.item.ItemStreamException;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.batch.infrastructure.item.ItemStreamReader;
+import org.springframework.batch.infrastructure.item.database.JdbcCursorItemReader;
+
+/**
+ * Per-partition worker reader that isolates state across parallel threads using a
+ * {@link ThreadLocal}-scoped {@link JdbcCursorItemReader}.
+ *
+ * <h3>Why ThreadLocal instead of {@code @StepScope}</h3>
+ * <p>Plugin classes are instantiated via {@code getDeclaredConstructor().newInstance()} — no
+ * Spring application context, so {@code @StepScope} is unavailable. The
+ * {@link org.springframework.batch.core.partition.support.TaskExecutorPartitionHandler}
+ * invokes the SAME step object on N threads concurrently. A plain instance-field delegate
+ * would cause race conditions between worker threads. A {@link ThreadLocal} guarantees each
+ * thread owns its own {@link JdbcCursorItemReader} from {@code beforeStep} through
+ * {@code afterStep} — the entire lifecycle runs on a single thread per partition.
+ *
+ * <h3>Registration</h3>
+ * <p>This class must be registered as BOTH the step's {@code reader} AND as a
+ * {@code StepExecutionListener} (via {@code .listener((Object) reader)}) on the worker step
+ * builder. This ensures {@link #beforeStep(StepExecution)} fires before
+ * {@link #open(ExecutionContext)}.
+ *
+ * <h3>Restart safety</h3>
+ * <p>{@code setSaveState(true)} is set on each per-thread delegate. Spring Batch persists
+ * {@code currentItemCount} to {@code BATCH_STEP_EXECUTION_CONTEXT} on every chunk commit.
+ * On restart, the delegate re-opens the cursor and fast-forwards past already-committed rows
+ * using the saved count, so the partition resumes from its last committed offset.
+ *
+ * <h3>SQL injection safety</h3>
+ * <p>The range SQL uses {@code ?} placeholders bound via {@code PreparedStatementSetter}.
+ * The {@code minId} and {@code maxId} values are never concatenated into the SQL string.
+ *
+ * @see ItemStreamReader
+ * @see StepExecutionListener
+ */
+public class PartitionedHarvesterReader
+        implements ItemStreamReader<UsageRecord>, StepExecutionListener {
+
+    private static final Logger log = LoggerFactory.getLogger(PartitionedHarvesterReader.class);
+
+    /** SQL: read only rows within the assigned partition range, ordered for stable restart. */
+    private static final String RANGE_SQL =
+            "SELECT id, subscriber_id, units, rate"
+                    + " FROM usage_record"
+                    + " WHERE id BETWEEN ? AND ?"
+                    + " ORDER BY id";
+
+    private final DataSource dataSource;
+
+    /**
+     * Per-thread delegate reader. Each worker thread sets its own delegate in
+     * {@link #beforeStep(StepExecution)} and removes it in {@link #afterStep(StepExecution)}.
+     */
+    private final ThreadLocal<JdbcCursorItemReader<UsageRecord>> threadLocal = new ThreadLocal<>();
+
+    /**
+     * Constructs the reader.
+     *
+     * @param dataSource the DataSource used to open per-thread JDBC cursors
+     */
+    public PartitionedHarvesterReader(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    /**
+     * Invoked by Spring Batch before the step opens the reader. Reads {@code minId} and
+     * {@code maxId} from the step's {@link ExecutionContext} (populated by the partitioner),
+     * builds a {@link JdbcCursorItemReader} bound to that range, and stores it in
+     * the calling thread's {@link ThreadLocal}.
+     *
+     * <p>Must be called on the same thread that will subsequently call {@link #open},
+     * {@link #read}, {@link #update}, and {@link #close}. This is guaranteed by
+     * {@code TaskExecutorPartitionHandler}.
+     *
+     * @param stepExecution the current step execution containing partition range keys
+     */
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        ExecutionContext ctx = stepExecution.getExecutionContext();
+        long minId = ctx.getLong("minId");
+        long maxId = ctx.getLong("maxId");
+        String stepName = stepExecution.getStepName();
+
+        log.info("beforeStep: thread={} step={} minId={} maxId={}",
+                Thread.currentThread().getName(), stepName, minId, maxId);
+
+        JdbcCursorItemReader<UsageRecord> delegate =
+                new JdbcCursorItemReader<>(dataSource, RANGE_SQL, new UsageRecordRowMapper());
+
+        // Unique name per partition so Spring Batch stores state under a distinct key
+        delegate.setName("usageReader-" + stepName);
+
+        // Persist currentItemCount to BATCH_STEP_EXECUTION_CONTEXT on each chunk commit
+        // so the cursor can fast-forward past already-committed rows on restart.
+        delegate.setSaveState(true);
+
+        // Bind minId and maxId as PreparedStatement parameters — injection-safe
+        delegate.setPreparedStatementSetter(new PreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps) throws SQLException {
+                ps.setLong(1, minId);
+                ps.setLong(2, maxId);
+            }
+        });
+
+        threadLocal.set(delegate);
+    }
+
+    /**
+     * Removes the ThreadLocal delegate after the step completes. Called on the same thread
+     * that ran the partition. Prevents memory leaks in thread-pool environments.
+     *
+     * @param stepExecution the completed step execution (not used)
+     * @return {@code null} (no exit-status override required)
+     */
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        log.debug("afterStep: cleaning up ThreadLocal for thread={}", Thread.currentThread().getName());
+        threadLocal.remove();
+        return null;
+    }
+
+    /**
+     * Opens the underlying per-thread delegate reader.
+     *
+     * @param executionContext the step execution context (passed to the delegate for restart state)
+     * @throws ItemStreamException if the delegate cannot open its cursor
+     */
+    @Override
+    public void open(ExecutionContext executionContext) throws ItemStreamException {
+        threadLocal.get().open(executionContext);
+    }
+
+    /**
+     * Reads the next {@link UsageRecord} from the current thread's partition cursor.
+     *
+     * @return the next item, or {@code null} if the partition is exhausted
+     * @throws NullPointerException if {@link #beforeStep(StepExecution)} was not called on
+     *         this thread (or {@link #afterStep(StepExecution)} has already cleaned up)
+     */
+    @Override
+    public UsageRecord read() throws Exception {
+        return threadLocal.get().read();
+    }
+
+    /**
+     * Updates the per-thread delegate's execution context (persists cursor offset for restart).
+     *
+     * @param executionContext the context to update
+     */
+    @Override
+    public void update(ExecutionContext executionContext) {
+        JdbcCursorItemReader<UsageRecord> delegate = threadLocal.get();
+        if (delegate != null) {
+            delegate.update(executionContext);
+        }
+    }
+
+    /**
+     * Closes the per-thread delegate reader and releases JDBC resources.
+     *
+     * @throws ItemStreamException if the delegate cannot close cleanly
+     */
+    @Override
+    public void close() throws ItemStreamException {
+        JdbcCursorItemReader<UsageRecord> delegate = threadLocal.get();
+        if (delegate != null) {
+            delegate.close();
+        }
+    }
+}

--- a/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/RatingProcessor.java
+++ b/partitioned-harvester-job/src/main/java/com/fronzec/plugins/partitionedharvester/batch/RatingProcessor.java
@@ -1,0 +1,46 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import org.springframework.batch.infrastructure.item.ItemProcessor;
+
+/**
+ * Applies flat-rate billing to a {@link UsageRecord}, producing an immutable
+ * {@link BillingCharge}.
+ *
+ * <h3>Cost computation</h3>
+ * <p>{@code cost = units × rate}, computed with {@link Math#multiplyExact} to detect
+ * overflow at processing time rather than silently wrapping into an incorrect value.
+ * An {@link ArithmeticException} from {@code multiplyExact} propagates as a non-skippable
+ * exception, failing the chunk and the partition immediately — operator intervention is
+ * required to fix the source data.
+ *
+ * <h3>Idempotency</h3>
+ * <p>The processor is stateless and side-effect-free. The same input always produces the
+ * same output, so re-processing after a restart does not alter cost values.
+ *
+ * @see BillingCharge
+ * @see UsageRecord
+ */
+public class RatingProcessor implements ItemProcessor<UsageRecord, BillingCharge> {
+
+    /**
+     * Converts a {@link UsageRecord} into a {@link BillingCharge}.
+     *
+     * <p>The {@code sourceId} of the resulting charge equals the {@code id} of the input
+     * record — this 1:1 mapping is the key used by {@code BillingChargeWriter} to enforce
+     * idempotency via the UNIQUE constraint on {@code billing_charge.source_id}.
+     *
+     * @param item the usage record to rate
+     * @return the corresponding billing charge with {@code costMinor = units × rateMinor}
+     * @throws ArithmeticException if {@code units × rateMinor} overflows {@code long}
+     */
+    @Override
+    public BillingCharge process(UsageRecord item) {
+        long cost = Math.multiplyExact(item.units(), item.rateMinor());
+        return new BillingCharge(
+                item.id(),
+                item.subscriberId(),
+                item.units(),
+                item.rateMinor(),
+                cost);
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/BillingChargeWriterTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/BillingChargeWriterTest.java
@@ -1,0 +1,155 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.infrastructure.item.Chunk;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link BillingChargeWriter} using an in-memory H2 database.
+ *
+ * <p>Covers: single write, idempotency (same source_id twice), batch write,
+ * mixed batch (new + duplicate), and frozen-source verification (usage_record not touched).
+ */
+class BillingChargeWriterTest {
+
+    private JdbcTemplate jdbc;
+    private BillingChargeWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:writer-billing-test-"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        jdbc = new JdbcTemplate(ds);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + " id BIGINT PRIMARY KEY,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS billing_charge ("
+                        + " id BIGINT AUTO_INCREMENT PRIMARY KEY,"
+                        + " source_id BIGINT NOT NULL,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " cost BIGINT NOT NULL,"
+                        + " job_execution_id BIGINT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_billing_charge_source UNIQUE (source_id)"
+                        + ")");
+
+        writer = new BillingChargeWriter(jdbc);
+    }
+
+    private void insertUsageRecord(long id) {
+        jdbc.update(
+                "INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?, 100, 5, 3)",
+                id);
+    }
+
+    private int countBillingCharges() {
+        Integer count = jdbc.queryForObject("SELECT COUNT(*) FROM billing_charge", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    private long getCostForSourceId(long sourceId) {
+        Long cost = jdbc.queryForObject(
+                "SELECT cost FROM billing_charge WHERE source_id = ?", Long.class, sourceId);
+        return cost != null ? cost : -1L;
+    }
+
+    // ── Single write ──────────────────────────────────────────────────────────
+
+    @Test
+    void write_singleCharge_insertsOneRow() throws Exception {
+        BillingCharge charge = new BillingCharge(1L, 100L, 5L, 3L, 15L);
+
+        writer.write(new Chunk<>(charge));
+
+        assertThat(countBillingCharges()).isEqualTo(1);
+        assertThat(getCostForSourceId(1L)).isEqualTo(15L);
+    }
+
+    // ── Idempotency — same source_id twice is a no-op ─────────────────────────
+
+    @Test
+    void write_sameSourceIdTwice_stillOneRow_costUnchanged() throws Exception {
+        BillingCharge first = new BillingCharge(5L, 200L, 10L, 4L, 40L);
+        BillingCharge duplicate = new BillingCharge(5L, 200L, 10L, 4L, 40L);
+
+        writer.write(new Chunk<>(first));
+        writer.write(new Chunk<>(duplicate));
+
+        assertThat(countBillingCharges()).isEqualTo(1);
+        assertThat(getCostForSourceId(5L)).isEqualTo(40L);
+    }
+
+    // ── Batch write ───────────────────────────────────────────────────────────
+
+    @Test
+    void write_batchOfThree_insertsThreeRows() throws Exception {
+        BillingCharge c1 = new BillingCharge(10L, 300L, 2L, 5L, 10L);
+        BillingCharge c2 = new BillingCharge(11L, 301L, 3L, 5L, 15L);
+        BillingCharge c3 = new BillingCharge(12L, 302L, 4L, 5L, 20L);
+
+        writer.write(new Chunk<>(c1, c2, c3));
+
+        assertThat(countBillingCharges()).isEqualTo(3);
+    }
+
+    // ── Mixed batch (1 new + 1 duplicate) ────────────────────────────────────
+
+    @Test
+    void write_mixedBatch_duplicateSkipped_newInserted() throws Exception {
+        BillingCharge existing = new BillingCharge(20L, 400L, 1L, 1L, 1L);
+        writer.write(new Chunk<>(existing));
+        assertThat(countBillingCharges()).isEqualTo(1);
+
+        BillingCharge duplicate = new BillingCharge(20L, 400L, 1L, 1L, 1L);
+        BillingCharge newCharge = new BillingCharge(21L, 401L, 2L, 2L, 4L);
+        writer.write(new Chunk<>(duplicate, newCharge));
+
+        // Total: still 2 rows (not 3)
+        assertThat(countBillingCharges()).isEqualTo(2);
+        assertThat(getCostForSourceId(20L)).isEqualTo(1L);
+        assertThat(getCostForSourceId(21L)).isEqualTo(4L);
+    }
+
+    // ── Frozen-source: usage_record is NOT modified ───────────────────────────
+
+    @Test
+    void write_doesNotMutateUsageRecord() throws Exception {
+        insertUsageRecord(30L);
+
+        BillingCharge charge = new BillingCharge(30L, 100L, 5L, 3L, 15L);
+        writer.write(new Chunk<>(charge));
+
+        // usage_record row should still exist and be unchanged
+        List<Long> ids = jdbc.queryForList("SELECT id FROM usage_record", Long.class);
+        assertThat(ids).containsExactly(30L);
+    }
+
+    // ── Empty chunk ───────────────────────────────────────────────────────────
+
+    @Test
+    void write_emptyChunk_insertsNothing() throws Exception {
+        writer.write(new Chunk<>());
+
+        assertThat(countBillingCharges()).isEqualTo(0);
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidatorTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidatorTest.java
@@ -12,14 +12,15 @@ import org.springframework.batch.core.job.parameters.JobParametersBuilder;
  * Unit tests for {@link PartitionedHarvesterJobParametersValidator}.
  *
  * <p>Mirrors the pattern from {@code HarvestJobParametersValidatorTest}.
- * Covers: null parameters, zero/negative GRID_SIZE, zero/negative CHUNK_SIZE,
- * missing parameters (treated as valid — defaults applied at runtime),
- * and valid parameter combinations per REQ-08 and SC-08.x.
+ * Covers: null parameters, GRID_SIZE/CHUNK_SIZE that differ from the build-time constants
+ * (rejected — overrides cannot take effect in this single-JVM plugin), missing parameters
+ * (valid — defaults applied at runtime), and the build-time defaults themselves (valid),
+ * per REQ-08 and SC-08.x.
  */
 class PartitionedHarvesterJobParametersValidatorTest {
 
     private final PartitionedHarvesterJobParametersValidator validator =
-            new PartitionedHarvesterJobParametersValidator();
+            new PartitionedHarvesterJobParametersValidator(4L, 100L);
 
     private JobParameters params(Long gridSize, Long chunkSize) {
         JobParametersBuilder b = new JobParametersBuilder();
@@ -72,27 +73,29 @@ class PartitionedHarvesterJobParametersValidatorTest {
                 .hasMessageContaining("CHUNK_SIZE");
     }
 
-    // ── SC-08.3 — Valid params accepted ──────────────────────────────────────
+    // ── SC-08.3 — Only the build-time defaults are accepted ──────────────────
 
     @Test
     void validate_defaultValues_noException() {
-        // Defaults: GRID_SIZE=4, CHUNK_SIZE=100
+        // Build-time constants: GRID_SIZE=4, CHUNK_SIZE=100
         assertThatCode(() -> validator.validate(params(4L, 100L)))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    void validate_customValidValues_noException() {
-        // Non-default but positive values: SC-08.3
-        assertThatCode(() -> validator.validate(params(8L, 50L)))
-                .doesNotThrowAnyException();
+    void validate_nonDefaultGridSize_throws() {
+        // A GRID_SIZE override cannot take effect (build-time constraint) → rejected loudly
+        assertThatThrownBy(() -> validator.validate(params(8L, 100L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("GRID_SIZE");
     }
 
     @Test
-    void validate_smallValidValues_noException() {
-        // Minimum valid case
-        assertThatCode(() -> validator.validate(params(1L, 1L)))
-                .doesNotThrowAnyException();
+    void validate_nonDefaultChunkSize_throws() {
+        // A CHUNK_SIZE override cannot take effect (build-time constraint) → rejected loudly
+        assertThatThrownBy(() -> validator.validate(params(4L, 50L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("CHUNK_SIZE");
     }
 
     // ── Missing parameters — treated as valid (defaults applied at launch) ────

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidatorTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobParametersValidatorTest.java
@@ -1,0 +1,120 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.job.parameters.InvalidJobParametersException;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+
+/**
+ * Unit tests for {@link PartitionedHarvesterJobParametersValidator}.
+ *
+ * <p>Mirrors the pattern from {@code HarvestJobParametersValidatorTest}.
+ * Covers: null parameters, zero/negative GRID_SIZE, zero/negative CHUNK_SIZE,
+ * missing parameters (treated as valid — defaults applied at runtime),
+ * and valid parameter combinations per REQ-08 and SC-08.x.
+ */
+class PartitionedHarvesterJobParametersValidatorTest {
+
+    private final PartitionedHarvesterJobParametersValidator validator =
+            new PartitionedHarvesterJobParametersValidator();
+
+    private JobParameters params(Long gridSize, Long chunkSize) {
+        JobParametersBuilder b = new JobParametersBuilder();
+        if (gridSize != null) {
+            b.addLong("GRID_SIZE", gridSize);
+        }
+        if (chunkSize != null) {
+            b.addLong("CHUNK_SIZE", chunkSize);
+        }
+        return b.toJobParameters();
+    }
+
+    // ── Null parameters guard ─────────────────────────────────────────────────
+
+    @Test
+    void validate_nullParameters_throws() {
+        assertThatThrownBy(() -> validator.validate(null))
+                .isInstanceOf(InvalidJobParametersException.class);
+    }
+
+    // ── SC-08.1 — GRID_SIZE = 0 is rejected ──────────────────────────────────
+
+    @Test
+    void validate_gridSizeZero_throws() {
+        assertThatThrownBy(() -> validator.validate(params(0L, 100L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("GRID_SIZE");
+    }
+
+    @Test
+    void validate_gridSizeNegative_throws() {
+        assertThatThrownBy(() -> validator.validate(params(-1L, 100L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("GRID_SIZE");
+    }
+
+    // ── SC-08.2 — CHUNK_SIZE = 0 or negative is rejected ─────────────────────
+
+    @Test
+    void validate_chunkSizeZero_throws() {
+        assertThatThrownBy(() -> validator.validate(params(4L, 0L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("CHUNK_SIZE");
+    }
+
+    @Test
+    void validate_chunkSizeNegative_throws() {
+        assertThatThrownBy(() -> validator.validate(params(4L, -1L)))
+                .isInstanceOf(InvalidJobParametersException.class)
+                .hasMessageContaining("CHUNK_SIZE");
+    }
+
+    // ── SC-08.3 — Valid params accepted ──────────────────────────────────────
+
+    @Test
+    void validate_defaultValues_noException() {
+        // Defaults: GRID_SIZE=4, CHUNK_SIZE=100
+        assertThatCode(() -> validator.validate(params(4L, 100L)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_customValidValues_noException() {
+        // Non-default but positive values: SC-08.3
+        assertThatCode(() -> validator.validate(params(8L, 50L)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_smallValidValues_noException() {
+        // Minimum valid case
+        assertThatCode(() -> validator.validate(params(1L, 1L)))
+                .doesNotThrowAnyException();
+    }
+
+    // ── Missing parameters — treated as valid (defaults applied at launch) ────
+
+    @Test
+    void validate_missingGridSize_noException() {
+        // Only CHUNK_SIZE provided; GRID_SIZE absent → valid (default will be used)
+        assertThatCode(() -> validator.validate(params(null, 100L)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_missingChunkSize_noException() {
+        // Only GRID_SIZE provided; CHUNK_SIZE absent → valid (default will be used)
+        assertThatCode(() -> validator.validate(params(4L, null)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_noParametersAtAll_noException() {
+        // Both absent → valid (all defaults apply)
+        assertThatCode(() -> validator.validate(params(null, null)))
+                .doesNotThrowAnyException();
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterReaderTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterReaderTest.java
@@ -1,0 +1,228 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link PartitionedHarvesterReader}.
+ *
+ * <p>Tests cover: beforeStep range binding, open/read/close delegation, afterStep
+ * ThreadLocal cleanup, and thread isolation for concurrent partitions.
+ */
+class PartitionedHarvesterReaderTest {
+
+    private JdbcDataSource dataSource;
+    private JdbcTemplate jdbc;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new JdbcDataSource();
+        // Unique DB per test run; DB_CLOSE_DELAY=-1 keeps it alive across threads
+        dataSource.setURL(
+                "jdbc:h2:mem:reader-test-"
+                        + System.nanoTime()
+                        + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+        jdbc = new JdbcTemplate(dataSource);
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + " id BIGINT PRIMARY KEY,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+    }
+
+    private void insertRow(long id, long subscriberId, long units, long rate) {
+        jdbc.update(
+                "INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?, ?, ?, ?)",
+                id, subscriberId, units, rate);
+    }
+
+    private StepExecution stepExecution(long minId, long maxId, String stepName) {
+        ExecutionContext ctx = new ExecutionContext();
+        ctx.putLong("minId", minId);
+        ctx.putLong("maxId", maxId);
+        return TestStepExecutionFactory.create(stepName, ctx);
+    }
+
+    // ── WU-06-A: beforeStep binds range and reads only rows in range ──────────
+
+    @Test
+    void beforeStep_readsOnlyRowsInRange() throws Exception {
+        // Insert rows 1-10
+        for (long i = 1; i <= 10; i++) {
+            insertRow(i, 100L, 5L, 3L);
+        }
+
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+
+        StepExecution step = stepExecution(3L, 6L, "usageWorkerStep:partition0");
+        reader.beforeStep(step);
+
+        ExecutionContext ctx = new ExecutionContext();
+        reader.open(ctx);
+
+        List<Long> ids = new ArrayList<>();
+        UsageRecord record;
+        while ((record = reader.read()) != null) {
+            ids.add(record.id());
+        }
+        reader.close();
+
+        assertThat(ids).containsExactly(3L, 4L, 5L, 6L);
+    }
+
+    // ── WU-06-B: open/read/close delegate to ThreadLocal ─────────────────────
+
+    @Test
+    void openReadClose_delegateToThreadLocal() throws Exception {
+        insertRow(1L, 100L, 10L, 2L);
+        insertRow(2L, 101L, 20L, 3L);
+
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+        reader.beforeStep(stepExecution(1L, 2L, "usageWorkerStep:partition0"));
+
+        ExecutionContext ctx = new ExecutionContext();
+        reader.open(ctx);
+
+        UsageRecord first = reader.read();
+        assertThat(first).isNotNull();
+        assertThat(first.id()).isEqualTo(1L);
+        assertThat(first.units()).isEqualTo(10L);
+        assertThat(first.rateMinor()).isEqualTo(2L);
+
+        UsageRecord second = reader.read();
+        assertThat(second).isNotNull();
+        assertThat(second.id()).isEqualTo(2L);
+
+        UsageRecord end = reader.read();
+        assertThat(end).isNull();
+
+        reader.close();
+    }
+
+    // ── WU-06-C: afterStep removes ThreadLocal (leak guard) ──────────────────
+
+    @Test
+    void afterStep_removesThreadLocal_readThrowsAfter() throws Exception {
+        insertRow(1L, 100L, 5L, 3L);
+
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+        reader.beforeStep(stepExecution(1L, 1L, "usageWorkerStep:partition0"));
+
+        ExecutionContext ctx = new ExecutionContext();
+        reader.open(ctx);
+        reader.read();
+        reader.close();
+
+        // afterStep should remove the ThreadLocal
+        reader.afterStep(stepExecution(1L, 1L, "usageWorkerStep:partition0"));
+
+        // After cleanup, read() must throw NullPointerException (no delegate)
+        assertThatThrownBy(reader::read)
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    // ── WU-06-D: thread isolation — two threads read disjoint ranges ──────────
+
+    @Test
+    void threadIsolation_concurrentReaders_doNotCrossContaminate() throws Exception {
+        // Insert rows 1-10
+        for (long i = 1; i <= 10; i++) {
+            insertRow(i, 200L, 1L, 1L);
+        }
+
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+
+        CountDownLatch beforeStepDone = new CountDownLatch(2);
+        CountDownLatch startRead = new CountDownLatch(1);
+        AtomicReference<List<Long>> thread1Ids = new AtomicReference<>();
+        AtomicReference<List<Long>> thread2Ids = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        Future<?> f1 = pool.submit(() -> {
+            try {
+                reader.beforeStep(stepExecution(1L, 5L, "usageWorkerStep:partition0"));
+                beforeStepDone.countDown();
+                startRead.await();
+                ExecutionContext ctx = new ExecutionContext();
+                reader.open(ctx);
+                List<Long> ids = new ArrayList<>();
+                UsageRecord rec;
+                while ((rec = reader.read()) != null) {
+                    ids.add(rec.id());
+                }
+                reader.close();
+                reader.afterStep(stepExecution(1L, 5L, "usageWorkerStep:partition0"));
+                thread1Ids.set(ids);
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        });
+
+        Future<?> f2 = pool.submit(() -> {
+            try {
+                reader.beforeStep(stepExecution(6L, 10L, "usageWorkerStep:partition1"));
+                beforeStepDone.countDown();
+                startRead.await();
+                ExecutionContext ctx = new ExecutionContext();
+                reader.open(ctx);
+                List<Long> ids = new ArrayList<>();
+                UsageRecord rec;
+                while ((rec = reader.read()) != null) {
+                    ids.add(rec.id());
+                }
+                reader.close();
+                reader.afterStep(stepExecution(6L, 10L, "usageWorkerStep:partition1"));
+                thread2Ids.set(ids);
+            } catch (Throwable t) {
+                error.set(t);
+            }
+        });
+
+        beforeStepDone.await();
+        startRead.countDown();
+        f1.get();
+        f2.get();
+        pool.shutdown();
+
+        assertThat(error.get()).isNull();
+        assertThat(thread1Ids.get()).containsExactly(1L, 2L, 3L, 4L, 5L);
+        assertThat(thread2Ids.get()).containsExactly(6L, 7L, 8L, 9L, 10L);
+    }
+
+    // ── WU-06-E: empty range reads 0 rows ────────────────────────────────────
+
+    @Test
+    void emptyRange_readsZeroRows() throws Exception {
+        // Table is empty
+        PartitionedHarvesterReader reader = new PartitionedHarvesterReader(dataSource);
+        reader.beforeStep(stepExecution(1L, 0L, "usageWorkerStep:partition0"));
+
+        ExecutionContext ctx = new ExecutionContext();
+        reader.open(ctx);
+        assertThat(reader.read()).isNull();
+        reader.close();
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/RatingProcessorTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/RatingProcessorTest.java
@@ -1,0 +1,77 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link RatingProcessor}.
+ *
+ * <p>Covers: SC-03.1 per-record cost, boundary values, overflow guard via
+ * {@link Math#multiplyExact}, and BillingCharge field mapping.
+ */
+class RatingProcessorTest {
+
+    private final RatingProcessor processor = new RatingProcessor();
+
+    // ── SC-03.1 — Per-record cost correctness ────────────────────────────────
+
+    @Test
+    void process_standard_computesCostCorrectly() throws Exception {
+        // units=5, rate=3 → cost=15
+        UsageRecord record = new UsageRecord(7L, 101L, 5L, 3L);
+        BillingCharge charge = processor.process(record);
+
+        assertThat(charge).isNotNull();
+        assertThat(charge.costMinor()).isEqualTo(15L);
+    }
+
+    @Test
+    void process_unitOne_rateOne_costOne() throws Exception {
+        UsageRecord record = new UsageRecord(1L, 200L, 1L, 1L);
+        BillingCharge charge = processor.process(record);
+
+        assertThat(charge.costMinor()).isEqualTo(1L);
+    }
+
+    @Test
+    void process_unitZero_costZero() throws Exception {
+        UsageRecord record = new UsageRecord(2L, 300L, 0L, 100L);
+        BillingCharge charge = processor.process(record);
+
+        assertThat(charge.costMinor()).isEqualTo(0L);
+    }
+
+    // ── Overflow guard — Math.multiplyExact ──────────────────────────────────
+
+    @Test
+    void process_overflow_throwsArithmeticException() {
+        UsageRecord record = new UsageRecord(99L, 999L, Long.MAX_VALUE, 2L);
+
+        assertThatThrownBy(() -> processor.process(record))
+                .isInstanceOf(ArithmeticException.class);
+    }
+
+    // ── BillingCharge field mapping ───────────────────────────────────────────
+
+    @Test
+    void process_sourceIdMatchesUsageRecordId() throws Exception {
+        UsageRecord record = new UsageRecord(42L, 500L, 10L, 5L);
+        BillingCharge charge = processor.process(record);
+
+        assertThat(charge.sourceId()).isEqualTo(42L);
+    }
+
+    @Test
+    void process_allFieldsMappedCorrectly() throws Exception {
+        UsageRecord record = new UsageRecord(10L, 777L, 20L, 4L);
+        BillingCharge charge = processor.process(record);
+
+        assertThat(charge.sourceId()).isEqualTo(10L);
+        assertThat(charge.subscriberId()).isEqualTo(777L);
+        assertThat(charge.units()).isEqualTo(20L);
+        assertThat(charge.rateMinor()).isEqualTo(4L);
+        assertThat(charge.costMinor()).isEqualTo(80L);
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/TestStepExecutionFactory.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/TestStepExecutionFactory.java
@@ -1,0 +1,36 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.JobInstance;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.step.StepExecution;
+import org.springframework.batch.infrastructure.item.ExecutionContext;
+
+/**
+ * Test utility that constructs minimal {@link StepExecution} instances for unit tests.
+ *
+ * <p>Avoids the need for a full Spring Batch infrastructure (JobRepository, DataSource, etc.)
+ * in unit tests that only need a step execution context with specific keys set.
+ */
+final class TestStepExecutionFactory {
+
+    private TestStepExecutionFactory() {}
+
+    /**
+     * Creates a {@link StepExecution} with the given step name and a pre-populated
+     * {@link ExecutionContext} containing the provided key-value pairs.
+     *
+     * @param stepName         the step name to use
+     * @param executionContext  the pre-populated execution context (copied into the step)
+     * @return a minimal StepExecution suitable for unit tests
+     */
+    static StepExecution create(String stepName, ExecutionContext executionContext) {
+        JobInstance instance = new JobInstance(1L, "partitioned-harvester-job");
+        JobExecution jobExecution = new JobExecution(1L, instance, new JobParameters());
+        StepExecution stepExecution = new StepExecution(stepName, jobExecution);
+        // Copy all keys from the provided context into the step's execution context
+        executionContext.entrySet().forEach(entry ->
+                stepExecution.getExecutionContext().put(entry.getKey(), entry.getValue()));
+        return stepExecution;
+    }
+}


### PR DESCRIPTION
## Summary

This is PR-2 of the `partitioned-harvester-job` plugin, stacked on merged PR-1 (#54).
Implements the full business-logic layer: the ThreadLocal reader, the rating processor,
the idempotent writer, the parameter validator, and the plugin class that wires everything
into a runnable partitioned job.

### Work units

- **WU-06 — PartitionedHarvesterReader** (`ItemStreamReader<UsageRecord>` + `StepExecutionListener`): ThreadLocal-scoped `JdbcCursorItemReader` delegate. `beforeStep` reads `minId`/`maxId` from the step ExecutionContext and builds a delegate with `setSaveState(true)` and a `PreparedStatementSetter` (injection-safe, no string concatenation). `afterStep` calls `threadLocal.remove()` as a leak guard. 5 tests: range isolation, open/read/close delegation, afterStep cleanup, concurrent thread isolation (two threads / two disjoint ranges), empty-range no-op.
- **WU-07 — RatingProcessor** (`ItemProcessor<UsageRecord, BillingCharge>`): flat rate `cost = Math.multiplyExact(units, rate)` — overflow-safe. Returns an immutable `BillingCharge` carrying the source `id` as `sourceId`. 6 tests: standard cost, boundary values, overflow throws `ArithmeticException`, full field mapping.
- **WU-08 — BillingChargeWriter** (`ItemWriter<BillingCharge>`): guarded INSERT keyed on `source_id` via `INSERT … SELECT … WHERE NOT EXISTS` — portable across H2 (MODE=MySQL) and MySQL. Silent no-op on duplicate `source_id` (0 rows affected, no exception). Never touches `usage_record`. 6 tests: single insert, idempotency on re-write, batch of three, mixed batch with duplicate, frozen-source assertion, empty chunk.
- **WU-09 — PartitionedHarvesterJobParametersValidator**: validates `GRID_SIZE` and `CHUNK_SIZE` as positive longs when present; missing parameters are valid (defaults apply). Mirrors the `HarvestJobParametersValidator` null-guard pattern. 11 tests.
- **WU-10 — PartitionedHarvesterJobPlugin**: `configureJob` builds `IdRangePartitioner(jdbc, GRID_SIZE_DEFAULT)` + manually constructed `ThreadPoolTaskExecutor` (core=max=4, queueCapacity=0, afterPropertiesSet()) + worker chunk step (reader+listener, processor, writer) + manager `PartitionStep` + job with validator. Static inner `PartitionedHarvesterJobMetadata`. Full build: 39 tests GREEN.

### ThreadLocal design — why no `@StepScope`

Plugin classes are loaded via `getDeclaredConstructor().newInstance()` — no Spring application context, so `@StepScope` is not available. `TaskExecutorPartitionHandler` executes the SAME step object on N threads concurrently; a plain instance-field delegate would race. A `ThreadLocal` gives each thread its own `JdbcCursorItemReader` for the duration of one partition lifecycle (`beforeStep → open → read → close → afterStep`), which is guaranteed to run entirely on a single thread by `TaskExecutorPartitionHandler`.

### gridSize build-time constraint

`configureJob` receives no `JobParameters`, so the partition count and thread-pool size are baked in at build time: `GRID_SIZE_DEFAULT = 4`. Both the `IdRangePartitioner` constructor and `PartitionStepBuilder.gridSize(N)` receive this same constant — a required invariant so Spring Batch's internal `StepExecutionSplitter` and the partitioner agree on the count. The `GRID_SIZE` JobParameter is validated (must be positive) but does NOT dynamically resize the grid in this pedagogical implementation. Documented in `PartitionedHarvesterJobPlugin` Javadoc and `PartitionedHarvesterJobParametersValidator`.

### Chain context

```
PR-1 (#54, merged) → scaffold + schema + domain types + IdRangePartitioner
PR-2 (this)        → reader + processor + writer + validator + plugin wiring  📍
PR-3 (follow-up)   → integration tests + restart test + CI + README
```

PR-3 will add the headline correctness/restart integration tests, the Maven CI step, and the README (including the frozen-source precondition warning and restart pitfall).

### Size exception

This PR carries `size:exception` (~815 lines). All five classes are batch pipeline components that a Spring Batch reviewer evaluates as a cohesive unit; splitting reader from processor artificially fragments the pipeline.

## Test plan

- [x] `mvn -B package -f partitioned-harvester-job/pom.xml` — 39 tests GREEN, shaded JAR produced
- [x] TDD RED→GREEN confirmed for WU-06, WU-07, WU-08, WU-09 (compilation failures observed before implementation)
- [x] Thread isolation test: two concurrent threads read disjoint ranges without cross-contamination
- [x] Idempotency test: same `source_id` written twice → still 1 row, cost unchanged
- [x] Overflow test: `Long.MAX_VALUE × 2` → `ArithmeticException`
- [ ] Integration tests (WU-11, WU-12) — PR-3