### PR TITLE
chore: extend task doctor to cover full local-dev toolchain

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
       - task --list
 
   doctor:
-    desc: Check required tools and print install hints (nothing is installed for you)
+    desc: Check required + optional tools and print install hints (nothing is installed for you)
     cmds:
       - |
         check() {
@@ -34,12 +34,29 @@ tasks:
             printf '  MISS  %-16s -> %s\n' "$1" "$2"
           fi
         }
+        # ok if ANY of the candidate binaries is present (e.g. jq OR python3)
+        check_any() {
+          label="$1"; shift
+          for bin in "$@"; do
+            if command -v "$bin" >/dev/null 2>&1; then
+              printf '  ok    %-16s %s\n' "$label" "$(command -v "$bin")"
+              return
+            fi
+          done
+          printf '  MISS  %-16s -> install one of: %s\n' "$label" "$*"
+        }
         echo "Required tools for local development:"
-        check java            "install JDK 21 (e.g. brew install temurin@21)"
-        check node            "install Node 20 LTS (e.g. brew install node@20)"
+        check java            "install JDK 21 (e.g. brew install temurin@21) — or use mise"
+        check node            "install Node 22 LTS (e.g. brew install node@22) — or use mise"
         check npm             "ships with Node"
         check podman          "brew install podman   (then: podman machine init)"
         check podman-compose  "brew install podman-compose"
+        check_any "jq/python3" jq python3   # load-plugins.sh parses the upload JSON with either
+        echo
+        echo "Optional tools (enhanced workflows):"
+        check mise            "pins Java 21 + Node 22 per .mise.toml — https://mise.jdx.dev"
+        check process-compose "one-command full stack via 'task dev' — brew install f1bonacc1/tap/process-compose"
+        check hurl            "declarative plugin loading + CI contract test — brew install hurl"
         echo
         echo "Maven is NOT required — tasks use ./fr-batch-service/mvnw"
         echo "A mysql client is NOT required — scripts exec into the DB container"


### PR DESCRIPTION
## What

Extends the existing `task doctor` so it diagnoses the **whole** local-dev toolchain, not just the original five tools.

- Adds checks for tools introduced this cycle: **mise**, **process-compose**, **hurl**.
- Adds a **jq OR python3** either-or check (`load-plugins.sh` needs one to parse the upload JSON).
- Splits output into **Required** vs **Optional (enhanced workflows)**.
- Fixes a stale hint: Node **20 → 22**, matching `.mise.toml` and `RUNNING_LOCALLY.md`.

## Why

After adding mise, process-compose, and the hurl contract test, `task doctor` no longer reflected reality — it still checked only java/node/npm/podman/podman-compose and pointed at the wrong Node version. A doctor that under-reports is worse than none: it tells you you're ready when you're not.

## Verification

Ran `task doctor` locally — all checks render correctly (required + optional), and `check_any` resolves `jq`/`python3`. No new dependency: it only probes `command -v`, installs nothing.