### PR TITLE
fix(plugins): re-instantiate stale-LOADED plugins on restart

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
@@ -146,9 +146,18 @@ public class PluginRegistryService {
         return Optional.ofNullable(pluginsByJobName.get(jobName));
     }
 
-    /** Returns the set of all registered job names. */
+    /**
+     * Returns an immutable snapshot of all registered job names.
+     *
+     * <p>Takes the {@code pluginsByJobName} monitor and copies the key set so the
+     * returned value is safe to read while concurrent register/unregister calls
+     * mutate the map. Returning the live {@code keySet()} view would race with
+     * those writers.
+     */
     public Set<String> getRegisteredJobNames() {
-        return Collections.unmodifiableSet(pluginsByJobName.keySet());
+        synchronized (pluginsByJobName) {
+            return Set.copyOf(pluginsByJobName.keySet());
+        }
     }
 
     /**

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
@@ -104,8 +104,10 @@ public class DynamicJobLoaderService {
               + entity.getApprovalStatus());
     }
 
-    // Optimistic guard: already loaded or currently loading
-    if (LoadResult.LOADED.equals(entity.getLoadStatus())) {
+    // Optimistic guard: already loaded in THIS JVM's registry. The persisted
+    // loadStatus can be a stale LOADED after a restart (the registry is
+    // in-memory and resets), so consult the live registry, not the DB column.
+    if (pluginRegistryService.getRegisteredJobNames().contains(entity.getJobName())) {
       throw new IllegalStateException(
           "Job \"" + entity.getJobName() + "\" (id=" + definitionId + ") is already loaded");
     }
@@ -371,8 +373,11 @@ public class DynamicJobLoaderService {
     Map<String, LoadResult> results = new LinkedHashMap<>();
 
     for (JobDefinitionEntity def : enabledDefs) {
-      // Skip already-loaded definitions
-      if (LoadResult.LOADED.equals(def.getLoadStatus())) {
+      // Skip definitions already loaded in THIS JVM's registry. After a restart
+      // the persisted loadStatus may still say LOADED while the in-memory registry
+      // is empty, so check the live registry — not the DB column — to avoid
+      // skipping definitions that need re-instantiating.
+      if (pluginRegistryService.getRegisteredJobNames().contains(def.getJobName())) {
         log.debug(
             "Skipping already-loaded definition '{}' (id={})",
             def.getJobName(),

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
@@ -280,9 +280,13 @@ class DynamicJobLoaderServiceTest {
 
   @Test
   void loadJob_alreadyLoaded_throwsIllegalStateException() {
-    JobDefinitionEntity entity = createEntity(7L, "already-loaded", true, LoadResult.LOADED);
+    // Persisted status is intentionally NOT LOADED: the guard must fire purely
+    // because the job is in the live registry, proving it consults the registry
+    // and not the DB column.
+    JobDefinitionEntity entity = createEntity(7L, "already-loaded", true, LoadResult.UNLOADED);
 
     when(jobDefinitionRepository.findById(7L)).thenReturn(Optional.of(entity));
+    when(pluginRegistryService.getRegisteredJobNames()).thenReturn(Set.of("already-loaded"));
 
     IllegalStateException ex =
         assertThrows(IllegalStateException.class, () -> service.loadJob(7L));
@@ -385,6 +389,9 @@ class DynamicJobLoaderServiceTest {
 
     when(jobDefinitionRepository.findByEnabled(true)).thenReturn(List.of(loaded, pending));
     when(jobDefinitionRepository.findById(13L)).thenReturn(Optional.of(pending));
+    // The "already-loaded" definition is the one currently in the live registry;
+    // "test-job" is not, so it must actually load.
+    when(pluginRegistryService.getRegisteredJobNames()).thenReturn(Set.of("already-loaded"));
     doNothing()
         .when(pluginRegistryService)
         .registerDynamicPlugin(any(BatchJobPlugin.class), any());

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoadingIntegrationTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoadingIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fronzec.frbatchservice.batchjobs.JobsManagerService;
 import com.fronzec.frbatchservice.batchjobs.plugins.PluginRegistryService;
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import com.fronzec.frbatchservice.restclients.ApiClient;
 import com.fronzec.frbatchservice.restclients.DataCalculatedResponse;
@@ -80,6 +81,7 @@ class DynamicJobLoadingIntegrationTest {
   @Autowired private JobDefinitionRepository jobDefinitionRepository;
   @Autowired private JobsManagerService jobsManagerService;
   @Autowired private PluginRegistryService pluginRegistryService;
+  @Autowired private DynamicJobLoaderService loaderService;
 
   @MockitoBean private ApiClient apiClient;
 
@@ -389,5 +391,43 @@ class DynamicJobLoadingIntegrationTest {
     assertThat(body).contains("\"job_name\":\"" + JOB_NAME + "\"");
     assertThat(body).contains("\"status\":\"" + LoadResult.LOADED + "\"");
     assertThat(body).contains("\"message\":\"Successfully loaded\"");
+  }
+
+  /* ── 13. Auto-load re-instantiates definitions with stale LOADED status ── */
+
+  @Test
+  @Order(13)
+  void loadAllEnabled_reloadsDefinitionWithStaleLoadedStatus() {
+    // Simulate a backend restart: the database still says LOADED from a previous
+    // JVM, but the in-memory registry is empty. Auto-load must actually load the
+    // plugin (re-instantiate it), not skip it as "Already loaded" off the stale
+    // persisted status.
+
+    // Ensure the registry does not hold it (unload if a prior test left it loaded).
+    if (pluginRegistryService.getRegisteredJobNames().contains(JOB_NAME)) {
+      loaderService.unloadJob(definitionId, true);
+    }
+    assertThat(pluginRegistryService.getRegisteredJobNames()).doesNotContain(JOB_NAME);
+
+    // Force the stale persisted state: enabled + LOADED, but not in the registry.
+    JobDefinitionEntity def = jobDefinitionRepository.findById(definitionId).orElseThrow();
+    def.setEnabled(true);
+    def.setLoadStatus(LoadResult.LOADED);
+    jobDefinitionRepository.save(def);
+
+    // Precondition: the persisted state really is the stale "LOADED" we mean to test
+    // (otherwise the assertions below could pass for the wrong reason).
+    assertThat(jobDefinitionRepository.findById(definitionId).orElseThrow().getLoadStatus())
+        .isEqualTo(LoadResult.LOADED);
+
+    Map<String, LoadResult> results = loaderService.loadAllEnabled();
+
+    LoadResult result = results.get(JOB_NAME);
+    assertThat(result).as("auto-load result for %s", JOB_NAME).isNotNull();
+    assertThat(result.status()).isEqualTo(LoadResult.LOADED);
+    assertThat(result.message())
+        .as("stale-LOADED definition must be loaded, not skipped")
+        .isEqualTo("Successfully loaded");
+    assertThat(pluginRegistryService.getRegisteredJobNames()).contains(JOB_NAME);
   }
 }


