### PR TITLE
chore: ignore generated graphify-out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 .DS_Store
 
 .atl/
+
+### graphify (generated knowledge graph — derived artifact, regenerate with /graphify) ###
+graphify-out/


### PR DESCRIPTION
## What

Add `graphify-out/` to `.gitignore`.

## Why

`graphify-out/` is a **derived artifact** generated by `/graphify` (a navigable knowledge graph of the repo). It should not be tracked:

- **Silent drift** — it's a snapshot of the code at build time; once any source changes, the graph/report mislead without git warning.
- **Leaks machine-local absolute paths** — `.graphify_python` and `.graphify_root` embed `$HOME` paths, per-machine and not portable.
- **Repo bloat** — ~11 MB (3.2 MB `graph.json` + 2.7 MB `graph.html`); every rebuild is a large binary diff kept in history forever.
- **Reproducible** — anyone can regenerate it with `/graphify`.

Same rationale as ignoring `target/`, `build/`, and `node_modules/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude generated output directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->