### PR TITLE
docs(partitioned-harvester): fix stale expected-sum comments in integration test

### DIFF
--- a/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobIntegrationTest.java
+++ b/partitioned-harvester-job/src/test/java/com/fronzec/plugins/partitionedharvester/batch/PartitionedHarvesterJobIntegrationTest.java
@@ -48,7 +48,7 @@ import org.springframework.transaction.PlatformTransactionManager;
  *
  * <h3>Scenarios covered</h3>
  * <ol>
- *   <li>Correctness and sum: COUNT=24, SUM(cost)=1440 after a full run.</li>
+ *   <li>Correctness and sum: COUNT=24, SUM(cost)=1290 after a full run.</li>
  *   <li>Parallelism: exactly 4 worker BATCH_STEP_EXECUTION rows with status COMPLETED.</li>
  *   <li>1:1 idempotency: no duplicate source_id; re-run does not change count or sum.</li>
  *   <li>Bounded memory: 1000-row run with CHUNK_SIZE=100 (default) completes correctly;
@@ -155,11 +155,11 @@ class PartitionedHarvesterJobIntegrationTest {
      *
      * <p>Partition membership (MIN=1, MAX=24, gridSize=4, rangeSize=5):
      * <pre>
-     *   partition0: ids  1-5  subscriber=100 units=10 rate=5  cost=50  Σ=300
-     *   partition1: ids  6-10 subscriber=101 units=20 rate=3  cost=60  Σ=360
-     *   partition2: ids 11-15 subscriber=102 units=5  rate=8  cost=40  Σ=240
-     *   partition3: ids 16-24 subscriber=103 units=15 rate=4  cost=60  Σ=540
-     *   Total Σcost = 1440
+     *   partition0: ids  1-5  subscriber=100 units=10 rate=5  cost=50  (5 rows) Σ=250
+     *   partition1: ids  6-10 subscriber=101 units=20 rate=3  cost=60  (5 rows) Σ=300
+     *   partition2: ids 11-15 subscriber=102 units=5  rate=8  cost=40  (5 rows) Σ=200
+     *   partition3: ids 16-24 subscriber=103 units=15 rate=4  cost=60  (9 rows) Σ=540
+     *   Total Σcost = 1290
      * </pre>
      */
     private void insertSeedData() {
@@ -229,7 +229,7 @@ class PartitionedHarvesterJobIntegrationTest {
     // ── Scenario 1: Correctness and sum ──────────────────────────────────────────
 
     /**
-     * Full run correctness: COUNT(billing_charge)==24 and SUM(cost)==1440 after COMPLETED job.
+     * Full run correctness: COUNT(billing_charge)==24 and SUM(cost)==1290 after COMPLETED job.
      * Verifies REQ-03 (SC-03.2 sum) and REQ-04 (SC-04.1 count).
      */
     @Test


### PR DESCRIPTION
Corrects three stale Javadoc/comment references in `PartitionedHarvesterJobIntegrationTest` that said the expected billing total was `1440` when the correct value is `1290`.

The test assertions were always correct (they use the `EXPECTED_SUM_COST = 1290L` constant); only the surrounding comments were stale, a carryover from an earlier 6-rows-per-partition seed draft before the partitioner moved to `rangeSize = (MAX - MIN) / gridSize`.

Real layout for MIN=1, MAX=24, gridSize=4 (rangeSize=5, last partition absorbs remainder):
- partition0 [1,5] 5 rows x 50 = 250
- partition1 [6,10] 5 rows x 60 = 300
- partition2 [11,15] 5 rows x 40 = 200
- partition3 [16,24] 9 rows x 60 = 540
- Total = 1290

Comment-only change; no production or test logic touched. Caught by sdd-verify (W-03/W-04/W-05).