### PR TITLE
ci: build example-payment-job to keep the plugin tutorial compiling

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,6 +55,11 @@ jobs:
         run: mvn -B package -f fault-tolerant-harvester-job/pom.xml
       - name: Build and test partitioned-harvester-job plugin
         run: mvn -B package -f partitioned-harvester-job/pom.xml
+      # Reference template for the plugin tutorial (example-payment-job/README.md).
+      # Build-only — it is intentionally NOT loaded by the platform; this step just
+      # keeps the documented example compiling against batch-job-api.
+      - name: Build example-payment-job (reference template)
+        run: mvn -B package -f example-payment-job/pom.xml
 
   # Boots the real backend against MySQL and drives the plugin lifecycle
   # (upload -> approve -> enable -> load) through scripts/load-plugins.hurl.


### PR DESCRIPTION
## What

Adds a build step for `example-payment-job` to the `build` CI job, alongside the four production plugins.

## Why

`example-payment-job` is the **reference template** for the plugin-authoring tutorial (`example-payment-job/README.md`) — a complete, standalone walkthrough of building and uploading a `BatchJobPlugin`. It lives in `com.example.payment` and is intentionally **not** a production plugin (not in `load-plugins.sh`, not loaded by the platform).

Until now CI never built it. That means a breaking change in `batch-job-api` could silently rot the example: the tutorial would compile-fail for anyone following it, and no gate would catch it. Documentation-as-code needs to be compiled like code.

## What this is NOT

This does **not** add the example to `load-plugins.sh` or the platform load flow — that would defeat its purpose as a clean standalone reference. It is build-only.

This PR's own CI run proves the template still compiles against the current `batch-job-api`.