### PR TITLE
fix(local-dev): idempotent dev seeds (no-op on re-seed)

### DIFF
--- a/fr-batch-service/_devenvironment/db/10_seed_event_tickets.sql
+++ b/fr-batch-service/_devenvironment/db/10_seed_event_tickets.sql
@@ -2,22 +2,27 @@
 -- Dev seed: event_tickets demo rows
 -- For local development only — integration tests seed their own data via JDBC
 -- Run AFTER V5__ticket_pdf_tables.sql has been applied
+--
+-- Idempotent: the WHERE NOT EXISTS guard makes a re-run a no-op once the table
+-- has data, so `task dev` / repeated seeding never hits duplicate-key errors.
 -- =========================================================
 
 INSERT INTO event_tickets (event_id, ticket_code, holder_name, event_name, event_location, seat, event_datetime, processed)
-VALUES
+SELECT * FROM (VALUES
     -- Event 1: Tech Conference 2024
-    (1, 'TC2024-001', 'Alice Johnson',    'Tech Conference 2024', 'Convention Center Hall A', 'A-01', '2024-09-15 09:00:00', FALSE),
-    (1, 'TC2024-002', 'Bob Martinez',     'Tech Conference 2024', 'Convention Center Hall A', 'A-02', '2024-09-15 09:00:00', FALSE),
-    (1, 'TC2024-003', 'Carol White',      'Tech Conference 2024', 'Convention Center Hall A', 'B-01', '2024-09-15 09:00:00', FALSE),
-    (1, 'TC2024-004', 'David Brown',      'Tech Conference 2024', 'Convention Center Hall A', 'B-02', '2024-09-15 09:00:00', FALSE),
+    ROW(1, 'TC2024-001', 'Alice Johnson',    'Tech Conference 2024', 'Convention Center Hall A', 'A-01', '2024-09-15 09:00:00', FALSE),
+    ROW(1, 'TC2024-002', 'Bob Martinez',     'Tech Conference 2024', 'Convention Center Hall A', 'A-02', '2024-09-15 09:00:00', FALSE),
+    ROW(1, 'TC2024-003', 'Carol White',      'Tech Conference 2024', 'Convention Center Hall A', 'B-01', '2024-09-15 09:00:00', FALSE),
+    ROW(1, 'TC2024-004', 'David Brown',      'Tech Conference 2024', 'Convention Center Hall A', 'B-02', '2024-09-15 09:00:00', FALSE),
 
     -- Event 2: Spring Music Fest
-    (2, 'SMF2024-001', 'Emma Davis',      'Spring Music Fest',    'Open Air Stadium',        'GA-100', '2024-05-20 18:00:00', FALSE),
-    (2, 'SMF2024-002', 'Frank Garcia',    'Spring Music Fest',    'Open Air Stadium',        'GA-101', '2024-05-20 18:00:00', FALSE),
-    (2, 'SMF2024-003', 'Grace Lee',       'Spring Music Fest',    'Open Air Stadium',        'VIP-01', '2024-05-20 18:00:00', FALSE),
-    (2, 'SMF2024-004', 'Henry Wilson',    'Spring Music Fest',    'Open Air Stadium',        'VIP-02', '2024-05-20 18:00:00', FALSE),
+    ROW(2, 'SMF2024-001', 'Emma Davis',      'Spring Music Fest',    'Open Air Stadium',        'GA-100', '2024-05-20 18:00:00', FALSE),
+    ROW(2, 'SMF2024-002', 'Frank Garcia',    'Spring Music Fest',    'Open Air Stadium',        'GA-101', '2024-05-20 18:00:00', FALSE),
+    ROW(2, 'SMF2024-003', 'Grace Lee',       'Spring Music Fest',    'Open Air Stadium',        'VIP-01', '2024-05-20 18:00:00', FALSE),
+    ROW(2, 'SMF2024-004', 'Henry Wilson',    'Spring Music Fest',    'Open Air Stadium',        'VIP-02', '2024-05-20 18:00:00', FALSE),
 
     -- Event 3: Annual Gala Dinner (no seat, no location)
-    (3, 'AGD2024-001', 'Irene Thompson',  'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE),
-    (3, 'AGD2024-002', 'Jack Robinson',   'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE);
+    ROW(3, 'AGD2024-001', 'Irene Thompson',  'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE),
+    ROW(3, 'AGD2024-002', 'Jack Robinson',   'Annual Gala Dinner',   NULL,                      NULL,     '2024-12-01 20:00:00', FALSE)
+) AS seed
+WHERE NOT EXISTS (SELECT 1 FROM event_tickets);

--- a/fr-batch-service/_devenvironment/db/20_seed_harvest_source.sql
+++ b/fr-batch-service/_devenvironment/db/20_seed_harvest_source.sql
@@ -8,32 +8,37 @@
 --   -  2 poison rows  (poison_flag=TRUE  → PoisonItemException → dead-letter SKIP)
 --   -  3 transient rows (transient_fail_until_attempt=1,2,3 → simulates retry threshold)
 --   -  1 abort row    (abort_flag=TRUE → AbortJobException → step FAILS; clear before restart demo)
+--
+-- Idempotent: harvest_source has no natural unique key, so the WHERE NOT EXISTS
+-- guard (not INSERT IGNORE) is what keeps a re-run from duplicating these rows.
 -- =========================================================
 
 INSERT INTO harvest_source (payload, poison_flag, transient_fail_until_attempt, abort_flag, processed)
-VALUES
+SELECT * FROM (VALUES
     -- Normal rows (processed in a single happy-path run)
-    ('{"type":"order","id":"ORD-001","amount":120.00}', FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-002","amount":75.50}',  FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-003","amount":200.00}', FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-004","amount":34.99}',  FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-005","amount":89.00}',  FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-006","amount":15.00}',  FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-007","amount":450.00}', FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-008","amount":300.00}', FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-009","amount":22.75}',  FALSE, 0, FALSE, FALSE),
-    ('{"type":"order","id":"ORD-010","amount":67.30}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-001","amount":120.00}', FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-002","amount":75.50}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-003","amount":200.00}', FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-004","amount":34.99}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-005","amount":89.00}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-006","amount":15.00}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-007","amount":450.00}', FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-008","amount":300.00}', FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-009","amount":22.75}',  FALSE, 0, FALSE, FALSE),
+    ROW('{"type":"order","id":"ORD-010","amount":67.30}',  FALSE, 0, FALSE, FALSE),
 
     -- Poison rows (poison_flag=TRUE → skipped and dead-lettered with failure_type='SKIP')
-    ('{"type":"poison","id":"PSN-001","reason":"malformed"}', TRUE,  0, FALSE, FALSE),
-    ('{"type":"poison","id":"PSN-002","reason":"corrupt"}',   TRUE,  0, FALSE, FALSE),
+    ROW('{"type":"poison","id":"PSN-001","reason":"malformed"}', TRUE,  0, FALSE, FALSE),
+    ROW('{"type":"poison","id":"PSN-002","reason":"corrupt"}',   TRUE,  0, FALSE, FALSE),
 
     -- Transient rows (simulate progressive retry thresholds; succeed after N retries)
-    ('{"type":"transient","id":"TRN-001","threshold":1}', FALSE, 1, FALSE, FALSE),
-    ('{"type":"transient","id":"TRN-002","threshold":2}', FALSE, 2, FALSE, FALSE),
-    ('{"type":"transient","id":"TRN-003","threshold":3}', FALSE, 3, FALSE, FALSE),
+    ROW('{"type":"transient","id":"TRN-001","threshold":1}', FALSE, 1, FALSE, FALSE),
+    ROW('{"type":"transient","id":"TRN-002","threshold":2}', FALSE, 2, FALSE, FALSE),
+    ROW('{"type":"transient","id":"TRN-003","threshold":3}', FALSE, 3, FALSE, FALSE),
 
     -- Abort row (abort_flag=TRUE → AbortJobException; triggers job FAILURE for restart demo)
     -- Clear this row's abort_flag before re-launching with identical params to demo restart.
-    ('{"type":"abort","id":"ABT-001","note":"clear abort_flag before restart demo"}',
-     FALSE, 0, TRUE, FALSE);
+    ROW('{"type":"abort","id":"ABT-001","note":"clear abort_flag before restart demo"}',
+     FALSE, 0, TRUE, FALSE)
+) AS seed
+WHERE NOT EXISTS (SELECT 1 FROM harvest_source);