### PR DESCRIPTION
## Summary

After a backend **restart**, previously-loaded plugins were not re-instantiated into the (fresh, empty) in-memory registry, so `/jobs/plugins` showed them inactive and the `plugins` health group stayed **DOWN** until a manual reload.

## Root cause

`DynamicJobLoaderService` decided "already loaded" from the **persisted** `load_status` column:

```java
if (LoadResult.LOADED.equals(entity.getLoadStatus())) { ...skip/throw "already loaded"... }
```

The registry is **in-memory** and resets on restart, but `load_status` persists. So on the next boot the DB said `LOADED` while the registry was empty, and `loadAllEnabled()` (run by `PluginAutoLoader` on startup) logged *"already loaded"* and skipped the definition instead of re-instantiating it.

## Fix

Both guards (`loadJob` and `loadAllEnabled`) now consult the **live registry** instead of the DB column:

```java
if (pluginRegistryService.getRegisteredJobNames().contains(jobName)) { ... }
```

Chose `PluginRegistryService` over the service's private `classLoaders` map because it's the proper registry abstraction **and** is mockable in unit tests. Behavior is unchanged within a single JVM (registry matches status); after a restart the empty registry means the definition is actually loaded rather than skipped.

### Also (from a fresh-context review)

- **Thread-safety:** `getRegisteredJobNames()` returned a live `keySet()` view that races with concurrent `register`/`unregister` (which synchronize on the map). The new guard calls it on hot paths, so it now returns an immutable `Set.copyOf(...)` snapshot taken under the registry monitor.

## Tests

- New integration test `DynamicJobLoadingIntegrationTest#loadAllEnabled_reloadsDefinitionWithStaleLoadedStatus` reproduces the restart state (force `load_status=LOADED` in the DB while the registry is empty), asserts the precondition, and asserts the definition is **actually loaded** (`"Successfully loaded"`, present in `getRegisteredJobNames()`) — red→green against the fix.
- Updated the two `DynamicJobLoaderServiceTest` unit tests that codified the old status-based guard; the `loadJob` one now uses a **non-LOADED** persisted status so the throw is driven purely by registry presence (discriminates the guard).
- Full `fr-batch-service` suite: **BUILD SUCCESS**.

## Notes

- Out of scope (pre-existing, very unlikely): an uploaded definition whose `jobName` collides with a classpath plugin name (e.g. `job1`) is treated as already-loaded by `loadAllEnabled`. That's an upload-validation concern, not a loader one.
