### PR TITLE
chore(local-dev): one-command stack via process-compose

### DIFF
--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -22,6 +22,22 @@ task ui         # start the UI
 Run `task --list` to see every target. The rest of this guide explains each step in full and is the
 source of truth if you are not using Task.
 
+### One command for everything (process-compose)
+
+If you have [process-compose](https://github.com/F1bonacc1/process-compose) installed
+(`brew install f1bonacc1/tap/process-compose`), `task dev` runs the **whole stack** —
+MySQL, backend, seed, plugins and UI — in a single TUI, with start-order, health gating
+and per-process logs. No more juggling terminals.
+
+```bash
+task deps     # one-time prerequisite (Maven cache)
+task dev      # everything, orchestrated; quit with q / Ctrl-C
+```
+
+`mysql`, `backend` and `ui` stay running; `seed` and `plugins` run once in order after the
+backend is healthy. The config lives in `process-compose.yaml` and mirrors the individual
+tasks below.
+
 ## Prerequisites
 
 | Tool | Version | Check |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,11 @@ tasks:
     cmds:
       - ./mvnw -q -f ../batch-job-api/pom.xml clean install
 
+  dev:
+    desc: Run the WHOLE stack (MySQL + backend + seed + plugins + UI) in one TUI via process-compose
+    cmds:
+      - process-compose
+
   up:
     desc: Start MySQL via Podman (machine + compose). The DB auto-creates on backend boot.
     dir: fr-batch-service/_devenvironment

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,77 @@
+# Run the whole local stack in one TUI, with start-order, health gating and
+# per-process logs — the "task up + backend + seed + plugins + ui" sequence,
+# orchestrated instead of juggled across terminals.
+#
+# Prereq (one-time):  task deps     # installs batch-job-api into the Maven cache
+# Run:                process-compose      (or: task dev)
+# Quit:               q / Ctrl-C in the TUI — the shutdown hook stops MySQL.
+#
+# Long-running: mysql, backend, ui.   One-shots: seed, plugins.
+# Each process mirrors the matching Taskfile task; Task stays the front door.
+
+version: "0.5"
+
+processes:
+  mysql:
+    description: "MySQL 8 via Podman"
+    working_dir: "fr-batch-service/_devenvironment"
+    # machine start errors if already running (or on Linux) — ignore. `up` (not -d)
+    # so process-compose owns the lifecycle and streams logs into its own panel.
+    command: "podman machine start 2>/dev/null || true; podman-compose up"
+    readiness_probe:
+      exec:
+        # bash /dev/tcp needs no extra client; passes once 3306 accepts connections.
+        command: "bash -c 'echo > /dev/tcp/127.0.0.1/3306'"
+      initial_delay_seconds: 5
+      period_seconds: 3
+      timeout_seconds: 2
+      failure_threshold: 40
+    shutdown:
+      command: "podman-compose down"
+      timeout_seconds: 30
+
+  backend:
+    description: "fr-batch-service — Spring Boot (local profile)"
+    working_dir: "fr-batch-service"
+    command: "./mvnw spring-boot:run -Dspring-boot.run.profiles=local"
+    depends_on:
+      mysql:
+        condition: process_healthy
+    readiness_probe:
+      http_get:
+        host: "127.0.0.1"
+        port: 8080
+        # /jobs/plugins returns 200 whenever the API is serving (same probe the
+        # load-plugins script uses); avoids depending on actuator aggregate health.
+        path: "/api/batch-service/jobs/plugins"
+        scheme: http
+      initial_delay_seconds: 15
+      period_seconds: 5
+      timeout_seconds: 3
+      failure_threshold: 60
+
+  seed:
+    description: "Apply local seed data (one-shot)"
+    command: "bash scripts/seed-local-db.sh"
+    depends_on:
+      backend:
+        condition: process_healthy
+    availability:
+      restart: "no"
+
+  plugins:
+    description: "Build + upload + approve + enable + load all plugins (one-shot)"
+    command: "bash scripts/load-plugins.sh --build"
+    depends_on:
+      backend:
+        condition: process_healthy
+    availability:
+      restart: "no"
+
+  ui:
+    description: "batch-ops-ui — Vite dev server"
+    working_dir: "batch-ops-ui"
+    command: "npm install && npm run dev"
+    depends_on:
+      backend:
+        condition: process_healthy


### PR DESCRIPTION
## Summary

Add **[process-compose](https://github.com/F1bonacc1/process-compose)** so `task dev` runs the entire local stack — MySQL, backend, seed, plugins, UI — in one TUI with start-order, health gating and per-process logs. Second spike of the local-dev tooling backlog: the "task all" we deliberately skipped, done properly.

## What & why

Today the stack needs five tasks juggled across terminals (`up` → `backend` → `seed` → `plugins` → `ui`), with the human eyeballing when the backend is ready before seeding. process-compose encodes that orchestration: dependencies, readiness probes and ordering.

- **Long-running:** `mysql`, `backend`, `ui`
- **One-shots:** `seed`, `plugins` — gated on `backend` becoming healthy
- Backend readiness = HTTP 200 on `/api/batch-service/jobs/plugins` (the same probe `load-plugins.sh` uses, not actuator aggregate health)
- MySQL readiness = TCP on 3306; shutdown hook runs `podman-compose down`
- Each process mirrors its Taskfile task — **Task stays the front door**

## Changes

| File | Change |
|------|--------|
| `process-compose.yaml` | New — 5 processes with deps, readiness probes, shutdown hooks |
| `Taskfile.yml` | New `dev` task → `process-compose` |
| `RUNNING_LOCALLY.md` | Document `task dev` as the one-command path |

## Verification

```
$ process-compose up --dry-run
Validated 5 configured processes from 2 files.   (exit 0)
```

Config is schema-valid. A full boot (Podman MySQL first-init + `mvnw spring-boot:run` build) was **not** run in this change — it's the heavy end-to-end path; `task dev` exercises it on a dev machine. Each command/path/probe is lifted verbatim from the existing, working Taskfile tasks.

## Notes

- Requires `process-compose` (`brew install f1bonacc1/tap/process-compose`) — optional tool, like Task itself.
- `task deps` (Maven cache) remains a one-time prerequisite, intentionally not a process-compose step (avoids a `clean install` on every launch).

## Test plan

- [x] `process-compose up --dry-run` validates the config (5 processes, exit 0)
- [x] No stray/override process-compose files; single repo config
- [ ] Full `task dev` boot on a dev machine (manual, heavy path)
