### PR TITLE
feat(batch-ops-ui): design-token theme foundation + Svelte 5 mount fix

### DIFF
--- a/batch-ops-ui/src/App.svelte
+++ b/batch-ops-ui/src/App.svelte
@@ -31,27 +31,6 @@
 </div>
 
 <style>
-  :global(*, *::before, *::after) {
-    box-sizing: border-box;
-  }
-
-  :global(body) {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    font-size: 16px;
-    color: #212529;
-    background: #fff;
-  }
-
-  :global(h2) {
-    margin: 0 0 1rem;
-    font-size: 1.25rem;
-  }
-
-  :global(h3) {
-    margin: 0 0 0.5rem;
-  }
-
   .app {
     min-height: 100vh;
     display: flex;
@@ -59,28 +38,29 @@
   }
 
   .app-header {
-    padding: 0.75rem 1rem;
-    background: #1a1a2e;
-    color: white;
+    padding: var(--space-3) var(--space-4);
+    background: var(--surface-inverse);
+    color: var(--text-on-inverse);
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: var(--space-4);
+    box-shadow: var(--shadow-md);
   }
 
   .app-title {
     display: flex;
     align-items: baseline;
-    gap: 1rem;
+    gap: var(--space-4);
   }
 
   .app-title h1 {
     margin: 0;
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: var(--text-xl);
+    font-weight: var(--weight-bold);
   }
 
   .subtitle {
-    font-size: 0.8rem;
+    font-size: var(--text-xs);
     opacity: 0.7;
   }
 

--- a/batch-ops-ui/src/components/LoginForm.svelte
+++ b/batch-ops-ui/src/components/LoginForm.svelte
@@ -51,58 +51,71 @@
 
 <style>
   .login-form {
-    padding: 0.5rem 1rem;
-    background: #fff3cd;
-    border-bottom: 1px solid #ffc107;
-    font-size: 0.875rem;
+    padding: var(--space-2) var(--space-4);
+    background: var(--banner-bg);
+    border-bottom: 1px solid var(--banner-border);
+    font-size: var(--text-sm);
+    color: var(--banner-text);
   }
 
   .credentials-form {
     display: flex;
     align-items: flex-end;
-    gap: 0.75rem;
+    gap: var(--space-3);
     flex-wrap: wrap;
   }
 
   label {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
-    font-weight: 500;
+    gap: var(--space-1);
+    font-weight: var(--weight-medium);
   }
 
   input {
-    padding: 0.3rem 0.5rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 0.875rem;
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--surface-base);
+    color: var(--text-primary);
+    font-size: var(--text-sm);
   }
 
   button {
-    padding: 0.35rem 0.8rem;
-    border-radius: 4px;
-    border: 1px solid #0066cc;
-    background: #0066cc;
-    color: white;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-brand);
+    background: var(--color-brand);
+    color: var(--text-on-brand);
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    transition: background 0.12s ease;
+  }
+
+  button:hover {
+    background: var(--color-brand-hover);
   }
 
   .caveat {
-    margin: 0.4rem 0 0;
-    color: #664d03;
-    font-size: 0.8rem;
+    margin: var(--space-2) 0 0;
+    color: var(--banner-text);
+    font-size: var(--text-xs);
   }
 
   .logged-in {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: var(--space-4);
   }
 
   .logout-btn {
-    background: white;
-    color: #cc0000;
-    border-color: #cc0000;
+    background: var(--surface-base);
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+  }
+
+  .logout-btn:hover {
+    background: var(--color-danger);
+    color: var(--text-on-brand);
   }
 </style>

--- a/batch-ops-ui/src/components/TabBar.svelte
+++ b/batch-ops-ui/src/components/TabBar.svelte
@@ -38,28 +38,31 @@
 <style>
   .tab-bar {
     display: flex;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    border-bottom: 1px solid #ddd;
-    background: #f8f9fa;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--surface-muted);
   }
 
   button {
-    padding: 0.4rem 0.9rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background: white;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--surface-base);
+    color: var(--text-secondary);
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: var(--text-sm);
+    transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
   }
 
   button.active {
-    background: #0066cc;
-    color: white;
-    border-color: #0066cc;
+    background: var(--color-brand);
+    color: var(--text-on-brand);
+    border-color: var(--color-brand);
   }
 
   button:hover:not(.active) {
-    background: #e9ecef;
+    background: var(--surface-accent);
+    border-color: var(--border-strong);
   }
 </style>

--- a/batch-ops-ui/src/main.ts
+++ b/batch-ops-ui/src/main.ts
@@ -1,6 +1,7 @@
+import { mount } from 'svelte';
 import App from './App.svelte';
 
