### PR TITLE
chore(local-dev): pin Java 21 + Node 22 via mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,15 @@
+# Toolchain versions this repo targets — `mise install` gives every contributor
+# (and CI) the same Java and Node, replacing per-machine sdkman/fnm/asdf juggling.
+#
+# Setup once:
+#   1. Install mise           → https://mise.jdx.dev/getting-started.html
+#   2. mise trust             # approve this config
+#   3. mise install           # download the pinned versions
+# After that, `java` and `node` auto-switch to these versions inside the repo.
+#
+# Java is pinned to 21 to match <java.version>21</java.version> in the poms
+# (Spring Boot 4). Node 22 LTS satisfies Vite 8 / Vitest 4 (need >= 20.19 / 22.12).
+
+[tools]
+java = "temurin-21"
+node = "22"

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -30,10 +30,13 @@ source of truth if you are not using Task.
 | JAVA_HOME | points to JDK 21 | `echo $JAVA_HOME` |
 | Podman | 4.0+ | `podman --version` |
 | podman-compose | 1.0+ | `podman-compose --version` |
-| Node.js | 20 LTS | `node -version` |
-| npm | bundled with Node 20 | `npm -version` |
+| Node.js | 22 LTS | `node -version` |
+| npm | bundled with Node 22 | `npm -version` |
 | Task (optional) | 3.x | `task --version` |
 
+> **Easiest path — [mise](https://mise.jdx.dev):** run `mise install` at the repo root to get the
+> pinned Java 21 + Node 22 automatically (see `.mise.toml`). No manual sdkman/fnm setup needed.
+>
 > **No Maven install needed** — every build uses the bundled wrapper `./fr-batch-service/mvnw`.
 > **No `mysql` client needed** — the seed script execs into the running DB container.
 > `python3` (built into macOS) covers the JSON parsing the scripts do; `jq` is used if present.


### PR DESCRIPTION
## Summary

Pin the repo toolchain with **[mise](https://mise.jdx.dev)** so `mise install` gives every contributor (and CI) the exact Java + Node the project targets — no more per-machine sdkman/fnm juggling. First spike of the local-dev tooling backlog.

## What & why

The poms target **Java 21** (`<java.version>21</java.version>`, Spring Boot 4), but a dev machine was silently running **JDK 22** — exactly the version drift mise eliminates. Node wasn't pinned at all, while Vite 8 / Vitest 4 (from the Svelte 5 migration) need Node ≥ 20.19 / 22.12.

A single `.mise.toml` declares both; inside the repo `java` and `node` auto-switch to the pinned versions.

## Changes

| File | Change |
|------|--------|
| `.mise.toml` | New — `java = "temurin-21"`, `node = "22"`, with setup notes |
| `RUNNING_LOCALLY.md` | Prerequisites: Node 20 → 22; add mise as the easiest setup path |

## Verification

Installed mise and resolved the config locally:

```
$ mise current
java temurin-21.0.11+10.0.LTS
node 22.23.0

$ java -version            # system
openjdk version "22.0.1"
$ mise exec -- java -version   # inside repo
openjdk version "21.0.11" LTS   ← drift fixed
```

## Notes

- Taskfile stays the front door; mise only manages versions. Future spikes (process-compose, hurl, mvnd) slot under Task too.
- The wrapper `./mvnw` still provides Maven — mise does not manage it.
- Shell auto-switch needs `mise activate` in the user's shell rc (a per-developer step, not committed).

## Test plan

- [x] `mise install` downloads Java 21 + Node 22 cleanly
- [x] `mise exec -- java -version` reports 21 over a system JDK 22
- [x] `mise exec -- node --version` reports v22.23.0
