### PR TITLE
feat(partitioned-harvester): PR-3 integration tests, partitioned restart, CI, README

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -53,6 +53,8 @@ jobs:
         run: mvn -B package -f ticket-bundle-job/pom.xml
       - name: Build and test fault-tolerant-harvester-job plugin
         run: mvn -B package -f fault-tolerant-harvester-job/pom.xml
+      - name: Build and test partitioned-harvester-job plugin
+        run: mvn -B package -f partitioned-harvester-job/pom.xml
 
   docker:
     needs: build

--- a/partitioned-harvester-job/README.md
+++ b/partitioned-harvester-job/README.md
@@ -1,0 +1,286 @@
+# partitioned-harvester-job
+
+Spring Batch plugin demonstrating id-range partitioning for parallel billing: one
+`billing_charge` per `usage_record`, flat-rate cost (`units × rate`), parallel
+execution via a bounded thread pool, and — most importantly — **partitioned restart
+with no double-billing**. Delivered as a standalone shaded JAR and loaded dynamically
+by the `fr-batch-service` host.
+
+## Purpose
+
+This module is a pedagogical showcase of Spring Batch 6 partitioning primitives:
+
+| Scenario | Mechanism |
+|---|---|
+| Cheap partitioning | `SELECT MIN(id), MAX(id)` — no full-table scan |
+| Parallel execution | `TaskExecutorPartitionHandler` over a `ThreadPoolTaskExecutor` |
+| Per-partition reader isolation | `ThreadLocal<JdbcCursorItemReader>` (no `@StepScope`) |
+| Idempotent write | Guarded `INSERT … WHERE NOT EXISTS` on UNIQUE `source_id` |
+| Partitioned restart | `saveState(true)` → cursor offset per partition; completed partitions skip |
+| No double-billing proof | UNIQUE `billing_charge.source_id` makes re-running a no-op |
+
+## Architecture
+
+```
+IdRangePartitioner
+  SELECT MIN(id), MAX(id) FROM usage_record
+  → N ExecutionContexts {minId, maxId, partitionName}
+        │
+        ▼
+  PartitionStep (usageManagerStep)
+    TaskExecutorPartitionHandler [gridSize=4 threads]
+        │ per partition
+        ▼
+  Worker chunk step (usageWorkerStep) ×N
+    PartitionedHarvesterReader [ThreadLocal JdbcCursorItemReader]
+      WHERE id BETWEEN minId AND maxId ORDER BY id
+        │
+    RatingProcessor
+      cost = Math.multiplyExact(units, rate)
+        │
+    BillingChargeWriter
+      INSERT INTO billing_charge … WHERE NOT EXISTS (… WHERE source_id = ?)
+```
+
+### Key components
+
+| Class | Role |
+|---|---|
+| `PartitionedHarvesterJobPlugin` | Plugin entry point; builds all steps and the job |
+| `IdRangePartitioner` | Computes N equal-width id ranges using MIN/MAX arithmetic |
+| `PartitionedHarvesterReader` | `ItemStreamReader` + `StepExecutionListener`; ThreadLocal delegate |
+| `RatingProcessor` | Stateless flat-rate processor; uses `Math.multiplyExact` |
+| `BillingChargeWriter` | Idempotent writer with guarded INSERT |
+| `PartitionedHarvesterJobParametersValidator` | Fail-fast parameter validation |
+
+### Partitioning vs chunking (important distinction)
+
+- **Partition** — the unit of parallelism AND restart. Each partition covers an id range.
+  `gridSize` = number of partitions = number of parallel worker threads. Larger gridSize
+  means more parallelism but also more Spring Batch metadata rows.
+- **Chunk** — the unit of transaction commit. Each chunk commits at most `chunkSize` items.
+  Smaller chunkSize = more frequent commits = finer-grained restart checkpoints within a
+  partition; larger chunkSize = fewer commits = higher throughput.
+
+`gridSize` and `chunkSize` are independent. Doubling `chunkSize` does not change the
+number of partitions or the partition boundaries.
+
+### Why over-partition?
+
+Setting `gridSize` to a small multiple of the physical thread-pool size (e.g. `gridSize=8`
+with 4 threads) acts as a work queue: large partitions finish slower than small ones, and
+free threads can pick up the remaining partitions. This absorbs skew from id gaps.
+
+For this plugin, `gridSize` equals the thread-pool size (both default to 4) because the
+table is assumed to have roughly uniform id density.
+
+### ThreadLocal reader — why no `@StepScope`
+
+`configureJob` constructs all beans without a Spring application context, so `@StepScope`
+and `@Value("#{stepExecutionContext[...]}")` are unavailable. The single worker step object
+is reused across N threads by `TaskExecutorPartitionHandler`. If a plain instance field
+held the per-partition reader, one thread's `beforeStep` would overwrite another thread's
+state.
+
+The solution: `PartitionedHarvesterReader` implements both `ItemStreamReader` and
+`StepExecutionListener`. Its `beforeStep(stepExecution)` reads `minId`/`maxId` from the
+execution context and stores a fully-configured `JdbcCursorItemReader` in a
+`ThreadLocal`. Spring Batch guarantees that `beforeStep → open → read → close → afterStep`
+all execute on the same thread (the one `TaskExecutorPartitionHandler` assigned to this
+partition). `afterStep` calls `threadLocal.remove()` to prevent leaks.
+
+## Job parameters
+
+| Parameter | Type | Default | Identifying | Description |
+|-----------|------|---------|-------------|-------------|
+| `GRID_SIZE` | Long | 4 | Yes | Number of partitions (parallelism). See the constraint note below. |
+| `CHUNK_SIZE` | Long | 100 | Yes | Items per commit (memory vs throughput). See the constraint note below. |
+
+Parameters are validated fail-fast by `PartitionedHarvesterJobParametersValidator` before
+any step runs.
+
+### gridSize/chunkSize build-time constraint (known gap — SC-07.1)
+
+`configureJob` receives no `JobParameters`, so the partition count and thread-pool size are
+baked in at build time using the constants `GRID_SIZE_DEFAULT=4` and `CHUNK_SIZE_DEFAULT=100`.
+
+A `GRID_SIZE` or `CHUNK_SIZE` value supplied at launch **cannot take effect**. Rather than
+silently ignoring an override (which would be a footgun: you ask for 8 partitions and
+silently get 4), the validator **rejects** any value that differs from the build-time
+constant with a message that explains the constraint:
+
+```
+GRID_SIZE is fixed at 4 at build time in this single-JVM plugin and cannot be overridden
+at launch (got: 8). Omit it to use the build-time default.
+```
+
+Full runtime-dynamic `gridSize` resolution (via a `JobExecutionListener.beforeJob` →
+holder → partitioner wiring) is a known enhancement deferred to a future PR.
+
+**Implication for restart**: use the default `gridSize=4` when launching; omit `GRID_SIZE`
+and `CHUNK_SIZE` parameters entirely.
+
+## Frozen-source precondition (REQ-09)
+
+> **CRITICAL**: `usage_record` MUST NOT be mutated between the start of a job run and
+> its completion, including any restart.
+
+The partitioner computes partition boundaries using `SELECT MIN(id), MAX(id)`. Both runs of
+a restart use the same identifying parameters; the ranges produced on Run 2 MUST be
+identical to Run 1 for the restart to be correct.
+
+If `usage_record` is mutated between runs:
+- Rows inserted with ids outside the original `[MIN, MAX]` range will NOT be included in
+  any partition range — they will be silently skipped.
+- Rows deleted may leave gaps. Arithmetic ranges still cover `[MIN, MAX]`, so empty ranges
+  are harmless, but the final `billing_charge` count may not equal `COUNT(usage_record)`.
+- `MIN(id)` or `MAX(id)` changing creates different ranges on Run 2. Previously-completed
+  partitions may no longer map to the same id ranges, breaking the restart guarantee.
+
+**Consequence of violation**: restart correctness is void. The only safe approach is to
+treat `usage_record` as immutable for the duration of a job run.
+
+## Restart behavior
+
+A partitioned restart is the headline capability of this plugin.
+
+### What Spring Batch saves
+
+For each worker step, Spring Batch writes a `BATCH_STEP_EXECUTION` row and a
+`BATCH_STEP_EXECUTION_CONTEXT` row (because `saveState(true)` is set on the reader).
+The context stores the reader's `currentItemCount` after each chunk commit.
+
+### On Run 2 (identical identifying parameters)
+
+1. Spring Batch finds the existing `FAILED` `JobExecution` for the same `JobInstance`.
+2. The manager step checks each worker step's previous status.
+3. Steps that are already `COMPLETED` are **skipped** — their partitions are not re-run.
+4. Steps that are `FAILED` or `STARTED` are **restarted** — the reader reopens the cursor
+   and fast-forwards past the already-committed items using the saved `currentItemCount`.
+5. The job reaches `COMPLETED` when all worker steps are `COMPLETED`.
+
+### No double-billing guarantee
+
+Even if the cursor restart replays items from the beginning of a partially-committed chunk
+(the chunk offset is stored per-commit, not per-item), the `BillingChargeWriter` uses a
+guarded `INSERT … WHERE NOT EXISTS`. Any `billing_charge` row that already exists for a
+`source_id` is silently skipped. The UNIQUE constraint on `billing_charge.source_id` is
+the final safety net.
+
+### Restart pitfall — identical parameters are required
+
+> **CRITICAL**: re-launching with ANY change to an identifying parameter creates a NEW
+> `JobInstance` — a fresh run from scratch, not a restart.
+
+Use the **same** `RUN_DATE` (or whichever identifying parameters you supply) on both runs.
+Introducing a `RUN_ID` or incrementing a counter creates a new `JobInstance`.
+
+## Schema (V8 migration)
+
+### `usage_record`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT AUTO_INCREMENT PK` | Partition key; MIN/MAX used for range computation |
+| `subscriber_id` | `BIGINT NOT NULL` | |
+| `units` | `BIGINT NOT NULL` | Billable usage units consumed |
+| `rate` | `BIGINT NOT NULL` | Flat rate in minor currency units per usage unit |
+| `recorded_at` | `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` | |
+| `created_at` | `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` | |
+
+No `processed` column — `usage_record` is FROZEN and never mutated by the job.
+
+### `billing_charge`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGINT AUTO_INCREMENT PK` | |
+| `source_id` | `BIGINT NOT NULL` | Soft FK to `usage_record.id`; UNIQUE (idempotency key) |
+| `subscriber_id` | `BIGINT NOT NULL` | Copied from source row |
+| `units` | `BIGINT NOT NULL` | Copied from source row |
+| `rate` | `BIGINT NOT NULL` | Copied from source row |
+| `cost` | `BIGINT NOT NULL` | `units × rate`, computed with `Math.multiplyExact` |
+| `job_execution_id` | `BIGINT NULL` | Optional audit: which execution produced this row |
+| `recorded_at` | `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` | |
+
+UNIQUE constraint: `uk_billing_charge_source UNIQUE (source_id)`.
+
+Created by Flyway migration `V8__partitioned_harvester_tables.sql`.
+
+## Building the fat JAR
+
+Requires Maven and a GitHub Packages token (the `batch-job-api` dependency is hosted there).
+
+Configure `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Then build:
+
+```bash
+mvn -B package -f partitioned-harvester-job/pom.xml
+```
+
+The shaded JAR is produced at
+`partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar`. All Spring Batch /
+Spring Framework / SLF4J dependencies are `provided` and excluded from the shade.
+
+## Running via the REST API
+
+### 1. Upload the JAR
+
+```bash
+curl -X POST http://localhost:8080/api/batch-service/jobs/upload \
+  -F "file=@partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar" \
+  -F "jobName=partitioned-harvester-job" \
+  -F "version=1.0.0" \
+  -F "mainClassName=com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin"
+```
+
+### 2. Run the job
+
+```bash
+# Omit GRID_SIZE and CHUNK_SIZE — defaults (4 and 100) are applied automatically.
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "partitioned-harvester-job",
+    "params": {
+      "RUN_DATE": "2026-06-16"
+    }
+  }'
+```
+
+### 3. Restart after a failure (identical parameters)
+
+```bash
+# Use the SAME RUN_DATE (and any other identifying params) as the failed run:
+curl -X POST http://localhost:8080/api/batch-service/jobs/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jobBeanName": "partitioned-harvester-job",
+    "params": {
+      "RUN_DATE": "2026-06-16"
+    }
+  }'
+```
+
+Spring Batch detects the existing `FAILED` execution, skips completed partitions, resumes
+the failed partition from its last committed chunk offset, and completes without
+double-billing any record.
+
+## Schema dependency
+
+This plugin requires the `usage_record` and `billing_charge` tables from Flyway migration
+`V8__partitioned_harvester_tables.sql`. Ensure the host has run at least V8 before loading
+this plugin.

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobIntegrationTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobIntegrationTest.java
@@ -1,0 +1,412 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * End-to-end integration tests for {@link PartitionedHarvesterJobPlugin}.
+ *
+ * <p>Uses an isolated in-module H2 database with {@code MODE=MySQL;DB_CLOSE_DELAY=-1}
+ * (multi-thread safe; DB survives for the full JVM lifetime). Spring Batch metadata
+ * and application tables are bootstrapped once per class; {@code billing_charge} is
+ * truncated before each test.
+ *
+ * <h3>Seed dataset (24 rows, gridSize=4)</h3>
+ * <p>Contiguous ids 1–24; partition ranges with MIN=1, MAX=24, gridSize=4:
+ * <ul>
+ *   <li>rangeSize = (24-1)/4 = 5 (integer division)</li>
+ *   <li>partition0: ids [1,5]   — 5 rows, subscriber 100, units=10, rate=5, cost=50 each → Σ=250</li>
+ *   <li>partition1: ids [6,10]  — 5 rows, subscriber 101, units=20, rate=3, cost=60 each → Σ=300</li>
+ *   <li>partition2: ids [11,15] — 5 rows, subscriber 102, units=5,  rate=8, cost=40 each → Σ=200</li>
+ *   <li>partition3: ids [16,24] — 9 rows, subscriber 103, units=15, rate=4, cost=60 each → Σ=540</li>
+ * </ul>
+ * <p>Expected total: Σcost = 250 + 300 + 200 + 540 = 1290.
+ *
+ * <h3>Scenarios covered</h3>
+ * <ol>
+ *   <li>Correctness and sum: COUNT=24, SUM(cost)=1440 after a full run.</li>
+ *   <li>Parallelism: exactly 4 worker BATCH_STEP_EXECUTION rows with status COMPLETED.</li>
+ *   <li>1:1 idempotency: no duplicate source_id; re-run does not change count or sum.</li>
+ *   <li>Bounded memory: 1000-row run with CHUNK_SIZE=100 (default) completes correctly;
+ *       passing is a proxy for cursor-based bounded-memory behaviour.</li>
+ * </ol>
+ *
+ * @see PartitionedHarvesterRestartIntegrationTest for the partitioned restart proof
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PartitionedHarvesterJobIntegrationTest {
+
+    /**
+     * Expected Σ(units × rate) for the 24-row seed dataset.
+     * partition0: ids 1-5  → 5×(10×5)  = 5×50  = 250
+     * partition1: ids 6-10 → 5×(20×3)  = 5×60  = 300
+     * partition2: ids 11-15→ 5×(5×8)   = 5×40  = 200
+     * partition3: ids 16-24→ 9×(15×4)  = 9×60  = 540
+     * Total: 250 + 300 + 200 + 540 = 1290
+     */
+    private static final long EXPECTED_SUM_COST = 1290L;
+
+    /** Total usage_record rows in the fixed seed. */
+    private static final int SEED_ROW_COUNT = 24;
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private StaticApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        // DB_CLOSE_DELAY=-1 keeps the in-memory database alive for the entire test class run.
+        // MODE=MySQL makes H2 accept MySQL-compatible DDL and the guarded INSERT ... WHERE NOT EXISTS.
+        ds.setURL("jdbc:h2:mem:partitioned-it-"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Bootstrap Spring Batch metadata schema (BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION, ...)
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Create application tables inline (mirrors the DDL from V8 Flyway migration)
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS billing_charge ("
+                        + " id BIGINT AUTO_INCREMENT PRIMARY KEY,"
+                        + " source_id BIGINT NOT NULL,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " cost BIGINT NOT NULL,"
+                        + " job_execution_id BIGINT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_billing_charge_source UNIQUE (source_id)"
+                        + ")");
+
+        // Bootstrap Spring Batch JobRepository
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub ApplicationContext exposing only the DataSource (mirrors existing IT pattern)
+        stubContext = new StaticApplicationContext();
+        stubContext.getBeanFactory().registerSingleton("dataSource", ds);
+        stubContext.refresh();
+
+        // Insert the fixed 24-row seed (frozen source; only truncated implicitly if needed)
+        insertSeedData();
+    }
+
+    /**
+     * Reset billing_charge before each test. usage_record is the frozen source and is
+     * not modified between tests. Seed is inserted once in @BeforeAll.
+     */
+    @BeforeEach
+    void cleanBillingCharge() {
+        jdbc.execute("DELETE FROM billing_charge");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Inserts the deterministic 24-row seed dataset.
+     *
+     * <p>Partition membership (MIN=1, MAX=24, gridSize=4, rangeSize=5):
+     * <pre>
+     *   partition0: ids  1-5  subscriber=100 units=10 rate=5  cost=50  Σ=300
+     *   partition1: ids  6-10 subscriber=101 units=20 rate=3  cost=60  Σ=360
+     *   partition2: ids 11-15 subscriber=102 units=5  rate=8  cost=40  Σ=240
+     *   partition3: ids 16-24 subscriber=103 units=15 rate=4  cost=60  Σ=540
+     *   Total Σcost = 1440
+     * </pre>
+     */
+    private void insertSeedData() {
+        // partition0: ids 1-5, subscriber=100, units=10, rate=5 → cost=50
+        for (long id = 1L; id <= 5L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 100L, 10L, 5L);
+        }
+        // partition1: ids 6-10, subscriber=101, units=20, rate=3 → cost=60
+        for (long id = 6L; id <= 10L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 101L, 20L, 3L);
+        }
+        // partition2: ids 11-15, subscriber=102, units=5, rate=8 → cost=40
+        for (long id = 11L; id <= 15L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 102L, 5L, 8L);
+        }
+        // partition3: ids 16-24, subscriber=103, units=15, rate=4 → cost=60
+        for (long id = 16L; id <= 24L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 103L, 15L, 4L);
+        }
+    }
+
+    private int countBillingCharges() {
+        Integer count = jdbc.queryForObject("SELECT COUNT(*) FROM billing_charge", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    private long sumCost() {
+        Long sum = jdbc.queryForObject("SELECT SUM(cost) FROM billing_charge", Long.class);
+        return sum != null ? sum : 0L;
+    }
+
+    private int countDistinctSourceIds() {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(DISTINCT source_id) FROM billing_charge", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    /**
+     * Launches the partitioned-harvester job with a unique run-discriminator so each test
+     * creates a fresh JobInstance. The identifying parameter {@code RUN_ID} differentiates
+     * job instances; GRID_SIZE and CHUNK_SIZE are omitted (defaults apply and pass validation).
+     *
+     * @param runId unique discriminator for this job instance
+     * @return the final BatchStatus of the execution
+     */
+    private BatchStatus runJob(String runId) throws Exception {
+        PartitionedHarvesterJobPlugin plugin = new PartitionedHarvesterJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("RUN_DATE", "2026-06-16")
+                .addString("RUN_ID", runId)
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        return execution.getStatus();
+    }
+
+    // ── Scenario 1: Correctness and sum ──────────────────────────────────────────
+
+    /**
+     * Full run correctness: COUNT(billing_charge)==24 and SUM(cost)==1440 after COMPLETED job.
+     * Verifies REQ-03 (SC-03.2 sum) and REQ-04 (SC-04.1 count).
+     */
+    @Test
+    void correctnessAndSum_fullRun_countAndSumMatch() throws Exception {
+        BatchStatus status = runJob("correctness-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(countBillingCharges())
+                .as("billing_charge must have exactly one row per usage_record")
+                .isEqualTo(SEED_ROW_COUNT);
+        assertThat(sumCost())
+                .as("SUM(cost) must equal the pre-computed Σ(units×rate)")
+                .isEqualTo(EXPECTED_SUM_COST);
+    }
+
+    /**
+     * Per-record cost correctness: spot-check that each charge cost equals units × rate.
+     * Verifies REQ-03 (SC-03.1).
+     */
+    @Test
+    void correctness_perRecordCost_matchesUnitsTimesRate() throws Exception {
+        BatchStatus status = runJob("per-record-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+
+        // Spot-check one charge per partition
+        // id=3:  units=10, rate=5  → cost=50
+        Long cost3 = jdbc.queryForObject(
+                "SELECT cost FROM billing_charge WHERE source_id = 3", Long.class);
+        assertThat(cost3).isEqualTo(50L);
+
+        // id=8:  units=20, rate=3  → cost=60
+        Long cost8 = jdbc.queryForObject(
+                "SELECT cost FROM billing_charge WHERE source_id = 8", Long.class);
+        assertThat(cost8).isEqualTo(60L);
+
+        // id=12: units=5,  rate=8  → cost=40
+        Long cost12 = jdbc.queryForObject(
+                "SELECT cost FROM billing_charge WHERE source_id = 12", Long.class);
+        assertThat(cost12).isEqualTo(40L);
+
+        // id=20: units=15, rate=4  → cost=60
+        Long cost20 = jdbc.queryForObject(
+                "SELECT cost FROM billing_charge WHERE source_id = 20", Long.class);
+        assertThat(cost20).isEqualTo(60L);
+    }
+
+    // ── Scenario 2: Parallelism ───────────────────────────────────────────────────
+
+    /**
+     * Parallelism proof: exactly 4 worker step executions with COMPLETED status exist in
+     * BATCH_STEP_EXECUTION for this specific job execution. Verifies REQ-02 (SC-02.1).
+     */
+    @Test
+    void parallelism_workerStepCount_exactlyGridSize() throws Exception {
+        PartitionedHarvesterJobPlugin plugin = new PartitionedHarvesterJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("RUN_DATE", "2026-06-16")
+                .addString("RUN_ID", "parallel-" + System.nanoTime())
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        JobExecution execution = launcher.run(job, params);
+        assertThat(execution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+
+        long jobExecutionId = execution.getId();
+
+        // Query worker step executions for THIS job execution only
+        List<Map<String, Object>> stepExecs = jdbc.queryForList(
+                "SELECT STEP_NAME, STATUS FROM BATCH_STEP_EXECUTION"
+                        + " WHERE JOB_EXECUTION_ID = ?"
+                        + " AND STEP_NAME LIKE 'usageWorkerStep:%'"
+                        + " AND STATUS = 'COMPLETED'",
+                jobExecutionId);
+
+        assertThat(stepExecs)
+                .as("Exactly gridSize=4 worker step executions must be COMPLETED for this execution")
+                .hasSize(4);
+
+        // Confirm each expected partition name is present
+        List<String> stepNames = stepExecs.stream()
+                .map(r -> (String) r.get("STEP_NAME"))
+                .toList();
+        assertThat(stepNames).containsExactlyInAnyOrder(
+                "usageWorkerStep:partition0",
+                "usageWorkerStep:partition1",
+                "usageWorkerStep:partition2",
+                "usageWorkerStep:partition3");
+    }
+
+    // ── Scenario 3: 1:1 idempotency ──────────────────────────────────────────────
+
+    /**
+     * No duplicate source_id in billing_charge: COUNT == COUNT(DISTINCT source_id).
+     * Verifies REQ-04 (SC-04.1).
+     */
+    @Test
+    void idempotency_noDuplicateSourceId_afterFullRun() throws Exception {
+        BatchStatus status = runJob("no-dup-" + System.nanoTime());
+
+        assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(countBillingCharges()).isEqualTo(SEED_ROW_COUNT);
+        assertThat(countDistinctSourceIds())
+                .as("COUNT(DISTINCT source_id) must equal COUNT(*) — no duplicates")
+                .isEqualTo(SEED_ROW_COUNT);
+    }
+
+    /**
+     * Re-run idempotency: a second job launch with NEW identifying params (fresh JobInstance)
+     * does not duplicate billing_charge rows (guarded INSERT is a no-op for existing charges).
+     * Verifies REQ-04 (SC-04.2).
+     */
+    @Test
+    void idempotency_freshReRunAfterCompletion_countAndSumUnchanged() throws Exception {
+        // First run: writes all 24 charges
+        BatchStatus run1Status = runJob("idem-run1-" + System.nanoTime());
+        assertThat(run1Status).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(countBillingCharges()).isEqualTo(SEED_ROW_COUNT);
+        assertThat(sumCost()).isEqualTo(EXPECTED_SUM_COST);
+
+        // Second run: fresh JobInstance (different RUN_ID) — guarded INSERT skips all 24
+        BatchStatus run2Status = runJob("idem-run2-" + System.nanoTime());
+        assertThat(run2Status).isEqualTo(BatchStatus.COMPLETED);
+
+        // Count and sum must be unchanged: second run is a no-op for all rows
+        assertThat(countBillingCharges())
+                .as("Second run with same data must not create duplicate billing_charge rows")
+                .isEqualTo(SEED_ROW_COUNT);
+        assertThat(sumCost())
+                .as("SUM(cost) must be unchanged after idempotent re-run")
+                .isEqualTo(EXPECTED_SUM_COST);
+    }
+
+    // ── Scenario 4: Bounded memory ────────────────────────────────────────────────
+
+    /**
+     * Bounded-memory proxy: inserts 1000 additional rows and runs with the default CHUNK_SIZE=100.
+     *
+     * <p>The job must COMPLETE and process all rows. If the cursor-based reader were
+     * materialising the whole partition in memory, it would either OOM or (in this test)
+     * simply have an outsized heap footprint. The assertion is correctness-under-load —
+     * passing is the bounded-memory signal. Verifies REQ-06 (SC-06.1).
+     *
+     * <p>The extra 1000 rows use ids 25–1024 and are cleaned up after the test via a
+     * compensating DELETE so they do not leak into other tests.
+     */
+    @Test
+    void boundedMemory_largeDataset_jobCompletesCorrectly() throws Exception {
+        // Insert 1000 additional rows with ids 25-1024
+        // units=10, rate=2 → cost=20 each → extra total = 1000 × 20 = 20000
+        long extraStart = 25L;
+        long extraEnd = 1024L;
+        long extraCount = extraEnd - extraStart + 1; // 1000
+        long extraCost = extraCount * 20L;           // 20000
+        for (long id = extraStart; id <= extraEnd; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 200L, 10L, 2L);
+        }
+
+        try {
+            BatchStatus status = runJob("bounded-mem-" + System.nanoTime());
+            assertThat(status).isEqualTo(BatchStatus.COMPLETED);
+            // 24 seed rows + 1000 extra rows
+            assertThat(countBillingCharges())
+                    .as("All 1024 usage_record rows must produce exactly one billing_charge")
+                    .isEqualTo((int) (SEED_ROW_COUNT + extraCount));
+            assertThat(sumCost())
+                    .as("SUM(cost) must include both seed rows (1290) and extra rows (20000)")
+                    .isEqualTo(EXPECTED_SUM_COST + extraCost);
+        } finally {
+            // Clean up extra rows so they do not affect other tests
+            jdbc.execute("DELETE FROM usage_record WHERE id >= 25 AND id <= 1024");
+        }
+    }
+}

--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterRestartIntegrationTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterRestartIntegrationTest.java
@@ -1,0 +1,383 @@
+package com.fronzec.plugins.partitionedharvester.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin;
+import java.sql.Connection;
+import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.support.TaskExecutorJobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.repository.support.JdbcJobRepositoryFactoryBean;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.init.ScriptUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Integration test proving partitioned restart with NO double-billing for
+ * {@link PartitionedHarvesterJobPlugin} (spec REQ-05, SC-05.1, SC-05.2).
+ *
+ * <h3>Failure-injection mechanism</h3>
+ * <p>No production code is changed. The already-built {@link RatingProcessor} calls
+ * {@link Math#multiplyExact} to compute {@code cost = units × rate}. By inserting a
+ * POISON row with {@code units = Long.MAX_VALUE / 2 + 1} and {@code rate = 3}, the
+ * multiplication overflows and {@code Math.multiplyExact} throws {@link ArithmeticException}.
+ * Since the chunk step has no skip or retry configuration, the exception propagates
+ * immediately and the worker step for that partition FAILS.
+ *
+ * <h3>Partition layout (MIN=1, MAX=24, gridSize=4, rangeSize=5)</h3>
+ * <pre>
+ *   partition0: ids [1,5]   — normal rows, complete and commit 5 charges in Run 1
+ *   partition1: ids [6,10]  — normal rows, complete and commit 5 charges in Run 1
+ *   partition2: ids [11,15] — contains POISON row at id=13, worker FAILS in Run 1
+ *   partition3: ids [16,24] — normal rows, complete and commit 9 charges in Run 1
+ * </pre>
+ *
+ * <h3>Restart scenario</h3>
+ * <ol>
+ *   <li><b>Seed</b>: 24 usage_record rows; id=13 has {@code units=Long.MAX_VALUE/2+1, rate=3}
+ *       (overflow poison). All other rows are normal.</li>
+ *   <li><b>Run 1</b>: launched with identifying params {@code RUN_DATE="2026-06-16"}.
+ *       partition0, partition1, and partition3 complete and commit their charges.
+ *       partition2 processes ids 11, 12 then fails on id=13 ({@code ArithmeticException}).
+ *       Chunk rollback removes any partial partition2 writes. Job status: FAILED.</li>
+ *   <li><b>Data fix</b>: UPDATE id=13 to safe values ({@code units=5, rate=8}).
+ *       JobParameters are NOT changed — this is the operator fix, not a new run.</li>
+ *   <li><b>Run 2</b>: re-launched with <em>identical</em> identifying params
+ *       ({@code RUN_DATE="2026-06-16"}). Spring Batch finds the existing FAILED execution
+ *       for the same {@code JobInstance} and restarts. Completed partitions (0, 1, 3) are
+ *       SKIPPED. Only partition2 resumes; its {@code JdbcCursorItemReader} restores cursor
+ *       offset from {@code BATCH_STEP_EXECUTION_CONTEXT} (saveState=true). Job: COMPLETED.</li>
+ * </ol>
+ *
+ * <h3>Key assertions</h3>
+ * <ul>
+ *   <li>Run 1 status is FAILED; {@code billing_charge} has the 19 charges from partitions 0, 1, 3
+ *       but 0 charges from partition2 (whole chunk rolled back).</li>
+ *   <li>Run 2 status is COMPLETED; {@code COUNT(billing_charge) == 24} (no double-billing).</li>
+ *   <li>{@code SUM(cost) == 1290} (expected total for the full 24-row seed).</li>
+ *   <li>{@code COUNT(DISTINCT source_id) == 24} — explicit no-duplicate proof.</li>
+ *   <li>Both executions share exactly ONE {@code JOB_INSTANCE_ID} in {@code BATCH_JOB_EXECUTION}.</li>
+ * </ul>
+ *
+ * <h3>Why DB_CLOSE_DELAY=-1 is critical</h3>
+ * <p>The H2 URL uses {@code DB_CLOSE_DELAY=-1}, which keeps the in-memory database alive for
+ * the duration of the JVM process. Both launches share the same {@link DataSource},
+ * {@link JobRepository}, and {@link StaticApplicationContext}, so Spring Batch metadata
+ * (BATCH_JOB_INSTANCE, BATCH_JOB_EXECUTION, BATCH_STEP_EXECUTION, BATCH_STEP_EXECUTION_CONTEXT)
+ * persists between runs. Only the {@link Job} instance is re-created for each launch.
+ *
+ * <h3>Restart pitfall (identical JobParameters required)</h3>
+ * <p>Run 2 uses exactly the same identifying parameters as Run 1. Changing ANY identifying
+ * parameter would create a NEW {@code JobInstance} — a fresh run from scratch, not a restart.
+ * See the module README for the full explanation.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PartitionedHarvesterRestartIntegrationTest {
+
+    /**
+     * Fixed identifying job parameter shared by both launches.
+     * Both runs must use the same value to target the same {@code JobInstance}.
+     */
+    private static final String RUN_DATE = "2026-06-16";
+
+    /**
+     * The poison row id. Placed inside partition2 range [11,15] so that partition2 fails
+     * while partitions 0, 1, and 3 complete in Run 1.
+     */
+    private static final long POISON_ID = 13L;
+
+    /**
+     * units value that causes Math.multiplyExact(units, rate) to overflow with rate=3.
+     * Long.MAX_VALUE / 2 + 1 = 4611686018427387904; multiplied by 3 overflows long.
+     */
+    private static final long POISON_UNITS = Long.MAX_VALUE / 2 + 1;
+    private static final long POISON_RATE = 3L;
+
+    /**
+     * Expected Σcost for all 24 rows after the data fix (id=13 restored to units=5, rate=8).
+     * partition0: ids 1-5   → 5×50 = 250
+     * partition1: ids 6-10  → 5×60 = 300
+     * partition2: ids 11-15 → 5×40 = 200 (id=13: after fix units=5,rate=8 → cost=40)
+     * partition3: ids 16-24 → 9×60 = 540
+     * Total: 250 + 300 + 200 + 540 = 1290
+     */
+    private static final long EXPECTED_FULL_SUM = 1290L;
+
+    /** Charges committed by partitions 0, 1, 3 in Run 1 (partition2 rolls back entirely). */
+    private static final int PARTIAL_CHARGE_COUNT = 19; // 5 + 5 + 9
+
+    private DataSource dataSource;
+    private JdbcTemplate jdbc;
+    private JobRepository jobRepository;
+    private PlatformTransactionManager txManager;
+    private StaticApplicationContext stubContext;
+
+    @BeforeAll
+    void setUpDatabase() throws Exception {
+        JdbcDataSource ds = new JdbcDataSource();
+        // DB_CLOSE_DELAY=-1 keeps the in-memory database alive for the entire JVM lifetime,
+        // which is required for Spring Batch metadata to survive BOTH launches in one JVM.
+        // DATABASE_TO_LOWER=TRUE normalises H2 column names to lowercase so
+        // jdbc.queryForList result map keys are lowercase (matching the query column aliases).
+        ds.setURL("jdbc:h2:mem:partitioned-restart-it-"
+                + System.nanoTime()
+                + ";DB_CLOSE_DELAY=-1;MODE=MySQL;DATABASE_TO_LOWER=TRUE");
+        ds.setUser("sa");
+        ds.setPassword("");
+        this.dataSource = ds;
+        this.jdbc = new JdbcTemplate(ds);
+        this.txManager = new DataSourceTransactionManager(ds);
+
+        // Bootstrap Spring Batch metadata schema
+        try (Connection conn = ds.getConnection()) {
+            ScriptUtils.executeSqlScript(conn,
+                    new ClassPathResource("org/springframework/batch/core/schema-h2.sql"));
+        }
+
+        // Create application tables (mirrors V8 Flyway migration DDL)
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS usage_record ("
+                        + " id BIGINT PRIMARY KEY AUTO_INCREMENT,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP"
+                        + ")");
+
+        jdbc.execute(
+                "CREATE TABLE IF NOT EXISTS billing_charge ("
+                        + " id BIGINT AUTO_INCREMENT PRIMARY KEY,"
+                        + " source_id BIGINT NOT NULL,"
+                        + " subscriber_id BIGINT NOT NULL,"
+                        + " units BIGINT NOT NULL,"
+                        + " rate BIGINT NOT NULL,"
+                        + " cost BIGINT NOT NULL,"
+                        + " job_execution_id BIGINT NULL,"
+                        + " recorded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+                        + " CONSTRAINT uk_billing_charge_source UNIQUE (source_id)"
+                        + ")");
+
+        // Bootstrap a single shared JobRepository — metadata persists between both launches
+        JdbcJobRepositoryFactoryBean factory = new JdbcJobRepositoryFactoryBean();
+        factory.setDataSource(ds);
+        factory.setTransactionManager(txManager);
+        factory.afterPropertiesSet();
+        this.jobRepository = factory.getObject();
+
+        // Stub ApplicationContext exposing only the DataSource
+        stubContext = new StaticApplicationContext();
+        stubContext.getBeanFactory().registerSingleton("dataSource", ds);
+        stubContext.refresh();
+
+        // Seed 24 usage_record rows. id=13 has overflow-triggering values.
+        seedUsageRecords();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    /**
+     * Inserts 24 usage_record rows. id=13 is the POISON row.
+     *
+     * <p>Partition ranges (MIN=1, MAX=24, gridSize=4, rangeSize=5):
+     * <pre>
+     *   partition0: ids 1-5   subscriber=100 units=10 rate=5  cost=50 (normal)
+     *   partition1: ids 6-10  subscriber=101 units=20 rate=3  cost=60 (normal)
+     *   partition2: ids 11-15 subscriber=102 units=5  rate=8  cost=40 (normal)
+     *                id=13:   units=POISON_UNITS rate=3 → overflow in RatingProcessor
+     *   partition3: ids 16-24 subscriber=103 units=15 rate=4  cost=60 (normal)
+     * </pre>
+     */
+    private void seedUsageRecords() {
+        // partition0: ids 1-5
+        for (long id = 1L; id <= 5L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 100L, 10L, 5L);
+        }
+        // partition1: ids 6-10
+        for (long id = 6L; id <= 10L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 101L, 20L, 3L);
+        }
+        // partition2: ids 11-15 — id=13 is the POISON row (overflow)
+        for (long id = 11L; id <= 15L; id++) {
+            if (id == POISON_ID) {
+                // Poison: units × rate overflows Math.multiplyExact
+                jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                        id, 102L, POISON_UNITS, POISON_RATE);
+            } else {
+                jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                        id, 102L, 5L, 8L);
+            }
+        }
+        // partition3: ids 16-24
+        for (long id = 16L; id <= 24L; id++) {
+            jdbc.update("INSERT INTO usage_record (id, subscriber_id, units, rate) VALUES (?,?,?,?)",
+                    id, 103L, 15L, 4L);
+        }
+    }
+
+    /**
+     * Launches the partitioned-harvester job with the fixed identifying parameters.
+     * A new {@link Job} instance is built each time (matching production behaviour), but
+     * {@link JobRepository} and {@link DataSource} are shared so Spring Batch finds the
+     * existing FAILED execution on the second call and restarts.
+     *
+     * @return the final {@link BatchStatus} of the execution
+     */
+    private JobExecution launchJob() throws Exception {
+        PartitionedHarvesterJobPlugin plugin = new PartitionedHarvesterJobPlugin();
+        Job job = plugin.configureJob(jobRepository, txManager, stubContext);
+
+        JobParameters params = new JobParametersBuilder()
+                .addString("RUN_DATE", RUN_DATE)
+                .toJobParameters();
+
+        TaskExecutorJobLauncher launcher = new TaskExecutorJobLauncher();
+        launcher.setJobRepository(jobRepository);
+        launcher.afterPropertiesSet();
+
+        return launcher.run(job, params);
+    }
+
+    private int countBillingCharges() {
+        Integer count = jdbc.queryForObject("SELECT COUNT(*) FROM billing_charge", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    private long sumCost() {
+        Long sum = jdbc.queryForObject("SELECT SUM(cost) FROM billing_charge", Long.class);
+        return sum != null ? sum : 0L;
+    }
+
+    private int countDistinctSourceIds() {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(DISTINCT source_id) FROM billing_charge", Integer.class);
+        return count != null ? count : 0;
+    }
+
+    // ── Restart scenario ──────────────────────────────────────────────────────────
+
+    /**
+     * Proves partitioned restart with no double-billing.
+     *
+     * <p>This is the headline capability of {@code partitioned-harvester-job}: a FAILED job
+     * execution is restarted with identical parameters, completed partitions are skipped,
+     * and the previously-failed partition resumes — producing exactly one {@code billing_charge}
+     * per {@code usage_record} with no duplicates.
+     */
+    @Test
+    void restart_poisonPartition2_resumesAndCompletes_noDoubleBilling() throws Exception {
+
+        // ── Run 1: FAIL ───────────────────────────────────────────────────────────
+        // partition2 fails on POISON_ID=13 (Math.multiplyExact overflow → ArithmeticException).
+        // partitions 0, 1, 3 complete and commit their charges before or concurrently.
+        // The chunk in partition2 rolls back entirely (chunkSize=100 > 5 rows in partition2
+        // range, so all 5 rows are in one chunk and none commit before the failure).
+        JobExecution run1 = launchJob();
+
+        assertThat(run1.getStatus())
+                .as("Run 1 must FAIL because partition2 hits ArithmeticException on id=13")
+                .isEqualTo(BatchStatus.FAILED);
+
+        // Partitions 0, 1, 3 committed: 5 + 5 + 9 = 19 charges
+        // Partition 2 (ids 11-15) rolled back entirely: 0 charges from it
+        assertThat(countBillingCharges())
+                .as("After Run 1 FAIL: billing_charge must contain only the 19 committed charges "
+                        + "from completed partitions (5+5+9); partition2 chunk rolled back")
+                .isEqualTo(PARTIAL_CHARGE_COUNT);
+
+        // No duplicate source_id in partial result
+        assertThat(countDistinctSourceIds())
+                .as("No duplicate source_id must exist after partial Run 1")
+                .isEqualTo(PARTIAL_CHARGE_COUNT);
+
+        // ── Operator fix: repair the poison row ───────────────────────────────────
+        // In production: operator corrects the bad source data before requesting a restart.
+        // This is a DATA fix — JobParameters do NOT change. The same identifying param
+        // (RUN_DATE="2026-06-16") will target the same JobInstance on restart.
+        jdbc.update("UPDATE usage_record SET units = 5, rate = 8 WHERE id = ?", POISON_ID);
+
+        // ── Run 2: RESTART with identical parameters ──────────────────────────────
+        // Spring Batch detects the existing FAILED execution for RUN_DATE="2026-06-16",
+        // finds the same JobInstance, and restarts the job. Completed partitions (0, 1, 3)
+        // are skipped. Only partition2 replays — its JdbcCursorItemReader restores the cursor
+        // offset from BATCH_STEP_EXECUTION_CONTEXT (saveState=true).
+        JobExecution run2 = launchJob();
+
+        assertThat(run2.getStatus())
+                .as("Run 2 must COMPLETE after the poison row is repaired")
+                .isEqualTo(BatchStatus.COMPLETED);
+
+        // ── No double-billing: exact count and sum ────────────────────────────────
+        assertThat(countBillingCharges())
+                .as("billing_charge must contain exactly one row per usage_record (24 total)")
+                .isEqualTo(24);
+
+        assertThat(sumCost())
+                .as("SUM(cost) must equal the full expected total (1290) after restart")
+                .isEqualTo(EXPECTED_FULL_SUM);
+
+        assertThat(countDistinctSourceIds())
+                .as("COUNT(DISTINCT source_id)==24 proves there is no double-billing: "
+                        + "partitions 0,1,3 are not re-processed, partition2 fills the gap")
+                .isEqualTo(24);
+
+        // ── Spring Batch metadata: 2 executions, 1 shared JobInstance ────────────
+        List<Map<String, Object>> executions = jdbc.queryForList(
+                "SELECT JOB_INSTANCE_ID, STATUS FROM BATCH_JOB_EXECUTION"
+                        + " ORDER BY JOB_EXECUTION_ID");
+
+        assertThat(executions)
+                .as("Exactly 2 JobExecutions must exist (Run 1 FAILED + Run 2 COMPLETED)")
+                .hasSize(2);
+
+        Long instanceId1 = (Long) executions.get(0).get("JOB_INSTANCE_ID");
+        Long instanceId2 = (Long) executions.get(1).get("JOB_INSTANCE_ID");
+        assertThat(instanceId1)
+                .as("Both executions must share the same JobInstance (identical identifying params)")
+                .isEqualTo(instanceId2);
+
+        assertThat(executions.get(0).get("STATUS"))
+                .as("Run 1 must be recorded as FAILED in BATCH_JOB_EXECUTION")
+                .isEqualTo("FAILED");
+        assertThat(executions.get(1).get("STATUS"))
+                .as("Run 2 must be recorded as COMPLETED in BATCH_JOB_EXECUTION")
+                .isEqualTo("COMPLETED");
+
+        // ── Completed partitions were skipped, not re-run ─────────────────────────
+        // In Run 2, only partition2 runs. Its step executions exist; partitions 0, 1, 3
+        // should NOT have new COMPLETED step executions under Run 2's JOB_EXECUTION_ID.
+        long run2ExecutionId = run2.getId();
+        List<Map<String, Object>> run2WorkerSteps = jdbc.queryForList(
+                "SELECT STEP_NAME, STATUS FROM BATCH_STEP_EXECUTION"
+                        + " WHERE JOB_EXECUTION_ID = ?"
+                        + " AND STEP_NAME LIKE 'usageWorkerStep:%'",
+                run2ExecutionId);
+
+        // Run 2 should execute only partition2 (the only non-COMPLETED partition)
+        assertThat(run2WorkerSteps)
+                .as("Run 2 must execute only the failed partition2 worker step")
+                .hasSize(1);
+        assertThat(run2WorkerSteps.get(0).get("STEP_NAME"))
+                .as("The resumed step must be partition2")
+                .isEqualTo("usageWorkerStep:partition2");
+        assertThat(run2WorkerSteps.get(0).get("STATUS"))
+                .as("partition2 must complete successfully in Run 2")
+                .isEqualTo("COMPLETED");
+    }
+}


### PR DESCRIPTION
## Summary

Final PR in the `partitioned-harvester-job` stacked chain (PR-1 ✓, PR-2 ✓). Delivers
the verification layer: integration tests proving correctness, parallelism, idempotency,
and — as the headline capability — **partitioned restart with no double-billing**.

This PR carries `size:exception` (verification layer is inherently test-heavy).

## Chain context

```
PR-1 (scaffold, schema, domain, partitioner)  ← merged to main
PR-2 (reader, processor, writer, validator, plugin wiring)  ← merged to main
PR-3 (integration tests, restart test, CI, README)  ← this PR  [📍]
```

## Work units

### WU-11 — Core integration tests (`PartitionedHarvesterJobIntegrationTest`)

Six test cases over a deterministic 24-row H2 dataset:

- **Correctness and sum**: full run → `COUNT(billing_charge)==24`, `SUM(cost)==1290`
- **Per-record cost**: spot-checks that each charge's `cost == units × rate`
- **Parallelism**: asserts exactly 4 `BATCH_STEP_EXECUTION` rows named
  `usageWorkerStep:partition0..3` with status COMPLETED, scoped by `JOB_EXECUTION_ID`
- **1:1 idempotency**: `COUNT(DISTINCT source_id)==COUNT(*)` — no duplicates
- **Re-run idempotency**: second job (new `JobInstance`, fresh `RUN_ID`) does not create
  duplicate rows; count and sum are unchanged
- **Bounded-memory proxy**: 1000-row run with default `CHUNK_SIZE=100` completes correctly

### WU-12 — Restart integration test (`PartitionedHarvesterRestartIntegrationTest`) — HEADLINE

**Failure-injection mechanism**: no production code changes. The already-built
`RatingProcessor` uses `Math.multiplyExact`. Inserting a row with
`units = Long.MAX_VALUE / 2 + 1, rate = 3` at id=13 (inside partition2 range [11,15])
causes `ArithmeticException` on multiplication — a non-skippable exception that fails
exactly partition2 while partitions 0, 1, and 3 commit concurrently.

**Restart scenario**:
1. Run 1: poison id=13 → partition2 FAILS; partitions 0, 1, 3 commit 5+5+9=19 charges.
   Job status: FAILED.
2. Operator data fix: `UPDATE usage_record SET units=5, rate=8 WHERE id=13`. Same
   identifying params — same `JobInstance`.
3. Run 2: Spring Batch skips COMPLETED partitions 0, 1, 3; only partition2 resumes from
   its `saveState(true)` cursor offset. Job status: COMPLETED.

**Assertions after Run 2**:
- `COUNT(billing_charge) == 24` (no double-billing)
- `SUM(cost) == 1290`
- `COUNT(DISTINCT source_id) == 24`
- `BATCH_JOB_EXECUTION` has 2 rows sharing ONE `JOB_INSTANCE_ID` (FAILED + COMPLETED)
- Run 2 `BATCH_STEP_EXECUTION` has exactly 1 worker row: `usageWorkerStep:partition2`
  (confirms completed partitions were skipped, not re-run)

### WU-13 — CI

Added `Build and test partitioned-harvester-job plugin` step to `.github/workflows/maven.yml`
immediately after the fault-tolerant-harvester step, mirroring the existing pattern.

### WU-14 — README

`partitioned-harvester-job/README.md` documents:
- Partition vs chunk distinction (parallelism/restart unit vs commit unit)
- `gridSize` tied to thread-pool size; over-partitioning for skew absorption
- MIN/MAX arithmetic partitioning (no full-table scan)
- ThreadLocal reader design (why not `@StepScope`)
- Flat-rate billing and integer minor units
- Idempotency via UNIQUE `source_id` + guarded INSERT
- Frozen-source precondition with explicit consequences if violated
- Restart behavior: which partitions skip, how `saveState(true)` restores cursor offset
- **gridSize/chunkSize build-time constraint** (GRID_SIZE/CHUNK_SIZE overrides REJECTED by
  validator — cannot take effect; documented known gap = no runtime-dynamic gridSize, SC-07.1)
- Usage parameters and REST API examples

## Verification

`mvn -B package -f partitioned-harvester-job/pom.xml` — 46 tests, 0 failures.