### PR TITLE
fix(local-dev): process-compose API port clash with backend (lost from #68)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,7 +54,8 @@ tasks:
   dev:
     desc: Run the WHOLE stack (MySQL + backend + seed + plugins + UI) in one TUI via process-compose
     cmds:
-      - process-compose
+      # --port 8099: process-compose's own API defaults to 8080, which the backend owns.
+      - process-compose --port 8099
 
   up:
     desc: Start MySQL via Podman (machine + compose). The DB auto-creates on backend boot.

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -3,8 +3,11 @@
 # orchestrated instead of juggled across terminals.
 #
 # Prereq (one-time):  task deps     # installs batch-job-api into the Maven cache
-# Run:                process-compose      (or: task dev)
+# Run:                task dev      (or: process-compose --port 8099)
 # Quit:               q / Ctrl-C in the TUI — the shutdown hook stops MySQL.
+#
+# NOTE: process-compose's own REST API defaults to port 8080, which the backend
+# owns — always start it on another port (--port 8099). `task dev` does this.
 #
 # Long-running: mysql, backend, ui.   One-shots: seed, plugins.
 # Each process mirrors the matching Taskfile task; Task stays the front door.


### PR DESCRIPTION
## Summary

Re-apply the process-compose port fix that did **not** make it into #68 before it merged. Without it, `task dev` is broken on `main`: process-compose's REST API and the backend both bind 8080.

## What & why

process-compose's own API server defaults to port **8080** — the same port the backend binds. process-compose grabs it first at launch, so the backend can never start under `task dev`. This was found by booting the stack end-to-end during #68, fixed in a follow-up commit, but that commit landed on the branch after #68 was already merged, so `main` shipped without it.

## Changes

| File | Change |
|------|--------|
| `Taskfile.yml` | `dev` task runs `process-compose --port 8099` |
| `process-compose.yaml` | Header note: API port must avoid the backend's 8080 |

## Verification

Already verified during #68's end-to-end boot: with `--port 8099`, mysql → backend (HTTP 200) → plugins (loaded) → ui (Vite 200) all came up and the shutdown hook stopped MySQL. The default 8080 reproduces the clash.

## Test plan

- [x] `process-compose up --dry-run` validates (5 processes, exit 0)
- [x] End-to-end boot on `--port 8099` succeeds (verified in #68)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development configuration to use port 8099 for the TUI startup to prevent conflicts with the backend service running on port 8080.
  * Updated development setup documentation with the preferred local startup workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->