### PR TITLE
ci: bump frontend job to Node 22

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -172,10 +172,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Node.js 20 LTS
+      - name: Set up Node.js 22 LTS
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: batch-ops-ui/package-lock.json
       - name: Install dependencies


### PR DESCRIPTION
## What

Bumps the `frontend` CI job from Node 20 to Node 22.

## Why

The repo's dev toolchain already targets Node 22 everywhere except this CI job:

- `.mise.toml` pins `node = "22"`
- `task doctor` (`Taskfile.yml`) recommends Node 22 LTS

The drift means the UI is validated in CI on a different Node than contributors run locally — exactly the gap version pinning is meant to close. The `.mise.toml` comment also notes Vitest 4 needs Node >= 22.12, so the test runner wants 22+.

This PR's own CI run validates the UI stays green on Node 22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to use Node.js 22 LTS for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->