-const app = new App({
+const app = mount(App, {
   target: document.getElementById('app')!,
 });
 

--- a/batch-ops-ui/src/main.ts
+++ b/batch-ops-ui/src/main.ts
@@ -1,3 +1,4 @@
+import './styles/base.css';
 import { mount } from 'svelte';
 import App from './App.svelte';
 

--- a/batch-ops-ui/src/styles/base.css
+++ b/batch-ops-ui/src/styles/base.css
@@ -1,0 +1,50 @@
+/*
+ * Global base styles: reset + element defaults.
+ * Everything here consumes design tokens — no hardcoded values.
+ */
+
+@import './tokens.css';
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: var(--text-md);
+  line-height: var(--leading-normal);
+  color: var(--text-primary);
+  background: var(--surface-base);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3 {
+  line-height: var(--leading-tight);
+}
+
+h2 {
+  margin: 0 0 var(--space-4);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-semibold);
+}
+
+h3 {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
+}
+
+/* Shared interactive affordances */
+a {
+  color: var(--color-brand);
+}
+
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}

--- a/batch-ops-ui/src/styles/tokens.css
+++ b/batch-ops-ui/src/styles/tokens.css
@@ -1,0 +1,168 @@
+/*
+ * Design tokens — the single source of truth for the visual system.
+ *
+ * Three layers:
+ *   1. Primitives — the raw palette/scales. Components should NOT consume these directly.
+ *   2. Semantic   — intent-based aliases (surface, text, border, brand...). Components use THESE.
+ *   3. Dark theme — opt-in overrides of the semantic layer under [data-theme="dark"].
+ *
+ * Changing the brand color, a surface, or spacing happens here once — never in components.
+ */
+
+:root {
+  /* ----- 1. Primitives: raw values, not used directly by components ----- */
+
+  /* Neutral ramp (cool gray) */
+  --gray-0: #ffffff;
+  --gray-50: #f7f8fa;
+  --gray-100: #eef1f5;
+  --gray-200: #e2e6ec;
+  --gray-300: #cbd2db;
+  --gray-400: #9aa4b2;
+  --gray-500: #6b7480;
+  --gray-600: #4b535e;
+  --gray-700: #343a42;
+  --gray-800: #222831;
+  --gray-900: #16191f;
+
+  /* Brand (indigo) */
+  --indigo-50: #eef2ff;
+  --indigo-100: #e0e7ff;
+  --indigo-500: #4f46e5;
+  --indigo-600: #4338ca;
+  --indigo-700: #3730a3;
+
+  /* Accent surfaces */
+  --navy-900: #1a1a2e;
+
+  /* Status */
+  --green-50: #e6f4ec;
+  --green-500: #1a7f4b;
+  --amber-50: #fff3cd;
+  --amber-border: #ffc107;
+  --amber-700: #664d03;
+  --amber-500: #b8860b;
+  --red-50: #fdecec;
+  --red-500: #cc0000;
+  --red-600: #a30000;
+
+  /* ----- 2. Semantic: what components actually consume ----- */
+
+  /* Surfaces */
+  --surface-base: var(--gray-0);
+  --surface-muted: var(--gray-50);
+  --surface-raised: var(--gray-0);
+  --surface-accent: var(--indigo-50); /* subtle highlight, e.g. row hover */
+  --surface-inverse: var(--navy-900);
+
+  /* Text */
+  --text-primary: var(--gray-900);
+  --text-secondary: var(--gray-700);
+  --text-muted: var(--gray-500);
+  --text-on-brand: var(--gray-0);
+  --text-on-inverse: var(--gray-0);
+
+  /* Borders */
+  --border-subtle: var(--gray-200);
+  --border-default: var(--gray-300);
+  --border-strong: var(--gray-400);
+
+  /* Brand */
+  --color-brand: var(--indigo-500);
+  --color-brand-hover: var(--indigo-600);
+  --color-brand-active: var(--indigo-700);
+  --color-brand-subtle: var(--indigo-50);
+
+  /* Status (intent) */
+  --color-success: var(--green-500);
+  --color-success-subtle: var(--green-50);
+  --color-danger: var(--red-500);
+  --color-danger-hover: var(--red-600);
+  --color-warning: var(--amber-500);
+
+  /* Banner (e.g. the read-only / auth notice) */
+  --banner-bg: var(--amber-50);
+  --banner-border: var(--amber-border);
+  --banner-text: var(--amber-700);
+
+  /* Focus ring */
+  --focus-ring: 0 0 0 3px rgba(79, 70, 229, 0.35);
+
+  /* ----- Spacing scale (4px base) ----- */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+
+  /* ----- Radius ----- */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 10px;
+  --radius-full: 999px;
+
+  /* ----- Elevation ----- */
+  --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06);
+  --shadow-md: 0 2px 8px rgba(16, 24, 40, 0.08);
+  --shadow-lg: 0 8px 24px rgba(16, 24, 40, 0.12);
+
+  /* ----- Typography ----- */
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  --leading-tight: 1.25;
+  --leading-normal: 1.5;
+}
+
+/*
+ * ----- 3. Dark theme -----
+ * Opt-in: set data-theme="dark" on <html>. Only semantic tokens are overridden,
+ * so every component that consumes tokens flips automatically. System-preference
+ * auto-detection and a UI toggle are deliberately left for a future feature.
+ */
+[data-theme="dark"] {
+  --surface-base: var(--gray-900);
+  --surface-muted: var(--gray-800);
+  --surface-raised: var(--gray-800);
+  --surface-accent: #232145;
+  --surface-inverse: #0e0e18;
+
+  --text-primary: var(--gray-100);
+  --text-secondary: var(--gray-300);
+  --text-muted: var(--gray-400);
+
+  --border-subtle: var(--gray-700);
+  --border-default: var(--gray-600);
+  --border-strong: var(--gray-500);
+
+  --color-brand: #818cf8;
+  --color-brand-hover: #a5b4fc;
+  --color-brand-active: #c7d2fe;
+  --color-brand-subtle: #1e1b4b;
+
+  --color-danger: #ff6b6b;
+  --color-danger-hover: #ff8585;
+
+  --banner-bg: #2e2613;
+  --banner-border: #6b5310;
+  --banner-text: #e6c200;
+
+  --focus-ring: 0 0 0 3px rgba(129, 140, 248, 0.4);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.5);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.6);
+}

