### PR TITLE
ci: add hurl plugin-lifecycle contract test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -56,6 +56,115 @@ jobs:
       - name: Build and test partitioned-harvester-job plugin
         run: mvn -B package -f partitioned-harvester-job/pom.xml
 
+  # Boots the real backend against MySQL and drives the plugin lifecycle
+  # (upload -> approve -> enable -> load) through scripts/load-plugins.hurl.
+  # Runs the suite twice: pass 1 proves the contract on a fresh database,
+  # pass 2 proves the flow is idempotent (re-runs return 409s and still pass).
+  contract-test:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    services:
+      mysql:
+        image: mysql:8.2.0
+        env:
+          # Mirrors the local dev profile: root with an empty password. The app
+          # creates fr_batch_local itself via createDatabaseIfNotExist=true.
+          MYSQL_ALLOW_EMPTY_PASSWORD: "1"
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 --silent"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=20
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: maven
+      - name: Configure GitHub Packages authentication
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << EOF
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${GITHUB_ACTOR}</username>
+                <password>${GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install hurl
+        env:
+          HURL_VERSION: 8.0.1
+        run: |
+          curl --location --silent --fail \
+            "https://github.com/Orange-OpenSource/hurl/releases/download/${HURL_VERSION}/hurl_${HURL_VERSION}_amd64.deb" \
+            -o /tmp/hurl.deb
+          sudo apt-get update
+          sudo apt-get install -y /tmp/hurl.deb
+          hurl --version
+      - name: Build backend and ticket-pdf-job plugin
+        run: |
+          mvn -B -q -DskipTests package -f fr-batch-service/pom.xml
+          mvn -B -q -DskipTests package -f ticket-pdf-job/pom.xml
+      - name: Start backend (local profile)
+        run: |
+          # Glob the repackaged executable JAR — *.jar excludes the thin
+          # *.jar.original, and stays correct across version bumps.
+          jar=$(echo fr-batch-service/target/*.jar)
+          echo "Booting $jar"
+          java -jar "$jar" --spring.profiles.active=local > /tmp/backend.log 2>&1 &
+          echo $! > /tmp/backend.pid
+      - name: Wait for backend to be healthy
+        run: |
+          for _ in $(seq 1 40); do
+            # Fail fast if the app died during startup instead of waiting out the loop.
+            if ! kill -0 "$(cat /tmp/backend.pid)" 2>/dev/null; then
+              echo "::error::Backend process died during startup"
+              tail -n 100 /tmp/backend.log
+              exit 1
+            fi
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              http://localhost:8080/api/batch-service/jobs/plugins || true)
+            if [ "$code" = "200" ]; then echo "Backend is up."; exit 0; fi
+            sleep 3
+          done
+          echo "::error::Backend did not become healthy in time"
+          tail -n 100 /tmp/backend.log
+          exit 1
+      - name: Run plugin lifecycle contract test (idempotent — runs twice)
+        run: |
+          run_hurl() {
+            hurl --test --file-root . \
+              --variable base=http://localhost:8080/api/batch-service \
+              --variable user=admin --variable pass=admin123 \
+              --variable jobName=ticket-pdf-job \
+              --variable version=1.0.0 \
+              --variable mainClass=com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin \
+              --variable jar=ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar \
+              scripts/load-plugins.hurl
+          }
+          echo "── Pass 1: fresh load ──"
+          run_hurl
+          echo "── Pass 2: idempotency (re-run must still pass) ──"
+          run_hurl
+      - name: Dump backend log on failure
+        if: failure()
+        run: tail -n 200 /tmp/backend.log || true
+
   frontend:
     runs-on: ubuntu-latest
     permissions:

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -304,6 +304,34 @@ curl -s -u admin:admin123 -X PUT "$BASE/jobs/definitions/$ID/enable"
 curl -s -u admin:admin123 -X POST "$BASE/jobs/definitions/$ID/load"
 ```
 
+### Declarative reference (hurl)
+
+The same four steps as a declarative HTTP file — [`scripts/load-plugins.hurl`](scripts/load-plugins.hurl).
+It replaces the `curl` + JSON-parsing chain above with five readable requests and native
+assertions; the definition `id` is captured from the definitions list by `job_name`, so there is
+nothing to parse by hand.
+
+```bash
+# one-time: install hurl (https://hurl.dev) — e.g. brew install hurl
+hurl --test --file-root . \
+  --variable base=http://localhost:8080/api/batch-service \
+  --variable user=admin --variable pass=admin123 \
+  --variable jobName=ticket-pdf-job \
+  --variable version=1.0.0 \
+  --variable mainClass=com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin \
+  --variable jar=ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar \
+  scripts/load-plugins.hurl
+```
+
+> `--file-root .` is required: hurl sandboxes file reads to the `.hurl` file's directory, and the
+> JAR lives outside `scripts/`. Swap the `--variable` values (see the coordinates table below) to
+> load a different plugin.
+
+The flow is idempotent — re-running returns `409`s and still passes. CI runs this file twice
+(fresh load + idempotency) for `ticket-pdf-job` as a contract test on every PR; see the
+`contract-test` job in `.github/workflows/maven.yml`. The coordinates table below covers all four
+plugins for manual runs.
+
 ### Plugin coordinates reference
 
 | jobName | JAR path | mainClassName |

--- a/scripts/load-plugins.hurl
+++ b/scripts/load-plugins.hurl
@@ -1,0 +1,71 @@
+# load-plugins.hurl — declarative replacement for the curl/jq/python3 HTTP chain
+# in scripts/load-plugins.sh. Drives ONE plugin through the full lifecycle:
+#   upload -> resolve id -> approve -> enable -> load
+#
+# This is a proof-of-concept for a single plugin. The thin wrapper that loops it
+# over all four plugins (and runs the optional Maven build) comes next, once this
+# flow is validated against a running backend.
+#
+# Run (from the repo root, backend up, JAR already built):
+#   hurl --variable base=http://localhost:8080/api/batch-service \
+#        --variable user=admin --variable pass=admin123 \
+#        --variable jobName=ticket-pdf-job \
+#        --variable version=1.0.0 \
+#        --variable mainClass=com.fronzec.plugins.ticketpdf.TicketPdfJobPlugin \
+#        --variable jar=ticket-pdf-job/target/ticket-pdf-job-1.0.0.jar \
+#        scripts/load-plugins.hurl
+#
+# Idempotent: re-running is a no-op. Upload accepts 201 (new) or 409 (exists);
+# approve and load accept their "already done" 409s. The definition id is ALWAYS
+# resolved from GET /definitions by job_name, so the flow never depends on parsing
+# the upload response — which carries no id on a 409.
+
+# ─── 1. Upload the JAR (multipart). 201 Created, or 409 if already uploaded. ───
+POST {{base}}/jobs/upload
+[BasicAuth]
+{{user}}: {{pass}}
+[MultipartFormData]
+file: file,{{jar}};
+jobName: {{jobName}}
+version: {{version}}
+mainClassName: {{mainClass}}
+HTTP *
+[Asserts]
+status toString matches "^(201|409)$"
+
+# ─── 2. Resolve the definition id by job_name — the single source of truth. ───
+# The API serializes snake_case (Jackson SNAKE_CASE), so the field is job_name.
+GET {{base}}/jobs/definitions
+[BasicAuth]
+{{user}}: {{pass}}
+HTTP 200
+[Captures]
+def_id: jsonpath "$[?(@.job_name=='{{jobName}}')].id"
+
+# ─── 3. Approve. 200 Approved, or 409 if already approved. ───
+# /load rejects PENDING definitions, so approval is required first. The body
+# field is approvedBy (camelCase in; the request record binds it directly).
+PUT {{base}}/jobs/definitions/{{def_id}}/approve
+Content-Type: application/json
+[BasicAuth]
+{{user}}: {{pass}}
+{
+  "approvedBy": "{{user}}"
+}
+HTTP *
+[Asserts]
+status toString matches "^(200|409)$"
+
+# ─── 4. Enable the definition (flips enabled = true; idempotent). ───
+PUT {{base}}/jobs/definitions/{{def_id}}/enable
+[BasicAuth]
+{{user}}: {{pass}}
+HTTP 200
+
+# ─── 5. Load the plugin into the registry. 200 Loaded, or 409 if already loaded. ───
+POST {{base}}/jobs/definitions/{{def_id}}/load
+[BasicAuth]
+{{user}}: {{pass}}
+HTTP *
+[Asserts]
+status toString matches "^(200|409)$"


### PR DESCRIPTION
## What

Adds an executable **HTTP contract test** for the plugin lifecycle, using [hurl](https://hurl.dev):

- **`scripts/load-plugins.hurl`** (new) — declarative version of the upload → resolve id → approve → enable → load flow, idempotent. Captures the definition `id` by `job_name` (no `jq`/`python3` parsing), accepts the "already done" `409`s.
- **`.github/workflows/maven.yml`** — new `contract-test` job: spins MySQL, boots the backend (`local` profile), waits for health, and runs the `.hurl` **twice** (fresh load + idempotency).
- **`RUNNING_LOCALLY.md`** — documents the declarative path alongside the existing `curl` reference.

## Why

`load-plugins.sh` is **left intact** — it works and is battle-tested. hurl is added where it does something the bash cannot: **contract verification in CI**. A `.hurl` that runs in CI can't bitrot, and it gives the plugin HTTP contract an executable spec.

## Validation

- The `.hurl` + the exact CI command were run twice against a real local backend — both passes green (fresh `201/200`s, then `409`s on re-run). Plugin confirmed registered in `/jobs/plugins`.
- YAML validated. The CI-only plumbing (MySQL service, hurl install, `java -jar` boot, health wait) is validated by **this PR's own `contract-test` run**.

## Review notes (fresh-context review applied)

- Boot step globs `target/*.jar` instead of a hardcoded version (excludes `*.jar.original`, survives version bumps).
- Health-wait fails fast via `kill -0` if the app dies, instead of waiting out the full timeout.
- Idempotency is asserted with `status toString matches "^(201|409)$"` — the id is captured without `nth` (a single filter match returns a scalar in hurl 8.x; `nth 0` errors).

## Scope

CI tests `ticket-pdf-job` (one plugin). Generalizing to all four via a thin wrapper is deliberately deferred.