### PR TITLE
chore: remove orphaned _devenvironment/Dockerfile

### DIFF
--- a/fr-batch-service/_devenvironment/Dockerfile
+++ b/fr-batch-service/_devenvironment/Dockerfile
@@ -1,5 +1,0 @@
-FROM maven:3.9.12-eclipse-temurin-21
-WORKDIR /tmp
-COPY . .
-RUN mvn clean verify
-CMD mvn spring-boot:run


### PR DESCRIPTION
## What

Removes `fr-batch-service/_devenvironment/Dockerfile`, an unreferenced (dead) file.

## Why

- `_devenvironment/docker-compose.yml` only defines the `mysql` service and has no `build:` key — it never builds this Dockerfile.
- Nothing else in the repo references it (`task up`/`down` run podman-compose against that compose file, which doesn't touch it).
- As written it could not build anyway: `COPY . . && RUN mvn clean verify` runs against the `_devenvironment` directory, which contains only the compose file and this Dockerfile — no `pom.xml`.

It also happened to be the **only** Maven base-image pin that diverged from the real build image: this file used `maven:3.9.12-eclipse-temurin-21` while `fr-batch-service/Dockerfile` uses `maven:3.9-eclipse-temurin-21`. Removing it leaves `fr-batch-service/Dockerfile` as the single source of truth for the build image.

## Risk

None — the file is unused. CI is unaffected (the real image build lives in `fr-batch-service/Dockerfile`, built by `docker` / `docker-dry-run`).