### PR TITLE
chore(local-dev): frictionless setup — root Taskfile + fewer install deps

### DIFF
--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -2,18 +2,43 @@
 
 Everything you need to go from a fresh clone to a fully operational local environment: MySQL running, backend migrated, seeds applied, all four plugins loaded, and the UI showing live data.
 
+## Quick Start (Task)
+
+If you have [Task](https://taskfile.dev) installed, the root `Taskfile.yml` wraps every step below.
+Each task just delegates to the same scripts and the Maven wrapper, so this is optional sugar — the
+manual steps work without Task.
+
+```bash
+task doctor     # check required tools
+task deps       # one-time: install batch-job-api into the local Maven cache
+task up         # start MySQL (Podman); the DB auto-creates on backend boot
+task backend    # run the backend (foreground — leave it running)
+# then, in another terminal:
+task seed       # load seed data
+task plugins    # build + upload + approve + enable + load all plugins
+task ui         # start the UI
+```
+
+Run `task --list` to see every target. The rest of this guide explains each step in full and is the
+source of truth if you are not using Task.
+
 ## Prerequisites
 
 | Tool | Version | Check |
 |------|---------|-------|
 | Java (JDK) | 21 | `java -version` |
 | JAVA_HOME | points to JDK 21 | `echo $JAVA_HOME` |
-| Maven | 3.9+ | `mvn -version` |
 | Podman | 4.0+ | `podman --version` |
 | podman-compose | 1.0+ | `podman-compose --version` |
 | Node.js | 20 LTS | `node -version` |
 | npm | bundled with Node 20 | `npm -version` |
-| jq or python3 | either | `jq --version` / `python3 --version` |
+| Task (optional) | 3.x | `task --version` |
+
+> **No Maven install needed** — every build uses the bundled wrapper `./fr-batch-service/mvnw`.
+> **No `mysql` client needed** — the seed script execs into the running DB container.
+> `python3` (built into macOS) covers the JSON parsing the scripts do; `jq` is used if present.
+>
+> Run `task doctor` to check these tools at any time.
 
 ---
 
@@ -26,8 +51,10 @@ Everything you need to go from a fresh clone to a fully operational local enviro
 Build and install `batch-job-api` into your local Maven cache. No GitHub PAT needed.
 
 ```bash
-mvn -f batch-job-api/pom.xml clean install
+./fr-batch-service/mvnw -f batch-job-api/pom.xml clean install
 ```
+
+> Or run `task deps`, which does exactly this.
 
 ### Option B — GitHub PAT in settings.xml
 
@@ -81,23 +108,13 @@ don't start with an alphanumeric, and the `_devenvironment` directory name would
 underscore into it.
 
 That `.env` configures `MYSQL_DATABASE=frbatchservicedb2` and a non-root user. The app's **local profile**
-connects to a different database (`fr_batch_local`) as `root` with an empty password — so you must create
-that database manually:
+connects to a different database (`fr_batch_local`) as `root` with an empty password. You do **not** need to
+create it by hand — the local JDBC URL carries `createDatabaseIfNotExist=true`, so the backend creates
+`fr_batch_local` on its first connection (Step 2). The container's server default charset is `utf8mb4`.
 
-```bash
-# Wait a few seconds for MySQL to be ready, then:
-podman-compose exec db \
-  mysql -u root -e "CREATE DATABASE IF NOT EXISTS fr_batch_local CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
-```
-
-Or connect with any MySQL client and run:
-
-```sql
-CREATE DATABASE IF NOT EXISTS fr_batch_local
-  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-```
-
-> **Why the mismatch?** `fr-batch-service/.env` is git-tracked and sets `DB_NAME=frbatchservicedb2`. The local Spring profile (`application-local.properties`) is hard-coded to `fr_batch_local`. They serve different purposes: the `.env` file pre-dates the local profile. The simplest fix is to create `fr_batch_local` as shown above; do not rename the `.env` value.
+> **Why the `.env` mismatch?** `fr-batch-service/.env` is git-tracked and sets `DB_NAME=frbatchservicedb2`,
+> while the local Spring profile (`application-local.properties`) targets `fr_batch_local`. They serve
+> different purposes and the `.env` value pre-dates the local profile — leave it as is.
 
 Verify MySQL is up:
 
@@ -111,8 +128,10 @@ podman-compose exec db mysqladmin ping -u root
 
 ```bash
 cd fr-batch-service
-mvn spring-boot:run -Dspring-boot.run.profiles=local
+./mvnw spring-boot:run -Dspring-boot.run.profiles=local
 ```
+
+> Uses the bundled Maven wrapper — no system Maven needed. The first run downloads the pinned Maven version.
 
 **The `local` profile flag is required.** Without it, the app tries to read `${DB_HOST}`, `${DB_PORT}`, `${DB_NAME}`, `${DB_USERNAME}`, and `${DB_PASSWORD}` from the environment and fails at startup.
 
@@ -120,7 +139,7 @@ What happens on first run with the `local` profile:
 
 - `FlywayMigrationRunner` (active only in the `local` profile) runs migrations V1–V8, creating all tables.
 - `spring.flyway.enabled=false` in `application-local.properties` keeps Spring's built-in Flyway autoconfigure out of the way.
-- Uploaded plugins must be **approved** before they can load (see Step 6). A dev-only `AutoApproveConfig` exists but does not currently persist the approval under the `local` profile, so the helper script approves each definition explicitly.
+- Uploaded plugins must be **approved** before they can load (see Step 6). Under the `local` profile `AutoApproveConfig` auto-approves each upload (toggle with `app.plugins.approval.auto-approve`); the helper script also approves explicitly, so it works either way.
 - NoOp password encoder is active (plain-text credentials work).
 
 Wait until you see a line similar to:
@@ -128,13 +147,17 @@ Wait until you see a line similar to:
 Started FrBatchServiceApplication in X.XXX seconds
 ```
 
-Health check:
+Readiness check — the public plugin endpoint responds as soon as the API is serving:
 
 ```bash
-curl -s http://localhost:8080/api/batch-service/actuator/health | python3 -m json.tool
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/batch-service/jobs/plugins
 ```
 
-Expected: `{"status":"UP"}`.
+Expected: `200`.
+
+> **Note on `/actuator/health`:** it reports `DOWN` (HTTP 503) until at least one uploaded plugin is loaded
+> — the `plugins` health group is unhealthy with zero loaded plugins. That is expected on a fresh start; it
+> flips to `UP` after Step 6. Use `/jobs/plugins` (above) as the "is the backend serving?" signal.
 
 ---
 
@@ -172,40 +195,29 @@ Seed files applied in order:
 
 ---
 
-## Step 4 — Create the Plugin JAR Directory
+## Step 4 — Plugin Storage (automatic — no action needed)
 
-The local profile stores uploaded JARs at an absolute path:
+The backend stores uploaded JARs under `${user.dir}/target/local-plugins/jars/` — i.e.
+`fr-batch-service/target/local-plugins/jars/` when started via the wrapper — and **creates that directory
+on first upload**. There is no manual `mkdir` step and no machine-specific path baked into config.
 
-```
-/Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/
-```
-
-This path is hard-coded in `fr-batch-service/src/main/resources/application-local.properties` (`fr-batch-service.plugins.jar-dir`). Create it before uploading plugins:
-
-```bash
-mkdir -p /Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/
-```
-
-> **Non-owner machines:** If your repo is checked out to a different path, override the property before starting the backend:
-> ```bash
-> mvn spring-boot:run \
->   -Dspring-boot.run.profiles=local \
->   -Dspring-boot.run.arguments="--fr-batch-service.plugins.jar-dir=/your/path/to/jars/"
-> ```
-> Or set it directly in `application-local.properties` — that file is not a secret, just local config.
+> Want a different location? Override `fr-batch-service.plugins.jar-dir` in `application-local.properties`,
+> or pass `-Dspring-boot.run.arguments="--fr-batch-service.plugins.jar-dir=/your/path/"` to the backend.
 
 ---
 
 ## Step 5 — Build the Plugin JARs
 
-Each plugin is a separate Maven module. Build all four fat JARs:
+Each plugin is a separate Maven module. Build all four fat JARs with the wrapper (no system Maven needed):
 
 ```bash
-mvn -B package -f ticket-pdf-job/pom.xml -DskipTests
-mvn -B package -f ticket-bundle-job/pom.xml -DskipTests
-mvn -B package -f fault-tolerant-harvester-job/pom.xml -DskipTests
-mvn -B package -f partitioned-harvester-job/pom.xml -DskipTests
+./fr-batch-service/mvnw -B package -f ticket-pdf-job/pom.xml -DskipTests
+./fr-batch-service/mvnw -B package -f ticket-bundle-job/pom.xml -DskipTests
+./fr-batch-service/mvnw -B package -f fault-tolerant-harvester-job/pom.xml -DskipTests
+./fr-batch-service/mvnw -B package -f partitioned-harvester-job/pom.xml -DskipTests
 ```
+
+> Or just run `task plugins`, which builds and loads everything via the helper script.
 
 Expected output jars:
 
@@ -216,7 +228,7 @@ Expected output jars:
 | fault-tolerant-harvester-job | `fault-tolerant-harvester-job/target/fault-tolerant-harvester-job-1.0.0.jar` |
 | partitioned-harvester-job | `partitioned-harvester-job/target/partitioned-harvester-job-1.0.0.jar` |
 
-> If you skipped Option A for GitHub Packages auth, Maven will 401 here. Go back and run `mvn -f batch-job-api/pom.xml clean install` first.
+> If you skipped Option A for GitHub Packages auth, Maven will 401 here. Go back and run `./fr-batch-service/mvnw -f batch-job-api/pom.xml clean install` (or `task deps`) first.
 
 ---
 
@@ -229,9 +241,10 @@ Plugin loading is **dynamic upload, not classpath**. At startup, zero plugins ar
 3. **Enable** — PUT to mark the definition active
 4. **Load** — POST to instantiate the plugin and register it as a Spring Batch job
 
-> The `approve` step is required under every non-production profile. A dev-only auto-approve exists but
-> does not currently persist, so the definition stays `PENDING` until approved explicitly — the helper
-> script does this for you.
+> Non-production profiles auto-approve uploads (`app.plugins.approval.auto-approve`, on by default), so a
+> definition is usually already `APPROVED`. The helper script still calls approve explicitly — a second
+> approve just returns `409 Already approved`, which it treats as success — so it works whether auto-approve
+> is on or off.
 
 Use the helper script (it handles all four plugins and all four steps):
 
@@ -320,9 +333,8 @@ Open the dashboard at http://localhost:5173 — you should see all four jobs lis
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `Could not resolve placeholder 'DB_HOST'` at startup | Missing `local` profile flag | Add `-Dspring-boot.run.profiles=local` |
-| `Unknown database 'fr_batch_local'` | DB not created | Run `CREATE DATABASE IF NOT EXISTS fr_batch_local;` in MySQL |
-| `mvn package` exits with HTTP 401 | GitHub Packages not authenticated | Run `mvn -f batch-job-api/pom.xml clean install` (Option A) |
-| Upload returns 500 / `No such file or directory` | JAR directory does not exist | `mkdir -p /Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/` |
+| `Unknown database 'fr_batch_local'` | JDBC URL lost `createDatabaseIfNotExist=true` | Restore the param in `application-local.properties`, or create the DB once: `podman-compose exec db mysql -u root -e "CREATE DATABASE IF NOT EXISTS fr_batch_local;"` |
+| `mvn package` exits with HTTP 401 | GitHub Packages not authenticated | Run `./fr-batch-service/mvnw -f batch-job-api/pom.xml clean install` (Option A / `task deps`) |
 | UI shows "Backend unreachable" | Backend not running on :8080 | Start backend first: Step 2 |
 | `POST /jobs/upload` returns 401 | Wrong credentials | Use `admin:admin123` for write operations |
 | Flyway fails with `Table already exists` | `00_create_schema.sql` was run manually | Drop all tables and let Flyway recreate, or restore a clean volume |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,89 @@
+# Frictionless local-dev orchestration.
+# Task reference: https://taskfile.dev/usage/
+#
+# This is a thin convenience layer: every task delegates to the portable scripts
+# and the Maven wrapper, so the setup also works WITHOUT Task (run the scripts
+# directly — see RUNNING_LOCALLY.md). Task just sequences and labels the steps.
+#
+# Typical first run (each in its own terminal where noted):
+#   task doctor     # verify required tools are installed
+#   task deps       # one-time: install batch-job-api into the local Maven cache
+#   task up         # start MySQL (Podman)
+#   task backend    # run the backend (foreground — leave it running)
+#   task seed       # in another terminal, once the backend is up
+#   task plugins    # build + upload + approve + enable + load all plugins
+#   task ui         # start the UI (foreground)
+---
+version: '3'
+silent: true
+
+tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+
+  doctor:
+    desc: Check required tools and print install hints (nothing is installed for you)
+    cmds:
+      - |
+        check() {
+          if command -v "$1" >/dev/null 2>&1; then
+            printf '  ok    %-16s %s\n' "$1" "$(command -v "$1")"
+          else
+            printf '  MISS  %-16s -> %s\n' "$1" "$2"
+          fi
+        }
+        echo "Required tools for local development:"
+        check java            "install JDK 21 (e.g. brew install temurin@21)"
+        check node            "install Node 20 LTS (e.g. brew install node@20)"
+        check npm             "ships with Node"
+        check podman          "brew install podman   (then: podman machine init)"
+        check podman-compose  "brew install podman-compose"
+        echo
+        echo "Maven is NOT required — tasks use ./fr-batch-service/mvnw"
+        echo "A mysql client is NOT required — scripts exec into the DB container"
+
+  deps:
+    desc: One-time — install batch-job-api into the local Maven cache (needed before building)
+    # Run the wrapper from fr-batch-service so it finds its own .mvn/wrapper; -f targets the api module.
+    dir: fr-batch-service
+    cmds:
+      - ./mvnw -q -f ../batch-job-api/pom.xml clean install
+
+  up:
+    desc: Start MySQL via Podman (machine + compose). The DB auto-creates on backend boot.
+    dir: fr-batch-service/_devenvironment
+    cmds:
+      # `machine start` errors if already running (or on Linux there is no machine) — ignore that.
+      - podman machine start 2>/dev/null || true
+      - podman-compose up -d
+
+  backend:
+    desc: Run the backend in the foreground (local profile). Creates fr_batch_local + runs Flyway.
+    dir: fr-batch-service
+    cmds:
+      - ./mvnw spring-boot:run -Dspring-boot.run.profiles=local
+
+  seed:
+    desc: Apply local seed data (run after the backend has migrated the schema)
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/seed-local-db.sh
+
+  plugins:
+    desc: Build, upload, approve, enable and load all four plugins
+    cmds:
+      - bash {{.TASKFILE_DIR}}/scripts/load-plugins.sh --build
+
+  ui:
+    desc: Install deps and start the batch-ops-ui dev server (foreground)
+    dir: batch-ops-ui
+    cmds:
+      - npm install
+      - npm run dev
+
+  down:
+    desc: Stop and remove the Podman MySQL container
+    dir: fr-batch-service/_devenvironment
+    cmds:
+      - podman-compose down

--- a/fr-batch-service/src/main/resources/application-local.properties
+++ b/fr-batch-service/src/main/resources/application-local.properties
@@ -1,10 +1,12 @@
 # ============================================================
 # Local Development Profile — MySQL via Podman/Docker
-# Run with: mvn spring-boot:run -Dspring-boot.run.profiles=local
+# Run with: ./mvnw spring-boot:run -Dspring-boot.run.profiles=local
 # ============================================================
 
-# MySQL connection — override full URL to avoid placeholder resolution issues
-spring.datasource.url=jdbc:mysql://localhost:3306/fr_batch_local?useLegacyDatetimeCode=false&serverTimezone=UTC
+# MySQL connection — override full URL to avoid placeholder resolution issues.
+# createDatabaseIfNotExist=true lets the backend create fr_batch_local on first
+# connect, so no manual database-creation step is needed.
+spring.datasource.url=jdbc:mysql://localhost:3306/fr_batch_local?useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
 spring.datasource.username=root
 spring.datasource.password=
 
@@ -12,7 +14,7 @@ spring.datasource.password=
 spring.batch.jdbc.initialize-schema=always
 
 # Override secondary datasource (avoids ${DB_NAME} placeholder from main config)
-datasources.main.jdbcUrl=jdbc:mysql://localhost:3306/fr_batch_local?useLegacyDatetimeCode=false&serverTimezone=UTC
+datasources.main.jdbcUrl=jdbc:mysql://localhost:3306/fr_batch_local?useLegacyDatetimeCode=false&serverTimezone=UTC&createDatabaseIfNotExist=true
 datasources.main.username=root
 datasources.main.password=
 
@@ -51,8 +53,11 @@ fr-batch-service.rest_clients.client1.base_url=http://localhost:9999
 fr-batch-service.rest_clients.client1.connection_timeout_millis=500
 fr-batch-service.rest_clients.client1.response_timeout_millis=500
 
-# Plugin storage (absolute path — relative resolves against Jetty temp dir)
-fr-batch-service.plugins.jar-dir=/Users/lalo/__home/projects/spring-batch-projects/target/local-plugins/jars/
+# Plugin storage. Must be absolute — a bare relative path resolves against the
+# Jetty temp dir. ${user.dir} (the process working dir, i.e. fr-batch-service/
+# when run via mvnw) keeps it absolute and machine-independent. The directory is
+# created automatically on first upload (JarUploadService#storeFile).
+fr-batch-service.plugins.jar-dir=${user.dir}/target/local-plugins/jars/
 
 # Enable audit listener logging
 logging.level.com.fronzec.frbatchservice.batchjobs.plugins.listener=INFO

--- a/scripts/load-plugins.sh
+++ b/scripts/load-plugins.sh
@@ -17,8 +17,9 @@
 #   - jq OR python3 must be in PATH (used to parse the upload response)
 #   - The backend must be running on BASE_URL before this script is called.
 #   - The plugin JAR directory must exist (see RUNNING_LOCALLY.md Step 4).
-#   - If --build is passed, mvn must be in PATH and batch-job-api must be
-#     installed locally (mvn -f batch-job-api/pom.xml clean install).
+#   - If --build is passed, Maven is resolved wrapper-first (fr-batch-service/mvnw,
+#     falling back to a system mvn), and batch-job-api must be installed locally
+#     (fr-batch-service/mvnw -f batch-job-api/pom.xml clean install).
 
 set -Eeuo pipefail
 
@@ -89,10 +90,24 @@ extract_id() {
     fi
 }
 
-if [[ "$BUILD" == "true" ]] && ! command -v mvn &>/dev/null; then
-    printf '[ERROR] --build was requested but mvn is not in PATH.\n' >&2
+# Resolve Maven wrapper-first so --build needs no system Maven install.
+MVNW="$REPO_ROOT/fr-batch-service/mvnw"
+if [[ "$BUILD" == "true" && ! -x "$MVNW" ]] && ! command -v mvn &>/dev/null; then
+    printf '[ERROR] --build requested but no Maven found (no fr-batch-service/mvnw, no mvn in PATH).\n' >&2
     exit 1
 fi
+
+# Build one module by absolute pom path. The wrapper bootstraps from its own
+# .mvn dir, so it must run with fr-batch-service as the working directory; a
+# system mvn (fallback) works from anywhere.
+build_module() {
+    local pom="$1"
+    if [[ -x "$MVNW" ]]; then
+        ( cd "$REPO_ROOT/fr-batch-service" && ./mvnw -B package -f "$pom" -DskipTests -q )
+    else
+        mvn -B package -f "$pom" -DskipTests -q
+    fi
+}
 
 # ─── Plugin definitions ───────────────────────────────────────────────────────
 # Format: "jobName|relative/jar/path|mainClassName"
@@ -114,22 +129,24 @@ if [[ "$BUILD" == "true" ]]; then
     )
     for module in "${MODULE_DIRS[@]}"; do
         printf '[INFO]   Building %s ...\n' "$module"
-        mvn -B package -f "$REPO_ROOT/$module/pom.xml" -DskipTests -q
+        build_module "$REPO_ROOT/$module/pom.xml"
         printf '[OK]     %s built.\n' "$module"
     done
     printf '[INFO] All JARs built.\n\n'
 fi
 
 # ─── Backend connectivity check ───────────────────────────────────────────────
+# Probe the public /jobs/plugins endpoint, NOT /actuator/health: aggregate health
+# reports DOWN (503) until plugins are loaded, which is exactly the bootstrap state
+# this script runs in. /jobs/plugins returns 200 whenever the API is serving.
 printf '[INFO] Checking backend at %s ...\n' "$BASE_URL"
 HEALTH_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
-    "${BASE_URL}/actuator/health" || true)
+    "${BASE_URL}/jobs/plugins" || true)
 
 if [[ "$HEALTH_STATUS" != "200" ]]; then
-    printf '[ERROR] Backend health check returned HTTP %s (expected 200).\n' \
-        "$HEALTH_STATUS" >&2
+    printf '[ERROR] Backend is not reachable at %s (HTTP %s).\n' "$BASE_URL" "$HEALTH_STATUS" >&2
     printf '        Is the backend running? Start it with:\n' >&2
-    printf '          cd fr-batch-service && mvn spring-boot:run -Dspring-boot.run.profiles=local\n' >&2
+    printf '          cd fr-batch-service && ./mvnw spring-boot:run -Dspring-boot.run.profiles=local\n' >&2
     exit 1
 fi
 printf '[INFO] Backend is up.\n\n'
@@ -149,7 +166,7 @@ for entry in "${PLUGINS[@]}"; do
     # Validate JAR exists
     if [[ ! -f "$JAR_ABS" ]]; then
         printf '[ERROR] JAR not found: %s\n' "$JAR_ABS" >&2
-        printf '        Build it first: mvn -B package -f %s/pom.xml -DskipTests\n' \
+        printf '        Build it first: ./fr-batch-service/mvnw -B package -f %s/pom.xml -DskipTests\n' \
             "$(dirname "$JAR_REL")" >&2
         FAILED=$((FAILED + 1))
         continue


### PR DESCRIPTION
## Summary

Make the local-dev setup frictionless and cut the install footprint. Adds a root `Taskfile.yml` as a thin convenience layer over the existing portable scripts (it works **without** Task too), and removes several manual steps and install dependencies.

**Verified end-to-end with a full clean run** (teardown → fresh MySQL → backend → seed → plugins → 6/6 ACTIVE, health 200).

## Fewer install dependencies / fewer manual steps

| Before | After |
|--------|-------|
| Install Maven | `./fr-batch-service/mvnw` everywhere |
| Install a `mysql` client | seed script execs into the DB container (already shipped) |
| Manually `CREATE DATABASE fr_batch_local` | `createDatabaseIfNotExist=true` — backend creates it on first connect |
| `mkdir` a hard-coded, username-bearing JAR path | `${user.dir}/target/local-plugins/jars/` (portable; auto-created by `storeFile`) |
| Remember a 7-step sequence | `task doctor/up/backend/seed/plugins/ui/down` |

## Changes

- **`Taskfile.yml`** (new, root): `doctor` (tool check with install hints), `deps`, `up`, `backend`, `seed`, `plugins`, `ui`, `down`. Each delegates to the scripts / the Maven wrapper — Task is optional sugar, not a hard dependency. The backend stays a separate foreground task (no fragile `task all`).
- **`application-local.properties`**: `createDatabaseIfNotExist=true` on both JDBC URLs; `jar-dir = ${user.dir}/target/local-plugins/jars/` (still absolute — a bare relative path resolves against the Jetty temp dir — but machine-independent).
- **`scripts/load-plugins.sh`** — two fixes surfaced by the full clean run:
  - Resolve Maven **wrapper-first** (`fr-batch-service/mvnw`, invoked from its own dir so it finds `.mvn/wrapper`; falls back to a system `mvn`), so `--build` needs no system Maven.
  - Readiness probe switched from `/actuator/health` to the public `/jobs/plugins`: aggregate health reports **DOWN (503) until a plugin is loaded** — exactly the bootstrap state this script runs in — so the old `== 200` gate could never pass on a fresh system.
- **`RUNNING_LOCALLY.md`**: Quick Start (Task) section, dropped the now-unneeded manual DB-create and JAR-dir steps, `./mvnw` everywhere, and documented the `/actuator/health` bootstrap behavior.

## Notes

- The existing module-level `fr-batch-service/Taskfile.yml` (Gitpod/infisical era) is left untouched and can be cleaned up separately.
- Discovered, not fixed here (follow-up): after a backend **restart**, `PluginAutoLoader` reports previously-loaded definitions as "already loaded" from persisted `load_status` and does not re-instantiate them into the fresh in-memory registry, so health stays DOWN until they are re-loaded.

## Test plan

- [x] `bash -n scripts/load-plugins.sh` passes
- [x] `task --list` / `task doctor` work
- [x] Full clean run on Podman/macOS: `task up` → fresh MySQL → `task backend` auto-creates `fr_batch_local` + Flyway 8 migrations from scratch → `task seed` → `task plugins` (built 4 modules via wrapper, uploaded to the new JAR dir, approve/enable/load) → **6/6 plugins ACTIVE, `/actuator/health` 200**