--- a/batch-ops-ui/src/views/DefinitionsView.svelte
+++ b/batch-ops-ui/src/views/DefinitionsView.svelte
@@ -106,28 +106,36 @@
 
 <style>
   .definitions-view {
-    padding: 1rem;
+    padding: var(--space-4);
   }
 
   .table-wrapper {
     overflow-x: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
   }
 
   table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
   }
 
   th, td {
     text-align: left;
-    padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  tr:last-child td {
+    border-bottom: none;
   }
 
   th {
-    background: #f8f9fa;
-    font-weight: 600;
+    background: var(--surface-muted);
+    color: var(--text-secondary);
+    font-weight: var(--weight-semibold);
   }
 
   .clickable-row {
@@ -135,40 +143,46 @@
   }
 
   .clickable-row:hover td {
-    background: #f0f4ff;
+    background: var(--surface-accent);
   }
 
   .empty-state {
-    color: #666;
+    color: var(--text-muted);
     font-style: italic;
   }
 
   .detail-header {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
+    gap: var(--space-4);
+    margin-bottom: var(--space-4);
   }
 
   .back-btn {
-    padding: 0.3rem 0.8rem;
-    border: 1px solid #0066cc;
-    border-radius: 4px;
-    background: white;
-    color: #0066cc;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-brand);
+    border-radius: var(--radius-md);
+    background: var(--surface-base);
+    color: var(--color-brand);
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+
+  .back-btn:hover {
+    background: var(--color-brand);
+    color: var(--text-on-brand);
   }
 
   .detail-panel dl {
     display: grid;
     grid-template-columns: 200px 1fr;
-    gap: 0.4rem 1rem;
-    font-size: 0.875rem;
+    gap: var(--space-2) var(--space-4);
+    font-size: var(--text-sm);
   }
 
   .detail-panel dt {
-    font-weight: 600;
-    color: #555;
+    font-weight: var(--weight-semibold);
+    color: var(--text-secondary);
   }
 </style>

--- a/batch-ops-ui/src/views/PluginsView.svelte
+++ b/batch-ops-ui/src/views/PluginsView.svelte
@@ -66,36 +66,44 @@
 
 <style>
   .plugins-view {
-    padding: 1rem;
+    padding: var(--space-4);
   }
 
   .table-wrapper {
     overflow-x: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
   }
 
   table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
   }
 
   th, td {
     text-align: left;
-    padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  tr:last-child td {
+    border-bottom: none;
   }
 
   th {
-    background: #f8f9fa;
-    font-weight: 600;
+    background: var(--surface-muted);
+    color: var(--text-secondary);
+    font-weight: var(--weight-semibold);
   }
 
   tr:hover td {
-    background: #f0f4ff;
+    background: var(--surface-accent);
   }
 
   .empty-state {
-    color: #666;
+    color: var(--text-muted);
     font-style: italic;
   }
 </style>

--- a/batch-ops-ui/src/views/RunningView.svelte
+++ b/batch-ops-ui/src/views/RunningView.svelte
@@ -64,24 +64,30 @@
 
 <style>
   .running-view {
-    padding: 1rem;
+    padding: var(--space-4);
   }
 
   .running-header {
     display: flex;
     align-items: center;
-    gap: 1rem;
-    margin-bottom: 1rem;
+    gap: var(--space-4);
+    margin-bottom: var(--space-4);
   }
 
   .refresh-btn {
-    padding: 0.3rem 0.8rem;
-    border: 1px solid #0066cc;
-    border-radius: 4px;
-    background: white;
-    color: #0066cc;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-brand);
+    border-radius: var(--radius-md);
+    background: var(--surface-base);
+    color: var(--color-brand);
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
+    transition: background 0.12s ease, color 0.12s ease;
+  }
+
+  .refresh-btn:hover:not(:disabled) {
+    background: var(--color-brand);
+    color: var(--text-on-brand);
   }
 
   .refresh-btn:disabled {
@@ -90,39 +96,47 @@
   }
 
   .job-section {
-    margin-bottom: 1.5rem;
+    margin-bottom: var(--space-5);
   }
 
   .job-name {
-    font-size: 1rem;
-    font-weight: 600;
-    margin-bottom: 0.5rem;
-    color: #333;
+    font-size: var(--text-md);
+    font-weight: var(--weight-semibold);
+    margin-bottom: var(--space-2);
+    color: var(--text-secondary);
   }
 
   .table-wrapper {
     overflow-x: auto;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
   }
 
   table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 0.875rem;
+    font-size: var(--text-sm);
   }
 
   th, td {
     text-align: left;
-    padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid #ddd;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  tr:last-child td {
+    border-bottom: none;
   }
 
   th {
-    background: #f8f9fa;
-    font-weight: 600;
+    background: var(--surface-muted);
+    color: var(--text-secondary);
+    font-weight: var(--weight-semibold);
   }
 
   .empty-state {
-    color: #666;
+    color: var(--text-muted);
     font-style: italic;
   }
 </style>


### PR DESCRIPTION
## Summary

Lay a **visual foundation** for `batch-ops-ui` before adding interactive features: a vanilla CSS **design-token** system (no new runtime deps) plus a modest visual refresh and an indigo brand. Also fixes a latent Svelte 5 boot bug found while running the app.

## What & why

Before this PR the UI had **no theme** — hardcoded hex (`#0066cc` repeated 6+ times, `#f8f9fa`, `#ddd`, `#666`, ...), no spacing/type scale, no single source of truth. Changing the brand color meant hunting across every component.

Now there is one contract (`tokens.css`) that every component consumes. Swapping the palette, spacing, or enabling dark mode is a one-place change.

**Architecture:** tokens live at the *design* layer; a future headless component lib (bits-ui / melt-ui) would consume these same tokens at the *behavior* layer. Tokens first, lib later — order on purpose.

## Changes

| File | Change |
|------|--------|
| `src/styles/tokens.css` | New — 3-layer tokens (primitives → semantic → `[data-theme="dark"]`), spacing/type/radius/shadow scales, indigo brand |
| `src/styles/base.css` | New — global reset + element defaults, consumes tokens |
| `src/main.ts` | Import global styles; **fix**: `mount(App, …)` instead of Svelte 4 `new App(…)` |
| `src/App.svelte` | Header tokenized + elevation; removed `:global` base styles (moved to `base.css`) |
| `src/components/{TabBar,LoginForm}.svelte` | Migrated to tokens; hover/transition states |
| `src/views/{Plugins,Running,Definitions}View.svelte` | Migrated to tokens; rounded/elevated tables, hover tints |

## The boot bug (separate `fix` commit)

The Svelte 5 runes migration left `main.ts` on `new App()`, invalid at Svelte 5 runtime (`component_api_invalid_new`). It slipped through because **none of the green gates boot the app**: `svelte-check` is static, `vitest` mounts components in isolation, `vite build` compiles without executing. It only surfaced on `npm run dev` in a browser. Worth a follow-up smoke test that mounts the entrypoint.

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test` — 43/43 pass
- [x] `npm run build` — OK (CSS 9.48 kB / 2.17 kB gzip)
- [x] Ran `npm run dev` — app boots and renders; light + `data-theme="dark"` verified
