### PR TITLE
fix(batch-ops-ui): make svelte-check pass and enforce it in CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install dependencies
         working-directory: batch-ops-ui
         run: npm ci
+      - name: Type check
+        working-directory: batch-ops-ui
+        run: npm run check
       - name: Build
         working-directory: batch-ops-ui
         run: npm run build

--- a/batch-ops-ui/src/views/RunningView.svelte
+++ b/batch-ops-ui/src/views/RunningView.svelte
@@ -5,6 +5,14 @@
   import type { RunningJobs } from '../lib/dto';
   import AsyncState from '../components/AsyncState.svelte';
 
+  // Slot values arrive untyped from AsyncState; these typed accessors satisfy
+  // svelte-check without a TS `as` cast inside the {#each} expression
+  // (Svelte 4's template parser rejects casts in each-expressions).
+  const jobEntries = (jobs: unknown): [string, Record<string, string>][] =>
+    Object.entries(jobs as RunningJobs);
+  const execEntries = (execs: unknown): [string, string][] =>
+    Object.entries(execs as Record<string, string>);
+
   let loading = true;
   let result: ApiResult<RunningJobs> | null = null;
   $: viewResult =
@@ -31,7 +39,7 @@
 
   <AsyncState result={viewResult} {loading}>
     <div slot="data" let:value={jobs}>
-      {#each Object.entries(jobs) as [jobName, executions]}
+      {#each jobEntries(jobs) as [jobName, executions]}
         <div class="job-section">
           <h3 class="job-name">{jobName}</h3>
           <div class="table-wrapper">
@@ -43,7 +51,7 @@
                 </tr>
               </thead>
               <tbody>
-                {#each Object.entries(executions) as [execId, params]}
+                {#each execEntries(executions) as [execId, params]}
                   <tr>
                     <td>{execId}</td>
                     <td>{params}</td>


### PR DESCRIPTION
Follow-up to #58. Fixes the one `svelte-check` type error and wires the type-check into CI so it can't regress.

## Changes
- **fix**: `RunningView.svelte` slot values arrive untyped from `AsyncState`, so `Object.entries(...)` produced `unknown` values. Added typed accessor helpers (`jobEntries`/`execEntries`) in the script block — a TS `as` cast inside the `{#each}` expression is rejected by Svelte 4's template parser, so the cast lives in typed helpers instead.
- **ci**: added a `Type check` step (`npm run check`) to the `frontend` job, between install and build, so template/type errors fail CI.

## Verification
- `npm run check` → 0 errors, 0 warnings
- `npm run test` → 43/43 passing
- `npm run build` → clean

Comment/typing only; no runtime behavior change, still read-only.