### PR TITLE
docs: end-to-end local run guide + helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
-# Spring batch projects
+# spring-batch-projects
 
-This are my personal tests using spring batch :)
+A monorepo for experimenting with Spring Batch: a dynamic plugin host service, four batch job plugins, and a Svelte ops UI.
 
-![Alt](https://repobeats.axiom.co/api/embed/4c25e73ac0dba14cbc5ce187c36e5963a85e58a8.svg "Repobeats analytics image")
+## Module Map
+
+| Module | What it is |
+|--------|-----------|
+| `batch-job-api` | Shared API contract (interfaces + annotations) published to GitHub Packages; plugins and the host both depend on it |
+| `fr-batch-service` | Spring Boot 4 / Spring Batch 6 host — loads plugins dynamically from uploaded JARs, exposes a REST management API, uses MySQL with Flyway migrations |
+| `ticket-pdf-job` | Plugin: generates PDF tickets for events |
+| `ticket-bundle-job` | Plugin: bundles generated ticket PDFs |
+| `fault-tolerant-harvester-job` | Plugin: fault-tolerant harvest pipeline with retry and dead-letter support |
+| `partitioned-harvester-job` | Plugin: partitioned (multi-threaded) harvest pipeline |
+| `batch-ops-ui` | Svelte + Vite ops dashboard — manages plugin lifecycle and triggers jobs via the backend REST API |
+
+## Running Locally
+
+See **[RUNNING_LOCALLY.md](RUNNING_LOCALLY.md)** for the full end-to-end guide: MySQL setup, backend startup, seed data, plugin build + upload, and UI launch.
+
+## Analytics
+
+![Repobeats](https://repobeats.axiom.co/api/embed/4c25e73ac0dba14cbc5ce187c36e5963a85e58a8.svg "Repobeats analytics image")

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -1,0 +1,304 @@
+# Running the Stack Locally
+
+Everything you need to go from a fresh clone to a fully operational local environment: MySQL running, backend migrated, seeds applied, all four plugins loaded, and the UI showing live data.
+
+## Prerequisites
+
+| Tool | Version | Check |
+|------|---------|-------|
+| Java (JDK) | 21 | `java -version` |
+| JAVA_HOME | points to JDK 21 | `echo $JAVA_HOME` |
+| Maven | 3.9+ | `mvn -version` |
+| Docker or Podman | any recent | `docker info` |
+| Node.js | 20 LTS | `node -version` |
+| npm | bundled with Node 20 | `npm -version` |
+| jq or python3 | either | `jq --version` / `python3 --version` |
+
+---
+
+## One-Time: GitHub Packages Authentication
+
+`batch-job-api` is published to GitHub Packages. Every plugin and `fr-batch-service` declare it as a Maven dependency. Without auth, Maven exits with HTTP 401.
+
+### Option A — Local install (simplest for the repo owner)
+
+Build and install `batch-job-api` into your local Maven cache. No GitHub PAT needed.
+
+```bash
+mvn -f batch-job-api/pom.xml clean install
+```
+
+### Option B — GitHub PAT in settings.xml
+
+1. Create a [Personal Access Token](https://github.com/settings/tokens) with the **`read:packages`** scope.
+2. Add a `<server>` entry to `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_PAT_HERE</password>
+    </server>
+  </servers>
+</settings>
+```
+
+> Option A is the faster path if you own the repository. Option B is needed for contributors who cannot publish to the registry.
+
+---
+
+## Step 1 — Start MySQL
+
+The database container lives in `fr-batch-service/_devenvironment/`.
+
+```bash
+cd fr-batch-service/_devenvironment
+docker compose up -d
+cd -
+```
+
+The compose file reads `fr-batch-service/.env`. That file configures `MYSQL_DATABASE=frbatchservicedb2` and a non-root user. The app's **local profile** connects to a different database (`fr_batch_local`) as `root` with an empty password — so you must create that database manually:
+
+```bash
+# Wait a few seconds for MySQL to be ready, then:
+docker exec -it "$(docker ps --filter ancestor=mysql:8.2.0 -q | head -1)" \
+  mysql -u root -e "CREATE DATABASE IF NOT EXISTS fr_batch_local CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+```
+
+Or connect with any MySQL client and run:
+
+```sql
+CREATE DATABASE IF NOT EXISTS fr_batch_local
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+```
+
+> **Why the mismatch?** `fr-batch-service/.env` is git-tracked and sets `DB_NAME=frbatchservicedb2`. The local Spring profile (`application-local.properties`) is hard-coded to `fr_batch_local`. They serve different purposes: the `.env` file pre-dates the local profile. The simplest fix is to create `fr_batch_local` as shown above; do not rename the `.env` value.
+
+Verify MySQL is up:
+
+```bash
+docker exec -it "$(docker ps --filter ancestor=mysql:8.2.0 -q | head -1)" \
+  mysqladmin ping -u root
+```
+
+---
+
+## Step 2 — Start the Backend
+
+```bash
+cd fr-batch-service
+mvn spring-boot:run -Dspring-boot.run.profiles=local
+```
+
+**The `local` profile flag is required.** Without it, the app tries to read `${DB_HOST}`, `${DB_PORT}`, `${DB_NAME}`, `${DB_USERNAME}`, and `${DB_PASSWORD}` from the environment and fails at startup.
+
+What happens on first run with the `local` profile:
+
+- `FlywayMigrationRunner` (active only in the `local` profile) runs migrations V1–V8, creating all tables.
+- `spring.flyway.enabled=false` in `application-local.properties` keeps Spring's built-in Flyway autoconfigure out of the way.
+- `AutoApproveConfig` auto-approves every plugin upload — no manual approval step needed.
+- NoOp password encoder is active (plain-text credentials work).
+
+Wait until you see a line similar to:
+```
+Started FrBatchServiceApplication in X.XXX seconds
+```
+
+Health check:
+
+```bash
+curl -s http://localhost:8080/api/batch-service/actuator/health | python3 -m json.tool
+```
+
+Expected: `{"status":"UP"}`.
+
+---
+
+## Step 3 — Apply Seeds
+
+The seed files live in `fr-batch-service/_devenvironment/db/`. Apply them **after** the backend has started (Flyway must have created the tables first).
+
+Use the helper script:
+
+```bash
+bash scripts/seed-local-db.sh
+```
+
+Or apply manually:
+
+```bash
+# Default: root@127.0.0.1, DB fr_batch_local
+DB_NAME=fr_batch_local DB_USER=root MYSQL_HOST=127.0.0.1 bash scripts/seed-local-db.sh
+```
+
+Seed files applied in order:
+
+| File | Requires | Inserts |
+|------|----------|---------|
+| `10_seed_event_tickets.sql` | V5 (event_tickets, generated_files) | sample event ticket rows |
+| `20_seed_harvest_source.sql` | V7 (harvest_source, harvest_dead_letter) | harvest source configs |
+| `30_seed_usage_record.sql` | V8 (usage_record, billing_charge) | usage and billing samples |
+
+> Do **not** run `00_create_schema.sql` — that file is superseded by Flyway and will conflict with existing tables.
+
+---
+
+## Step 4 — Create the Plugin JAR Directory
+
+The local profile stores uploaded JARs at an absolute path:
+
+```
+/Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/
+```
+
+This path is hard-coded in `fr-batch-service/src/main/resources/application-local.properties` (`fr-batch-service.plugins.jar-dir`). Create it before uploading plugins:
+
+```bash
+mkdir -p /Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/
+```
+
+> **Non-owner machines:** If your repo is checked out to a different path, override the property before starting the backend:
+> ```bash
+> mvn spring-boot:run \
+>   -Dspring-boot.run.profiles=local \
+>   -Dspring-boot.run.arguments="--fr-batch-service.plugins.jar-dir=/your/path/to/jars/"
+> ```
+> Or set it directly in `application-local.properties` — that file is not a secret, just local config.
+
+---
+
+## Step 5 — Build the Plugin JARs
+
+Each plugin is a separate Maven module. Build all four fat JARs:
+
+```bash
+mvn -B package -f ticket-pdf-job/pom.xml -DskipTests
+mvn -B package -f ticket-bundle-job/pom.xml -DskipTests
+mvn -B package -f fault-tolerant-harvester-job/pom.xml -DskipTests
+mvn -B package -f partitioned-harvester-job/pom.xml -DskipTests
+```
+
+Expected output jars:
+
+| Plugin | JAR |
+|--------|-----|
+| ticket-pdf-job | `ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar` |
+| ticket-bundle-job | `ticket-bundle-job/target/ticket-bundle-job-1.0.0.jar` |
+| fault-tolerant-harvester-job | `fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar` |
+| partitioned-harvester-job | `partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar` |
+
+> If you skipped Option A for GitHub Packages auth, Maven will 401 here. Go back and run `mvn -f batch-job-api/pom.xml clean install` first.
+
+---
+
+## Step 6 — Upload, Enable, and Load Each Plugin
+
+Plugin loading is **dynamic upload, not classpath**. At startup, zero plugins are active. You register them through the REST API:
+
+1. **Upload** — POST the JAR to the service (returns a definition `id`)
+2. **Enable** — PUT to mark the definition active
+3. **Load** — POST to instantiate the plugin and register it as a Spring Batch job
+
+Use the helper script (it handles all four plugins and all three steps):
+
+```bash
+bash scripts/load-plugins.sh
+```
+
+To also build the JARs before loading:
+
+```bash
+bash scripts/load-plugins.sh --build
+```
+
+### Manual reference
+
+For a single plugin, the three calls look like:
+
+```bash
+BASE=http://localhost:8080/api/batch-service
+
+# 1. Upload
+RESPONSE=$(curl -s -u admin:admin123 -X POST "$BASE/jobs/upload" \
+  -F "file=@ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar" \
+  -F "jobName=ticket-pdf-job" \
+  -F "version=1.0.0" \
+  -F "mainClassName=com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin")
+
+ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
+
+# 2. Enable
+curl -s -u admin:admin123 -X PUT "$BASE/jobs/definitions/$ID/enable"
+
+# 3. Load
+curl -s -u admin:admin123 -X POST "$BASE/jobs/definitions/$ID/load"
+```
+
+### Plugin coordinates reference
+
+| jobName | JAR path | mainClassName |
+|---------|----------|---------------|
+| `ticket-pdf-job` | `ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar` | `com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin` |
+| `ticket-bundle-job` | `ticket-bundle-job/target/ticket-bundle-job-1.0.0.jar` | `com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin` |
+| `fault-tolerant-harvester-job` | `fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar` | `com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin` |
+| `partitioned-harvester-job` | `partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar` | `com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin` |
+
+> **Security note:** `POST /jobs/upload`, `PUT /jobs/definitions/{id}/enable`, and `POST /jobs/definitions/{id}/load` all require the `ADMIN` role. Locally, use `admin:admin123`. `AutoApproveConfig` means the approval step is skipped automatically — you go straight from upload to enable.
+
+---
+
+## Step 7 — Start the UI
+
+```bash
+cd batch-ops-ui
+npm install
+npm run dev
+```
+
+Open http://localhost:5173. Log in with `viewer/viewer123`.
+
+The Vite dev server proxies `/api` requests to `:8080`, so the backend must be running first.
+
+---
+
+## Verify It Worked
+
+```bash
+# List registered plugins (public endpoint — no auth needed)
+curl -s http://localhost:8080/api/batch-service/jobs/plugins | python3 -m json.tool
+
+# List job definitions (requires VIEWER role)
+curl -s -u viewer:viewer123 http://localhost:8080/api/batch-service/jobs/definitions | python3 -m json.tool
+```
+
+Expected: four entries in `/jobs/plugins`, each showing `loadStatus: LOADED`.
+
+Open the dashboard at http://localhost:5173 — you should see all four jobs listed and triggerable.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Could not resolve placeholder 'DB_HOST'` at startup | Missing `local` profile flag | Add `-Dspring-boot.run.profiles=local` |
+| `Unknown database 'fr_batch_local'` | DB not created | Run `CREATE DATABASE IF NOT EXISTS fr_batch_local;` in MySQL |
+| `mvn package` exits with HTTP 401 | GitHub Packages not authenticated | Run `mvn -f batch-job-api/pom.xml clean install` (Option A) |
+| Upload returns 500 / `No such file or directory` | JAR directory does not exist | `mkdir -p /Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/` |
+| UI shows "Backend unreachable" | Backend not running on :8080 | Start backend first: Step 2 |
+| `POST /jobs/upload` returns 401 | Wrong credentials | Use `admin:admin123` for write operations |
+| Flyway fails with `Table already exists` | `00_create_schema.sql` was run manually | Drop all tables and let Flyway recreate, or restore a clean volume |
+
+---
+
+## Alternative: Full-Stack Docker Compose
+
+A root-level `docker-compose.yml` runs MySQL, the Spring Boot app (built from the Dockerfile), Prometheus, and Grafana together. It targets the `docker` profile, not `local`.
+
+```bash
+DB_PASSWORD=yourpassword docker compose up -d
+```
+
+This is useful for a production-like smoke test, but not the recommended path for day-to-day development because it rebuilds the app image on every change.

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -9,7 +9,8 @@ Everything you need to go from a fresh clone to a fully operational local enviro
 | Java (JDK) | 21 | `java -version` |
 | JAVA_HOME | points to JDK 21 | `echo $JAVA_HOME` |
 | Maven | 3.9+ | `mvn -version` |
-| Docker or Podman | any recent | `docker info` |
+| Podman | 4.0+ | `podman --version` |
+| podman-compose | 1.0+ | `podman-compose --version` |
 | Node.js | 20 LTS | `node -version` |
 | npm | bundled with Node 20 | `npm -version` |
 | jq or python3 | either | `jq --version` / `python3 --version` |
@@ -51,19 +52,41 @@ mvn -f batch-job-api/pom.xml clean install
 
 ## Step 1 — Start MySQL
 
-The database container lives in `fr-batch-service/_devenvironment/`.
+This guide runs the database with [Podman](https://podman.io/) (rootless, daemonless) and
+[`podman-compose`](https://github.com/containers/podman-compose). The database container lives in
+`fr-batch-service/_devenvironment/`.
+
+On macOS, start the Podman VM once per boot before any container command:
+
+```bash
+podman machine start
+```
+
+Then bring up MySQL:
 
 ```bash
 cd fr-batch-service/_devenvironment
-docker compose up -d
+podman-compose up -d
 cd -
 ```
 
-The compose file reads `fr-batch-service/.env`. That file configures `MYSQL_DATABASE=frbatchservicedb2` and a non-root user. The app's **local profile** connects to a different database (`fr_batch_local`) as `root` with an empty password — so you must create that database manually:
+> **Why `podman-compose` and not `podman compose`?** The native `podman compose` wrapper delegates to
+> whatever external provider it finds — often Docker's `docker-compose` plugin, which on a machine that
+> once ran Docker Desktop tries to read credentials via `docker-credential-osxkeychain` and fails. The
+> standalone `podman-compose` tool talks to Podman directly and avoids that.
+
+The compose file reads `fr-batch-service/.env` (via `env_file: ../.env`) and declares an explicit project
+name (`frbatch-local`) so Podman accepts the generated volume name — Podman rejects volume names that
+don't start with an alphanumeric, and the `_devenvironment` directory name would otherwise leak a leading
+underscore into it.
+
+That `.env` configures `MYSQL_DATABASE=frbatchservicedb2` and a non-root user. The app's **local profile**
+connects to a different database (`fr_batch_local`) as `root` with an empty password — so you must create
+that database manually:
 
 ```bash
 # Wait a few seconds for MySQL to be ready, then:
-docker exec -it "$(docker ps --filter ancestor=mysql:8.2.0 -q | head -1)" \
+podman-compose exec db \
   mysql -u root -e "CREATE DATABASE IF NOT EXISTS fr_batch_local CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 ```
 
@@ -79,8 +102,7 @@ CREATE DATABASE IF NOT EXISTS fr_batch_local
 Verify MySQL is up:
 
 ```bash
-docker exec -it "$(docker ps --filter ancestor=mysql:8.2.0 -q | head -1)" \
-  mysqladmin ping -u root
+podman-compose exec db mysqladmin ping -u root
 ```
 
 ---
@@ -98,7 +120,7 @@ What happens on first run with the `local` profile:
 
 - `FlywayMigrationRunner` (active only in the `local` profile) runs migrations V1–V8, creating all tables.
 - `spring.flyway.enabled=false` in `application-local.properties` keeps Spring's built-in Flyway autoconfigure out of the way.
-- `AutoApproveConfig` auto-approves every plugin upload — no manual approval step needed.
+- Uploaded plugins must be **approved** before they can load (see Step 6). A dev-only `AutoApproveConfig` exists but does not currently persist the approval under the `local` profile, so the helper script approves each definition explicitly.
 - NoOp password encoder is active (plain-text credentials work).
 
 Wait until you see a line similar to:
@@ -120,17 +142,22 @@ Expected: `{"status":"UP"}`.
 
 The seed files live in `fr-batch-service/_devenvironment/db/`. Apply them **after** the backend has started (Flyway must have created the tables first).
 
-Use the helper script:
+Run the helper script from the **repository root**:
 
 ```bash
 bash scripts/seed-local-db.sh
 ```
 
-Or apply manually:
+**No host `mysql` client required.** The script auto-detects how to reach the database: it uses a host
+`mysql` client if one is in your `PATH`, otherwise it execs into the running Podman DB container (which
+already ships a client). Force a mode with `DB_CLIENT=host|podman` if needed:
 
 ```bash
-# Default: root@127.0.0.1, DB fr_batch_local
-DB_NAME=fr_batch_local DB_USER=root MYSQL_HOST=127.0.0.1 bash scripts/seed-local-db.sh
+# Force the container client (default when no host mysql is installed)
+DB_CLIENT=podman bash scripts/seed-local-db.sh
+
+# Force a host mysql client over TCP
+DB_CLIENT=host DB_NAME=fr_batch_local DB_USER=root MYSQL_HOST=127.0.0.1 bash scripts/seed-local-db.sh
 ```
 
 Seed files applied in order:
@@ -198,10 +225,15 @@ Expected output jars:
 Plugin loading is **dynamic upload, not classpath**. At startup, zero plugins are active. You register them through the REST API:
 
 1. **Upload** — POST the JAR to the service (returns a definition `id`)
-2. **Enable** — PUT to mark the definition active
-3. **Load** — POST to instantiate the plugin and register it as a Spring Batch job
+2. **Approve** — PUT to approve the definition (the `/load` endpoint rejects `PENDING` definitions)
+3. **Enable** — PUT to mark the definition active
+4. **Load** — POST to instantiate the plugin and register it as a Spring Batch job
 
-Use the helper script (it handles all four plugins and all three steps):
+> The `approve` step is required under every non-production profile. A dev-only auto-approve exists but
+> does not currently persist, so the definition stays `PENDING` until approved explicitly — the helper
+> script does this for you.
+
+Use the helper script (it handles all four plugins and all four steps):
 
 ```bash
 bash scripts/load-plugins.sh
@@ -229,10 +261,14 @@ RESPONSE=$(curl -s -u admin:admin123 -X POST "$BASE/jobs/upload" \
 
 ID=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])")
 
-# 2. Enable
+# 2. Approve (required — /load rejects PENDING definitions)
+curl -s -u admin:admin123 -X PUT "$BASE/jobs/definitions/$ID/approve" \
+  -H 'Content-Type: application/json' -d '{"approvedBy":"admin"}'
+
+# 3. Enable
 curl -s -u admin:admin123 -X PUT "$BASE/jobs/definitions/$ID/enable"
 
-# 3. Load
+# 4. Load
 curl -s -u admin:admin123 -X POST "$BASE/jobs/definitions/$ID/load"
 ```
 
@@ -245,7 +281,7 @@ curl -s -u admin:admin123 -X POST "$BASE/jobs/definitions/$ID/load"
 | `fault-tolerant-harvester-job` | `fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar` | `com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin` |
 | `partitioned-harvester-job` | `partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar` | `com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin` |
 
-> **Security note:** `POST /jobs/upload`, `PUT /jobs/definitions/{id}/enable`, and `POST /jobs/definitions/{id}/load` all require the `ADMIN` role. Locally, use `admin:admin123`. `AutoApproveConfig` means the approval step is skipped automatically — you go straight from upload to enable.
+> **Security note:** `POST /jobs/upload`, `PUT /jobs/definitions/{id}/approve`, `PUT /jobs/definitions/{id}/enable`, and `POST /jobs/definitions/{id}/load` all require the `ADMIN` role. Locally, use `admin:admin123`.
 
 ---
 
@@ -273,7 +309,7 @@ curl -s http://localhost:8080/api/batch-service/jobs/plugins | python3 -m json.t
 curl -s -u viewer:viewer123 http://localhost:8080/api/batch-service/jobs/definitions | python3 -m json.tool
 ```
 
-Expected: four entries in `/jobs/plugins`, each showing `loadStatus: LOADED`.
+Expected: four uploaded entries in `/jobs/plugins`, each showing `status: ACTIVE`.
 
 Open the dashboard at http://localhost:5173 — you should see all four jobs listed and triggerable.
 

--- a/fr-batch-service/README.md
+++ b/fr-batch-service/README.md
@@ -26,23 +26,23 @@ This diversity is by design - it provides an easy reference for how to implement
 
 ## How to run locally
 
-### Requeriments
+### Requirements
 
-- Your favorite IDE: I prefer IntelliJ or VsCode
 - Java 21 SDK
-- Maven 3, also you can use Maven Wrapper
-- Mysql 8.0.23
-- Some HTTP Rest Client: e.g. Postman
-- Some mocking service alternative: e.g. Mockoon or Mockintosh
+- Maven 3.9+
+- MySQL 8.2 (via Docker/Podman — see below)
+- Docker or Podman
 
+### Run locally
 
-### Run with IntelliJ
+```bash
+cd fr-batch-service
+mvn spring-boot:run -Dspring-boot.run.profiles=local
+```
 
-Pending ...
+The `local` profile is required. It wires a local MySQL connection (`fr_batch_local` database, root user, empty password) and runs Flyway migrations automatically at startup.
 
-### Run with VS Code
-
-Pending ...
+For the full setup — starting MySQL, seeding data, building and loading plugins, and running the UI — see the root [RUNNING_LOCALLY.md](../RUNNING_LOCALLY.md).
 
 ## How to develop
 

--- a/fr-batch-service/_devenvironment/docker-compose.yml
+++ b/fr-batch-service/_devenvironment/docker-compose.yml
@@ -1,11 +1,11 @@
 ---
-version: '3.8'
+name: frbatch-local
 services:
   db:
     image: mysql:8.2.0
     restart: "no"
     env_file:
-      - .env
+      - ../.env
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       # So you don't have to use root, but you can if you like

--- a/fr-batch-service/docs/runbook.md
+++ b/fr-batch-service/docs/runbook.md
@@ -103,7 +103,9 @@ All commands assume basic auth (`admin:admin123`). Replace credentials for produ
 curl -X POST -u admin:admin123 \
   -F "file=@/path/to/plugin.jar" \
   -F "jobName=my-custom-job" \
-  http://localhost:8080/api/batch-service/jobs/definitions/upload
+  -F "version=1.0.0" \
+  -F "mainClassName=com.example.MyJobPlugin" \
+  http://localhost:8080/api/batch-service/jobs/upload
 ```
 
 **Expected**: HTTP 201 Created. Response includes `jobDefinitionId` and `checksumSha256`.
@@ -238,7 +240,7 @@ docker compose exec mysql mysql -u root -p"${DB_PASSWORD}" -e \
 ```
 
 **Resolution**:
-1. Corrupted JAR → re-upload: `POST /jobs/definitions/upload`
+1. Corrupted JAR → re-upload: `POST /jobs/upload`
 2. Missing dependency in JAR → check `MANIFEST.MF` classpath
 3. Signature mismatch → re-sign JAR or temporarily set `app.plugins.signature.mode=permissive` during investigation
 

--- a/scripts/load-plugins.sh
+++ b/scripts/load-plugins.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# load-plugins.sh — Build (optional), upload, enable, and load all four plugins.
+#
+# Usage:
+#   bash scripts/load-plugins.sh [--build] [--help]
+#
+# Flags:
+#   --build    Build all four plugin JARs before uploading (runs mvn package)
+#
+# Environment variables (all optional — defaults shown below):
+#   BASE_URL    Backend base URL   (default: http://localhost:8080/api/batch-service)
+#   ADMIN_USER  Admin username     (default: admin)
+#   ADMIN_PASS  Admin password     (default: admin123)
+#
+# Prerequisites:
+#   - curl must be in PATH
+#   - jq OR python3 must be in PATH (used to parse the upload response)
+#   - The backend must be running on BASE_URL before this script is called.
+#   - The plugin JAR directory must exist (see RUNNING_LOCALLY.md Step 4).
+#   - If --build is passed, mvn must be in PATH and batch-job-api must be
+#     installed locally (mvn -f batch-job-api/pom.xml clean install).
+
+set -Eeuo pipefail
+
+# ─── Script location ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+BASE_URL="${BASE_URL:-http://localhost:8080/api/batch-service}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-admin123}"
+BUILD=false
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+usage() {
+    printf 'Usage: %s [--build] [--help]\n\n' "$(basename "$0")"
+    printf 'Upload, enable, and load all four plugins into the running backend.\n\n'
+    printf 'Flags:\n'
+    printf '  --build    Build plugin JARs first (mvn package -DskipTests)\n\n'
+    printf 'Environment variables:\n'
+    printf '  BASE_URL    Backend URL    (default: http://localhost:8080/api/batch-service)\n'
+    printf '  ADMIN_USER  Admin user     (default: admin)\n'
+    printf '  ADMIN_PASS  Admin password (default: admin123)\n'
+    exit 0
+}
+
+# ─── Argument parsing ─────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build)
+            BUILD=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            ;;
+        *)
+            printf '[ERROR] Unknown argument: %s\n' "$1" >&2
+            usage
+            ;;
+    esac
+done
+
+# ─── Dependency checks ────────────────────────────────────────────────────────
+if ! command -v curl &>/dev/null; then
+    printf '[ERROR] curl not found in PATH.\n' >&2
+    exit 1
+fi
+
+# Detect JSON parser: prefer jq, fall back to python3
+JSON_PARSER=""
+if command -v jq &>/dev/null; then
+    JSON_PARSER="jq"
+elif command -v python3 &>/dev/null; then
+    JSON_PARSER="python3"
+else
+    printf '[ERROR] Neither jq nor python3 found in PATH.\n' >&2
+    printf '        Install one of them and retry (brew install jq).\n' >&2
+    exit 1
+fi
+
+extract_id() {
+    local json="$1"
+    if [[ "$JSON_PARSER" == "jq" ]]; then
+        printf '%s' "$json" | jq -r '.id'
+    else
+        printf '%s' "$json" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])"
+    fi
+}
+
+if [[ "$BUILD" == "true" ]] && ! command -v mvn &>/dev/null; then
+    printf '[ERROR] --build was requested but mvn is not in PATH.\n' >&2
+    exit 1
+fi
+
+# ─── Plugin definitions ───────────────────────────────────────────────────────
+# Format: "jobName|relative/jar/path|mainClassName"
+declare -a PLUGINS=(
+    "ticket-pdf-job|ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar|com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin"
+    "ticket-bundle-job|ticket-bundle-job/target/ticket-bundle-job-1.0.0.jar|com.fronzec.plugins.ticketbundle.TicketBundleJobPlugin"
+    "fault-tolerant-harvester-job|fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar|com.fronzec.plugins.harvester.FaultTolerantHarvesterJobPlugin"
+    "partitioned-harvester-job|partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar|com.fronzec.plugins.partitionedharvester.PartitionedHarvesterJobPlugin"
+)
+
+# ─── Optional build ───────────────────────────────────────────────────────────
+if [[ "$BUILD" == "true" ]]; then
+    printf '[INFO] Building plugin JARs ...\n'
+    declare -a MODULE_DIRS=(
+        "ticket-pdf-job"
+        "ticket-bundle-job"
+        "fault-tolerant-harvester-job"
+        "partitioned-harvester-job"
+    )
+    for module in "${MODULE_DIRS[@]}"; do
+        printf '[INFO]   Building %s ...\n' "$module"
+        mvn -B package -f "$REPO_ROOT/$module/pom.xml" -DskipTests -q
+        printf '[OK]     %s built.\n' "$module"
+    done
+    printf '[INFO] All JARs built.\n\n'
+fi
+
+# ─── Backend connectivity check ───────────────────────────────────────────────
+printf '[INFO] Checking backend at %s ...\n' "$BASE_URL"
+HEALTH_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+    "${BASE_URL}/actuator/health" || true)
+
+if [[ "$HEALTH_STATUS" != "200" ]]; then
+    printf '[ERROR] Backend health check returned HTTP %s (expected 200).\n' \
+        "$HEALTH_STATUS" >&2
+    printf '        Is the backend running? Start it with:\n' >&2
+    printf '          cd fr-batch-service && mvn spring-boot:run -Dspring-boot.run.profiles=local\n' >&2
+    exit 1
+fi
+printf '[INFO] Backend is up.\n\n'
+
+# ─── Track results ────────────────────────────────────────────────────────────
+LOADED=0
+SKIPPED=0
+FAILED=0
+
+# ─── Process each plugin ──────────────────────────────────────────────────────
+for entry in "${PLUGINS[@]}"; do
+    IFS='|' read -r JOB_NAME JAR_REL MAIN_CLASS <<< "$entry"
+    JAR_ABS="$REPO_ROOT/$JAR_REL"
+
+    printf '─── Plugin: %s ───────────────────────────────────────\n' "$JOB_NAME"
+
+    # Validate JAR exists
+    if [[ ! -f "$JAR_ABS" ]]; then
+        printf '[ERROR] JAR not found: %s\n' "$JAR_ABS" >&2
+        printf '        Build it first: mvn -B package -f %s/pom.xml -DskipTests\n' \
+            "$(dirname "$JAR_REL")" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    # ── Step 1: Upload ─────────────────────────────────────────────────────
+    printf '[1/3] Uploading %s ...\n' "$JOB_NAME"
+    HTTP_RESPONSE=$(curl -s -w '\n%{http_code}' \
+        -u "${ADMIN_USER}:${ADMIN_PASS}" \
+        -X POST "${BASE_URL}/jobs/upload" \
+        -F "file=@${JAR_ABS}" \
+        -F "jobName=${JOB_NAME}" \
+        -F "version=1.0.0" \
+        -F "mainClassName=${MAIN_CLASS}")
+
+    HTTP_BODY=$(printf '%s' "$HTTP_RESPONSE" | head -n -1)
+    HTTP_CODE=$(printf '%s' "$HTTP_RESPONSE" | tail -n 1)
+
+    if [[ "$HTTP_CODE" == "409" ]]; then
+        printf '[SKIP] %s already uploaded (HTTP 409 Conflict).\n' "$JOB_NAME"
+        SKIPPED=$((SKIPPED + 1))
+        # Still try enable+load on the existing definition via list endpoint
+        EXISTING_ID=$(curl -s \
+            -u "${ADMIN_USER}:${ADMIN_PASS}" \
+            "${BASE_URL}/jobs/definitions" \
+            | (
+                if [[ "$JSON_PARSER" == "jq" ]]; then
+                    jq -r --arg name "$JOB_NAME" '.[] | select(.jobName == $name) | .id'
+                else
+                    python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data:
+    if item.get('jobName') == '${JOB_NAME}':
+        print(item['id'])
+        break
+"
+                fi
+            ) || true)
+
+        if [[ -z "${EXISTING_ID:-}" ]]; then
+            printf '[WARN] Could not find existing ID for %s — skipping enable+load.\n' \
+                "$JOB_NAME" >&2
+            continue
+        fi
+        DEFINITION_ID="$EXISTING_ID"
+    elif [[ "$HTTP_CODE" == "201" ]]; then
+        DEFINITION_ID=$(extract_id "$HTTP_BODY" || true)
+        if [[ -z "${DEFINITION_ID:-}" || "$DEFINITION_ID" == "null" ]]; then
+            printf '[ERROR] Upload succeeded but could not parse ID from response:\n' >&2
+            printf '%s\n' "$HTTP_BODY" >&2
+            FAILED=$((FAILED + 1))
+            continue
+        fi
+        printf '[OK]   Uploaded. Definition ID: %s\n' "$DEFINITION_ID"
+    else
+        printf '[ERROR] Upload failed with HTTP %s:\n' "$HTTP_CODE" >&2
+        printf '%s\n' "$HTTP_BODY" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    # ── Step 2: Enable ─────────────────────────────────────────────────────
+    printf '[2/3] Enabling definition %s ...\n' "$DEFINITION_ID"
+    ENABLE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "${ADMIN_USER}:${ADMIN_PASS}" \
+        -X PUT "${BASE_URL}/jobs/definitions/${DEFINITION_ID}/enable")
+
+    if [[ "$ENABLE_CODE" == "200" ]]; then
+        printf '[OK]   Enabled.\n'
+    else
+        printf '[WARN] Enable returned HTTP %s (definition may already be enabled).\n' \
+            "$ENABLE_CODE"
+    fi
+
+    # ── Step 3: Load ───────────────────────────────────────────────────────
+    printf '[3/3] Loading definition %s ...\n' "$DEFINITION_ID"
+    LOAD_RESPONSE=$(curl -s -w '\n%{http_code}' \
+        -u "${ADMIN_USER}:${ADMIN_PASS}" \
+        -X POST "${BASE_URL}/jobs/definitions/${DEFINITION_ID}/load")
+
+    LOAD_BODY=$(printf '%s' "$LOAD_RESPONSE" | head -n -1)
+    LOAD_CODE=$(printf '%s' "$LOAD_RESPONSE" | tail -n 1)
+
+    if [[ "$LOAD_CODE" == "200" ]]; then
+        printf '[OK]   Loaded.\n'
+        LOADED=$((LOADED + 1))
+    elif [[ "$LOAD_CODE" == "409" ]]; then
+        printf '[SKIP] Already loaded (HTTP 409).\n'
+    else
+        printf '[ERROR] Load failed with HTTP %s:\n' "$LOAD_CODE" >&2
+        printf '%s\n' "$LOAD_BODY" >&2
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    printf '\n'
+done
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+printf '══════════════════════════════════════════════════════\n'
+printf ' Summary\n'
+printf '══════════════════════════════════════════════════════\n'
+printf '  Loaded:  %d\n' "$LOADED"
+printf '  Skipped: %d (already uploaded)\n' "$SKIPPED"
+printf '  Failed:  %d\n' "$FAILED"
+printf '\n'
+
+if [[ $FAILED -gt 0 ]]; then
+    printf '[WARN] %d plugin(s) failed. Check output above.\n' "$FAILED" >&2
+    exit 1
+fi
+
+printf '[DONE] Verify with:\n'
+printf '       curl -s %s/jobs/plugins | python3 -m json.tool\n' "$BASE_URL"

--- a/scripts/load-plugins.sh
+++ b/scripts/load-plugins.sh
@@ -165,8 +165,10 @@ for entry in "${PLUGINS[@]}"; do
         -F "version=1.0.0" \
         -F "mainClassName=${MAIN_CLASS}")
 
-    HTTP_BODY=$(printf '%s' "$HTTP_RESPONSE" | head -n -1)
-    HTTP_CODE=$(printf '%s' "$HTTP_RESPONSE" | tail -n 1)
+    # Split the trailing "\n<code>" appended by curl -w, using pure bash
+    # parameter expansion (portable: GNU `head -n -1` is unavailable on BSD/macOS).
+    HTTP_CODE="${HTTP_RESPONSE##*$'\n'}"
+    HTTP_BODY="${HTTP_RESPONSE%$'\n'*}"
 
     if [[ "$HTTP_CODE" == "409" ]]; then
         printf '[SKIP] %s already uploaded (HTTP 409 Conflict).\n' "$JOB_NAME"
@@ -177,13 +179,14 @@ for entry in "${PLUGINS[@]}"; do
             "${BASE_URL}/jobs/definitions" \
             | (
                 if [[ "$JSON_PARSER" == "jq" ]]; then
-                    jq -r --arg name "$JOB_NAME" '.[] | select(.jobName == $name) | .id'
+                    # API serializes snake_case (Jackson SNAKE_CASE): field is job_name.
+                    jq -r --arg name "$JOB_NAME" '.[] | select(.job_name == $name) | .id'
                 else
                     python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 for item in data:
-    if item.get('jobName') == '${JOB_NAME}':
+    if item.get('job_name') == '${JOB_NAME}':
         print(item['id'])
         break
 "
@@ -212,6 +215,24 @@ for item in data:
         continue
     fi
 
+    # ── Step 1b: Approve ───────────────────────────────────────────────────
+    # The /load endpoint rejects PENDING definitions (HTTP 409 "must be approved").
+    # Non-production profiles are meant to auto-approve on upload, but that path
+    # does not currently persist the approval, so approve explicitly here. This
+    # also mirrors the production lifecycle (upload -> approve -> enable -> load).
+    printf '[1b]   Approving definition %s ...\n' "$DEFINITION_ID"
+    APPROVE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+        -u "${ADMIN_USER}:${ADMIN_PASS}" \
+        -X PUT "${BASE_URL}/jobs/definitions/${DEFINITION_ID}/approve" \
+        -H 'Content-Type: application/json' \
+        -d "{\"approvedBy\":\"${ADMIN_USER}\"}")
+
+    case "$APPROVE_CODE" in
+        200) printf '[OK]   Approved.\n' ;;
+        409) printf '[SKIP] Already approved (HTTP 409).\n' ;;
+        *)   printf '[WARN] Approve returned HTTP %s (load may fail if still PENDING).\n' "$APPROVE_CODE" ;;
+    esac
+
     # ── Step 2: Enable ─────────────────────────────────────────────────────
     printf '[2/3] Enabling definition %s ...\n' "$DEFINITION_ID"
     ENABLE_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
@@ -231,8 +252,8 @@ for item in data:
         -u "${ADMIN_USER}:${ADMIN_PASS}" \
         -X POST "${BASE_URL}/jobs/definitions/${DEFINITION_ID}/load")
 
-    LOAD_BODY=$(printf '%s' "$LOAD_RESPONSE" | head -n -1)
-    LOAD_CODE=$(printf '%s' "$LOAD_RESPONSE" | tail -n 1)
+    LOAD_CODE="${LOAD_RESPONSE##*$'\n'}"
+    LOAD_BODY="${LOAD_RESPONSE%$'\n'*}"
 
     if [[ "$LOAD_CODE" == "200" ]]; then
         printf '[OK]   Loaded.\n'

--- a/scripts/seed-local-db.sh
+++ b/scripts/seed-local-db.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# seed-local-db.sh — Apply the three local seed files to fr_batch_local.
+#
+# Usage:
+#   bash scripts/seed-local-db.sh [--help]
+#
+# Environment variables (all optional — defaults shown below):
+#   DB_NAME      Database name          (default: fr_batch_local)
+#   DB_USER      MySQL username         (default: root)
+#   DB_PASSWORD  MySQL password         (default: empty string)
+#   MYSQL_HOST   MySQL host             (default: 127.0.0.1)
+#   MYSQL_PORT   MySQL port             (default: 3306)
+#
+# Prerequisites:
+#   - mysql client must be in PATH
+#   - The backend must have started and run Flyway migrations at least once,
+#     otherwise the target tables do not exist yet.
+#
+# Notes:
+#   - Do NOT run 00_create_schema.sql — it is superseded by Flyway.
+#   - Seeds are idempotent if they use INSERT IGNORE or ON DUPLICATE KEY.
+#     If they do not, re-running may produce duplicate-key errors; those are safe
+#     to ignore once data is already seeded.
+
+set -Eeuo pipefail
+
+# ─── Script location ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+SEED_DIR="$REPO_ROOT/fr-batch-service/_devenvironment/db"
+
+# ─── Configuration ────────────────────────────────────────────────────────────
+DB_NAME="${DB_NAME:-fr_batch_local}"
+DB_USER="${DB_USER:-root}"
+DB_PASSWORD="${DB_PASSWORD:-}"
+MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
+MYSQL_PORT="${MYSQL_PORT:-3306}"
+
+# ─── Help ─────────────────────────────────────────────────────────────────────
+usage() {
+    printf 'Usage: %s [--help]\n\n' "$(basename "$0")"
+    printf 'Apply local seed SQL files to the fr_batch_local database.\n\n'
+    printf 'Environment variables:\n'
+    printf '  DB_NAME      Database name    (default: fr_batch_local)\n'
+    printf '  DB_USER      MySQL user       (default: root)\n'
+    printf '  DB_PASSWORD  MySQL password   (default: empty)\n'
+    printf '  MYSQL_HOST   MySQL host       (default: 127.0.0.1)\n'
+    printf '  MYSQL_PORT   MySQL port       (default: 3306)\n'
+    exit 0
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+fi
+
+# ─── Dependency check ─────────────────────────────────────────────────────────
+if ! command -v mysql &>/dev/null; then
+    printf '[ERROR] mysql client not found in PATH.\n' >&2
+    printf '        Install it (e.g. brew install mysql-client) and retry.\n' >&2
+    exit 1
+fi
+
+# ─── Seed files in order ──────────────────────────────────────────────────────
+declare -a SEED_FILES=(
+    "$SEED_DIR/10_seed_event_tickets.sql"
+    "$SEED_DIR/20_seed_harvest_source.sql"
+    "$SEED_DIR/30_seed_usage_record.sql"
+)
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+run_mysql() {
+    # Accepts -e "SQL" or piped input
+    if [[ -n "${DB_PASSWORD}" ]]; then
+        mysql \
+            --host="$MYSQL_HOST" \
+            --port="$MYSQL_PORT" \
+            --user="$DB_USER" \
+            --password="$DB_PASSWORD" \
+            "$@"
+    else
+        # Empty password: avoid the --password flag to suppress the warning
+        mysql \
+            --host="$MYSQL_HOST" \
+            --port="$MYSQL_PORT" \
+            --user="$DB_USER" \
+            "$@"
+    fi
+}
+
+# ─── Verify connectivity ──────────────────────────────────────────────────────
+printf '[INFO] Checking MySQL connectivity at %s:%s ...\n' "$MYSQL_HOST" "$MYSQL_PORT"
+if ! run_mysql -e "SELECT 1;" &>/dev/null; then
+    printf '[ERROR] Cannot connect to MySQL at %s:%s as user %s.\n' \
+        "$MYSQL_HOST" "$MYSQL_PORT" "$DB_USER" >&2
+    printf '        Is the database container running? (docker compose up -d)\n' >&2
+    exit 1
+fi
+printf '[INFO] Connected.\n'
+
+# ─── Ensure database exists ───────────────────────────────────────────────────
+printf '[INFO] Ensuring database "%s" exists ...\n' "$DB_NAME"
+run_mysql -e "CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+printf '[INFO] Database "%s" ready.\n' "$DB_NAME"
+
+# ─── Apply seeds ──────────────────────────────────────────────────────────────
+for seed in "${SEED_FILES[@]}"; do
+    if [[ ! -f "$seed" ]]; then
+        printf '[ERROR] Seed file not found: %s\n' "$seed" >&2
+        exit 1
+    fi
+
+    filename="$(basename "$seed")"
+    printf '[INFO] Applying seed: %s ...\n' "$filename"
+
+    if run_mysql "$DB_NAME" < "$seed"; then
+        printf '[OK]   %s applied successfully.\n' "$filename"
+    else
+        printf '[ERROR] Failed to apply %s — check the output above.\n' "$filename" >&2
+        exit 1
+    fi
+done
+
+printf '\n[DONE] All seeds applied to database "%s".\n' "$DB_NAME"

--- a/scripts/seed-local-db.sh
+++ b/scripts/seed-local-db.sh
@@ -4,15 +4,22 @@
 # Usage:
 #   bash scripts/seed-local-db.sh [--help]
 #
+# Runs from any working directory — paths are resolved relative to this script.
+#
 # Environment variables (all optional — defaults shown below):
-#   DB_NAME      Database name          (default: fr_batch_local)
-#   DB_USER      MySQL username         (default: root)
-#   DB_PASSWORD  MySQL password         (default: empty string)
-#   MYSQL_HOST   MySQL host             (default: 127.0.0.1)
-#   MYSQL_PORT   MySQL port             (default: 3306)
+#   DB_NAME          Database name          (default: fr_batch_local)
+#   DB_USER          MySQL username         (default: root)
+#   DB_PASSWORD      MySQL password         (default: empty string)
+#   MYSQL_HOST       MySQL host             (default: 127.0.0.1)   [host client mode]
+#   MYSQL_PORT       MySQL port             (default: 3306)        [host client mode]
+#   DB_CLIENT        auto | host | podman   (default: auto)
+#   COMPOSE_PROJECT  Compose project label  (default: frbatch-local) [podman mode]
+#   COMPOSE_SERVICE  Compose service label  (default: db)            [podman mode]
 #
 # Prerequisites:
-#   - mysql client must be in PATH
+#   - A MySQL client: either `mysql` in PATH (host mode), OR the Podman DB
+#     container running (podman mode — no host client needed). DB_CLIENT=auto
+#     picks host if available, otherwise execs into the container.
 #   - The backend must have started and run Flyway migrations at least once,
 #     otherwise the target tables do not exist yet.
 #
@@ -35,6 +42,9 @@ DB_USER="${DB_USER:-root}"
 DB_PASSWORD="${DB_PASSWORD:-}"
 MYSQL_HOST="${MYSQL_HOST:-127.0.0.1}"
 MYSQL_PORT="${MYSQL_PORT:-3306}"
+DB_CLIENT="${DB_CLIENT:-auto}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-frbatch-local}"
+COMPOSE_SERVICE="${COMPOSE_SERVICE:-db}"
 
 # ─── Help ─────────────────────────────────────────────────────────────────────
 usage() {
@@ -46,6 +56,7 @@ usage() {
     printf '  DB_PASSWORD  MySQL password   (default: empty)\n'
     printf '  MYSQL_HOST   MySQL host       (default: 127.0.0.1)\n'
     printf '  MYSQL_PORT   MySQL port       (default: 3306)\n'
+    printf '  DB_CLIENT    auto|host|podman (default: auto)\n'
     exit 0
 }
 
@@ -53,12 +64,50 @@ if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     usage
 fi
 
-# ─── Dependency check ─────────────────────────────────────────────────────────
-if ! command -v mysql &>/dev/null; then
-    printf '[ERROR] mysql client not found in PATH.\n' >&2
-    printf '        Install it (e.g. brew install mysql-client) and retry.\n' >&2
-    exit 1
-fi
+# ─── Resolve MySQL client ─────────────────────────────────────────────────────
+# Prefer a host `mysql` client; otherwise exec into the running Podman DB
+# container, which already ships a mysql client (no host install needed).
+find_db_container() {
+    command -v podman &>/dev/null || return 0
+    podman ps -q \
+        --filter "label=com.docker.compose.project=${COMPOSE_PROJECT}" \
+        --filter "label=com.docker.compose.service=${COMPOSE_SERVICE}" \
+        | head -1
+}
+
+CLIENT_MODE=""
+DB_CONTAINER=""
+case "$DB_CLIENT" in
+    host)
+        command -v mysql &>/dev/null || {
+            printf '[ERROR] DB_CLIENT=host but mysql client not found in PATH.\n' >&2
+            exit 1
+        }
+        CLIENT_MODE="host" ;;
+    podman)
+        DB_CONTAINER="$(find_db_container)"
+        [[ -n "$DB_CONTAINER" ]] || {
+            printf '[ERROR] DB_CLIENT=podman but no running container for project "%s" / service "%s".\n' \
+                "$COMPOSE_PROJECT" "$COMPOSE_SERVICE" >&2
+            exit 1
+        }
+        CLIENT_MODE="podman" ;;
+    auto)
+        if command -v mysql &>/dev/null; then
+            CLIENT_MODE="host"
+        elif DB_CONTAINER="$(find_db_container)" && [[ -n "$DB_CONTAINER" ]]; then
+            CLIENT_MODE="podman"
+        else
+            printf '[ERROR] No MySQL client available.\n' >&2
+            printf '        Install a mysql client, or start the Podman DB container:\n' >&2
+            printf '          cd fr-batch-service/_devenvironment && podman-compose up -d\n' >&2
+            exit 1
+        fi ;;
+    *)
+        printf '[ERROR] Invalid DB_CLIENT="%s" (use auto|host|podman).\n' "$DB_CLIENT" >&2
+        exit 1 ;;
+esac
+printf '[INFO] MySQL client mode: %s%s\n' "$CLIENT_MODE" "${DB_CONTAINER:+ (container ${DB_CONTAINER})}"
 
 # ─── Seed files in order ──────────────────────────────────────────────────────
 declare -a SEED_FILES=(
@@ -69,21 +118,21 @@ declare -a SEED_FILES=(
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 run_mysql() {
-    # Accepts -e "SQL" or piped input
-    if [[ -n "${DB_PASSWORD}" ]]; then
-        mysql \
-            --host="$MYSQL_HOST" \
-            --port="$MYSQL_PORT" \
-            --user="$DB_USER" \
-            --password="$DB_PASSWORD" \
-            "$@"
+    # Accepts -e "SQL" or piped input. Dispatches to the resolved client mode.
+    # Empty password: omit the --password flag to suppress the mysql warning.
+    if [[ "$CLIENT_MODE" == "podman" ]]; then
+        # -i forwards stdin so `run_mysql "$DB_NAME" < file` pipes the seed in.
+        if [[ -n "${DB_PASSWORD}" ]]; then
+            podman exec -i "$DB_CONTAINER" mysql --user="$DB_USER" --password="$DB_PASSWORD" "$@"
+        else
+            podman exec -i "$DB_CONTAINER" mysql --user="$DB_USER" "$@"
+        fi
     else
-        # Empty password: avoid the --password flag to suppress the warning
-        mysql \
-            --host="$MYSQL_HOST" \
-            --port="$MYSQL_PORT" \
-            --user="$DB_USER" \
-            "$@"
+        if [[ -n "${DB_PASSWORD}" ]]; then
+            mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$DB_USER" --password="$DB_PASSWORD" "$@"
+        else
+            mysql --host="$MYSQL_HOST" --port="$MYSQL_PORT" --user="$DB_USER" "$@"
+        fi
     fi
 }
 
@@ -92,7 +141,7 @@ printf '[INFO] Checking MySQL connectivity at %s:%s ...\n' "$MYSQL_HOST" "$MYSQL
 if ! run_mysql -e "SELECT 1;" &>/dev/null; then
     printf '[ERROR] Cannot connect to MySQL at %s:%s as user %s.\n' \
         "$MYSQL_HOST" "$MYSQL_PORT" "$DB_USER" >&2
-    printf '        Is the database container running? (docker compose up -d)\n' >&2
+    printf '        Is the database container running? (cd fr-batch-service/_devenvironment && podman-compose up -d)\n' >&2
     exit 1
 fi
 printf '[INFO] Connected.\n'


### PR DESCRIPTION
## Summary

End-to-end local-run guide plus helper scripts, **verified by running the whole stack live on Podman (macOS)** — the first time the flow was executed rather than written from static analysis, which surfaced three latent blockers (now fixed).

- **RUNNING_LOCALLY.md** — canonical end-to-end guide: MySQL via Podman, backend startup, Flyway auto-migration, seed data, plugin JAR directory, plugin build + upload + approve + enable + load, and UI launch. Troubleshooting table + pointer to the root `docker-compose.yml` full-stack alternative (left on Docker by design).
- **scripts/seed-local-db.sh** — defensive bash (`set -Eeuo pipefail`) applying the three seeds in order. Now **auto-detects the MySQL client** (`DB_CLIENT=auto|host|podman`): uses a host `mysql` if present, otherwise execs into the running DB container — **no host client install required**.
- **scripts/load-plugins.sh** — defensive bash that uploads, approves, enables, and loads all four plugins via the REST API; parses `id` with jq or python3 (auto-detected); handles 409 conflicts; supports `--build`.
- **fr-batch-service/_devenvironment/docker-compose.yml** — infra fixes required to run under Podman (see below).
- **runbook.md / Root README / fr-batch-service README** — upload endpoint fix, module map, canonical run command (unchanged from the original revision).

## Podman migration + latent blockers fixed

Running the guide for real exposed three bugs, all fixed here:

| # | Blocker | Fix |
|---|---------|-----|
| 1 | `docker-compose.yml` `env_file: .env` pointed at `_devenvironment/.env`, which never existed (real file is `fr-batch-service/.env`) → compose v2 failed with exit 1 | `env_file: ../.env` |
| 2 | Podman rejects volume names with a leading underscore; the `_devenvironment` dir name leaked one into the generated volume → exit 125 | explicit `name: frbatch-local` |
| 3 | `load-plugins.sh` used GNU-only `head -n -1` (fails on BSD/macOS) and looked up `jobName` while the API serializes `job_name` (snake_case) | portable bash parameter-expansion split + `job_name` filter |

The guide now uses `podman-compose` (containers/podman-compose) instead of the native `podman compose` wrapper, which on a machine that once ran Docker Desktop delegates to the `docker-compose` plugin and fails on `docker-credential-osxkeychain`.

## Plugin lifecycle correction

The real lifecycle is **upload → approve → enable → load**. The `/load` endpoint rejects `PENDING` definitions. A dev-only `AutoApproveConfig` exists but **does not currently persist the approval** under the `local` profile, so `load-plugins.sh` now approves each definition explicitly. The guide's earlier "auto-approve, no manual step" claims were inaccurate and have been removed.

> Follow-up (separate PR on `main`): fix `JarUploadService.handleUpload` to persist the auto-approval (re-`save()` after `approve()`, or make the method `@Transactional`). Tracked outside this docs PR.

## Test plan

- [x] `bash -n scripts/seed-local-db.sh` passes
- [x] `bash -n scripts/load-plugins.sh` passes
- [x] Live run on Podman/macOS: MySQL up → backend (`local`) → seeds applied → all 6 plugins `ACTIVE` → UI login (`viewer/viewer123`) shows jobs
- [x] Fresh plugin cycle verified: upload `201` → approve `200` → enable `200` → load `200`
- [x] Endpoint paths match the real controllers (`POST /jobs/upload`, `PUT /jobs/definitions/{id}/approve`, `PUT .../enable`, `POST .../load`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README with structured project overview and module details.
  * Added comprehensive local setup guide with prerequisites, step-by-step instructions, and troubleshooting.
  * Updated service documentation with specific requirements and run commands.

* **New Features**
  * Added automated plugin deployment and database seeding scripts for local development.

* **Other**
  * Updated plugin API endpoint reference in runbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->