### PR TITLE
fix(plugins): persist auto-approval on JAR upload

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -115,8 +115,14 @@ public class JarUploadService {
 
         pluginMetrics.incrementUpload();
 
-        // Auto-approve in dev profile (no-op when AutoApproveConfig is absent)
-        autoApproveConfig.ifPresent(ac -> ac.approve(entity));
+        // Auto-approve in non-production profiles (no-op when AutoApproveConfig is absent).
+        // approve() only mutates the entity in memory, and persistMetadata's save has
+        // already committed it as PENDING, so re-save to persist the approval.
+        autoApproveConfig.ifPresent(
+            ac -> {
+              ac.approve(entity);
+              jobDefinitionRepository.save(entity);
+            });
 
         log.info(
                 "JAR uploaded: job={}, version={}, id={}, checksum={}",

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/AutoApproveConfig.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/AutoApproveConfig.java
@@ -5,6 +5,7 @@ import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -17,11 +18,19 @@ import org.springframework.stereotype.Component;
  * guard in {@code DynamicJobLoaderService} is active and requires explicit
  * approval via the REST API.
  *
+ * <p>Can be disabled within a non-production profile via
+ * {@code app.plugins.approval.auto-approve=false} (defaults to {@code true}) — e.g.
+ * to exercise the manual approval lifecycle in a test.
+ *
  * <p>Injected into {@code JarUploadService}, which calls {@link #approve} and
  * then re-saves the entity to persist the approval.
  */
 @Component
 @Profile("!production")
+@ConditionalOnProperty(
+    name = "app.plugins.approval.auto-approve",
+    havingValue = "true",
+    matchIfMissing = true)
 public class AutoApproveConfig {
 
   private static final Logger log = LoggerFactory.getLogger(AutoApproveConfig.class);

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/AutoApproveConfig.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/config/AutoApproveConfig.java
@@ -9,15 +9,16 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
- * Dev-profile component that auto-approves newly uploaded job definitions.
+ * Non-production component that auto-approves newly uploaded job definitions.
  *
- * <p>In the {@code dev} profile, every upload is implicitly trusted and set to
- * {@code APPROVED} — no manual approve step needed. This component is NOT loaded
- * in production where the approval guard in {@code DynamicJobLoaderService} is
- * active and requires explicit approval via the REST API.
+ * <p>In every non-production profile ({@code @Profile("!production")}), each
+ * upload is implicitly trusted and set to {@code APPROVED} — no manual approve
+ * step needed. This component is NOT loaded in production, where the approval
+ * guard in {@code DynamicJobLoaderService} is active and requires explicit
+ * approval via the REST API.
  *
- * <p>Injected into {@code JarUploadService} so the auto-approval happens
- * atomically at persist time.
+ * <p>Injected into {@code JarUploadService}, which calls {@link #approve} and
+ * then re-saves the entity to persist the approval.
  */
 @Component
 @Profile("!production")

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoadingIntegrationTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoadingIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -51,6 +52,9 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
+// Disable auto-approval so this suite exercises the real manual lifecycle
+// (upload -> enable -> approve -> load), including the explicit approve endpoint.
+@TestPropertySource(properties = "app.plugins.approval.auto-approve=false")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/web/PluginManagementIntegrationTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/web/PluginManagementIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.web.dto.ErrorResponse;
 import java.io.ByteArrayOutputStream;
@@ -282,5 +283,44 @@ class PluginManagementIntegrationTest {
     assertThat(body.status()).isEqualTo(413);
     assertThat(body.error()).isEqualTo("Payload Too Large");
     assertThat(body.path()).isEqualTo(JOBS_BASE + "/upload");
+  }
+
+  // ─── auto-approval persistence ──────────────────────────────────────────────
+
+  @Test
+  @Order(12)
+  void uploadUnderNonProductionProfile_persistsAutoApproval() throws Exception {
+    // Under any non-production profile, AutoApproveConfig (@Profile("!production"))
+    // auto-approves uploads. The approval must be PERSISTED, so a fresh read from
+    // the database reflects APPROVED — not the default PENDING.
+    String jobName = "auto-approve-persist-job";
+    MockMultipartFile jarFile =
+        new MockMultipartFile(
+            "file",
+            "auto-approve.jar",
+            MediaType.APPLICATION_OCTET_STREAM_VALUE,
+            createMinimalJarBytes("META-INF/MANIFEST.MF"));
+
+    String responseBody =
+        mockMvc
+            .perform(
+                multipart(JOBS_BASE + "/upload")
+                    .file(jarFile)
+                    .param("jobName", jobName)
+                    .param("version", TEST_VERSION)
+                    .param("mainClassName", TEST_MAIN_CLASS))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    int idStart = responseBody.indexOf("\"id\":") + 5;
+    int idEnd = responseBody.indexOf(",", idStart);
+    long id = Long.parseLong(responseBody.substring(idStart, idEnd).trim());
+
+    JobDefinitionEntity persisted = jobDefinitionRepository.findById(id).orElseThrow();
+    assertThat(persisted.getApprovalStatus()).isEqualTo("APPROVED");
+    assertThat(persisted.getApprovedBy()).isEqualTo("system");
+    assertThat(persisted.getApprovedAt()).isNotNull();
   }
 }


### PR DESCRIPTION
## Summary

Uploaded plugin definitions stayed `PENDING` under every non-production profile (`local`, `dev`, `test`), so `POST /jobs/definitions/{id}/load` rejected them with HTTP 409 *"must be approved before loading"*. The documented local-run flow could not load plugins without an explicit approve call.

## Root cause

`AutoApproveConfig.approve()` only **mutates the entity in memory** (`setApprovalStatus("APPROVED")`). In `JarUploadService.uploadJar()`, `persistMetadata()` had already `save()`d the entity as `PENDING` and committed, and `uploadJar` is not `@Transactional`, so the in-memory approval was never flushed. The bean is active (`@Profile("!production")`) but its effect was silently lost.

## Fix

Re-save the entity after auto-approving:

```java
autoApproveConfig.ifPresent(
    ac -> {
      ac.approve(entity);
      jobDefinitionRepository.save(entity);
    });
```

### Why not `@Transactional` on `uploadJar`?

A method-level transaction would defer the initial INSERT to commit time, **outside** `persistMetadata`'s `try/catch`. That `catch` relies on `save()` throwing `DataIntegrityViolationException` **synchronously** to convert it into `DuplicateJobDefinitionException` — making the method transactional would break duplicate detection. It would also hold a DB connection across the upfront file I/O and signature verification. The targeted re-save is the minimal, side-effect-free fix; auto-approval only runs in non-production profiles.

## Test

`PluginManagementIntegrationTest.uploadUnderNonProductionProfile_persistsAutoApproval` uploads a JAR via MockMvc, then reads the definition back **from the database** and asserts `approvalStatus == APPROVED`. Verified red→green:

- Before the fix: `expected: "APPROVED" but was: "PENDING"`
- After the fix: 12/12 tests pass

A unit test with a mocked repository would not catch this (the `ArgumentCaptor` would hold the same reference `approve()` later mutates) — hence a behavior-first integration test against H2.

## Also (from a fresh-context review)

- Corrected `AutoApproveConfig` Javadoc: it said *"dev profile"* / *"atomically at persist time"*, now accurately *"non-production profiles"* and notes the caller re-saves.
- Added the missing `@Order(12)` to the new test to honor the class's `@TestMethodOrder` convention.

## Context

Companion to the local-run guide (PR #60, merged). The `load-plugins.sh` helper already approves explicitly, so the local flow works regardless; this fixes the underlying behavior so non-production uploads are auto-approved as intended.
