### PR TITLE
test(batch-ops-ui): app-boot smoke test (closes the #65 verification gap)

### DIFF
--- a/batch-ops-ui/src/app-boot.test.ts
+++ b/batch-ops-ui/src/app-boot.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/*
+ * App-boot smoke test.
+ *
+ * Imports the REAL entrypoint (main.ts) and asserts it mounts. This is the one
+ * test that exercises the entrypoint's top-level `mount(App, …)` call.
+ *
+ * Why it exists: the Svelte 5 `new App()` boot bug (component_api_invalid_new)
+ * passed svelte-check, vitest and vite build — none of which actually boot the
+ * app — and only surfaced when running the dev server in a browser. This guards
+ * that gap.
+ *
+ * The API layer is mocked so the boot is deterministic and never touches the
+ * network (the default 'plugins' view fetches on mount).
+ */
+
+const okEmpty = () => Promise.resolve({ kind: 'data', value: [] });
+
+vi.mock('./lib/api', () => ({
+  getPlugins: vi.fn(okEmpty),
+  getDefinitions: vi.fn(okEmpty),
+  getDefinition: vi.fn(() => Promise.resolve({ kind: 'not-found' })),
+  getRunningJobs: vi.fn(okEmpty),
+}));
+
+describe('app boot', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="app"></div>';
+  });
+
+  it('mounts the entrypoint without throwing and renders the shell', async () => {
+    // Dynamic import so #app exists before main.ts runs its top-level mount().
+    await import('./main');
+
+    const app = document.getElementById('app');
+    expect(app).not.toBeNull();
+    expect(app!.querySelector('header')).not.toBeNull();
+    expect(app!.textContent).toContain('Batch Ops UI');
+  });
+});


### PR DESCRIPTION
## Summary

Add a single **app-boot smoke test** that closes the verification gap exposed in #65: the Svelte 5 `new App()` bug shipped green because no gate actually boots the app.

## What & why

`svelte-check` is static, `vitest` mounts components in isolation (never importing `main.ts`), and `vite build` compiles without executing. So the entrypoint's `mount(App, …)` was never exercised — and `component_api_invalid_new` only surfaced on `npm run dev` in a browser.

This test imports the **real** `main.ts` and asserts the shell renders, so a regression in the entrypoint fails CI instead of a human.

## Changes

| File | Change |
|------|--------|
| `src/app-boot.test.ts` | New — boots `main.ts`, asserts `<header>` + "Batch Ops UI" render; API layer mocked for determinism |

## Verification

Proved the guard actually guards (red → green):

- Reverted `main.ts` to `new App()` → test **fails** with `component_api_invalid_new`
- Restored `mount()` → test **passes**

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings
- [x] `npm run test` — 44/44 pass (43 + this smoke test)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a smoke test to validate successful application initialization, ensuring the core UI shell renders with expected components and completes startup without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->