--- a/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
+++ b/fr-batch-service/_devenvironment/db/30_seed_usage_record.sql
@@ -21,37 +21,44 @@
 -- Partition ranges deliberately do NOT align with the cost blocks above:
 -- partitioning is orthogonal to the data's grouping, and Sigma(cost) is
 -- unaffected by how rows are split across workers.
+--
+-- Idempotent: the WHERE NOT EXISTS guard ensures a re-run is a no-op, so the
+-- ids stay exactly 1-24 (re-seeding would otherwise append ids 25+ and break
+-- the demo's expected partition ranges and 1260 total).
 -- =========================================================
 
-INSERT INTO usage_record (subscriber_id, units, rate) VALUES
+INSERT INTO usage_record (subscriber_id, units, rate)
+SELECT * FROM (VALUES
     -- Cost block (ids 1-6): subscriber 100, units=10, rate=5 -> cost=50 each
-    (100, 10, 5),
-    (100, 10, 5),
-    (100, 10, 5),
-    (100, 10, 5),
-    (100, 10, 5),
-    (100, 10, 5),
+    ROW(100, 10, 5),
+    ROW(100, 10, 5),
+    ROW(100, 10, 5),
+    ROW(100, 10, 5),
+    ROW(100, 10, 5),
+    ROW(100, 10, 5),
 
     -- Cost block (ids 7-12): subscriber 101, units=20, rate=3 -> cost=60 each
-    (101, 20, 3),
-    (101, 20, 3),
-    (101, 20, 3),
-    (101, 20, 3),
-    (101, 20, 3),
-    (101, 20, 3),
+    ROW(101, 20, 3),
+    ROW(101, 20, 3),
+    ROW(101, 20, 3),
+    ROW(101, 20, 3),
+    ROW(101, 20, 3),
+    ROW(101, 20, 3),
 
     -- Cost block (ids 13-18): subscriber 102, units=5, rate=8 -> cost=40 each
-    (102, 5, 8),
-    (102, 5, 8),
-    (102, 5, 8),
-    (102, 5, 8),
-    (102, 5, 8),
-    (102, 5, 8),
+    ROW(102, 5, 8),
+    ROW(102, 5, 8),
+    ROW(102, 5, 8),
+    ROW(102, 5, 8),
+    ROW(102, 5, 8),
+    ROW(102, 5, 8),
 
     -- Cost block (ids 19-24): subscriber 103, units=15, rate=4 -> cost=60 each
-    (103, 15, 4),
-    (103, 15, 4),
-    (103, 15, 4),
-    (103, 15, 4),
-    (103, 15, 4),
-    (103, 15, 4);
+    ROW(103, 15, 4),
+    ROW(103, 15, 4),
+    ROW(103, 15, 4),
+    ROW(103, 15, 4),
+    ROW(103, 15, 4),
+    ROW(103, 15, 4)
+) AS seed
+WHERE NOT EXISTS (SELECT 1 FROM usage_record);


### PR DESCRIPTION
## Summary

Make the three dev seed files idempotent so re-seeding is a clean no-op. Closes the loose end from the process-compose work (#68): `task dev` runs `seed` on every launch against the persistent MySQL volume, so a non-idempotent seed showed a red failed process on every run after the first.

## What & why

- `event_tickets` — re-run failed with `Duplicate entry 'TC2024-001'` (unique key).
- `harvest_source` — no unique key, so a re-run would silently **duplicate** rows.
- `usage_record` — no unique key, and the partitioned-harvester demo expects exactly ids 1-24 (total 1260); re-seeding would append ids 25+ and break it.

Each `INSERT ... VALUES` becomes `INSERT ... SELECT * FROM (VALUES ROW(...)) AS seed WHERE NOT EXISTS (SELECT 1 FROM <table>)` — the whole insert is skipped once the table has any data. This matches the convention the seed script header already documents.

## Changes

| File | Change |
|------|--------|
| `…/db/10_seed_event_tickets.sql` | NOT EXISTS guard |
| `…/db/20_seed_harvest_source.sql` | NOT EXISTS guard |
| `…/db/30_seed_usage_record.sql` | NOT EXISTS guard (preserves ids 1-24) |

## Verification

Ran the seed script twice against the already-seeded local DB (MySQL 8.2 via Podman):

```
[OK] 10_seed_event_tickets.sql applied successfully.
[OK] 20_seed_harvest_source.sql applied successfully.
[OK] 30_seed_usage_record.sql applied successfully.
>>> seed exit code: 0          # was exit 1 before

row counts after re-seed:  event_tickets=10  harvest_source=16  usage_record=24  max(id)=24   # not doubled
guard mechanics:  returns 3 rows when table empty · 0 rows when data present
```

## Test plan

- [x] Re-seeding an already-seeded DB exits 0, no duplicates, ids stable
- [x] `VALUES ROW(...)` + `WHERE NOT EXISTS` validated both directions on MySQL 8.2
