### PR TITLE
fix(plugins): harden JAR checksum and guard registry reads

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/PluginRegistryService.java
@@ -5,7 +5,6 @@ import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
 import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
 import jakarta.annotation.PostConstruct;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -136,14 +135,24 @@ public class PluginRegistryService {
                 pluginsByJobName.keySet());
     }
 
-    /** Returns all registered plugins in registration order. */
+    /**
+     * Returns an immutable snapshot of all registered plugins in registration order.
+     *
+     * <p>Takes the {@code pluginsByJobName} monitor and copies the values so the
+     * returned collection is safe to read while concurrent register/unregister calls
+     * mutate the map.
+     */
     public Collection<BatchJobPlugin> getPlugins() {
-        return Collections.unmodifiableCollection(pluginsByJobName.values());
+        synchronized (pluginsByJobName) {
+            return List.copyOf(pluginsByJobName.values());
+        }
     }
 
     /** Returns the plugin registered under the given job name, or empty if not found. */
     public Optional<BatchJobPlugin> getPlugin(String jobName) {
-        return Optional.ofNullable(pluginsByJobName.get(jobName));
+        synchronized (pluginsByJobName) {
+            return Optional.ofNullable(pluginsByJobName.get(jobName));
+        }
     }
 
     /**
@@ -284,8 +293,10 @@ public class PluginRegistryService {
      *         or {@code null} if not found in either source
      */
     public String getPluginBySource(String jobName) {
-        if (pluginsByJobName.containsKey(jobName)) {
-            return "CLASSPATH";
+        synchronized (pluginsByJobName) {
+            if (pluginsByJobName.containsKey(jobName)) {
+                return "CLASSPATH";
+            }
         }
         Optional<JobDefinitionEntity> def = jobDefinitionRepository.findByJobName(jobName);
         if (def.isPresent() && Boolean.TRUE.equals(def.get().getEnabled())) {

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -100,11 +100,13 @@ public class JarUploadService {
         validateJar(file);
         validateMainClassName(mainClassName);
 
-        String checksum = ChecksumUtil.computeSha256(file);
-
         checkDuplicate(jobName);
 
     Path storedPath = storeFile(file, jobName, version);
+
+    // Compute the checksum from the persisted file (not the multipart stream) so the
+    // stored digest matches the bytes that load-time integrity verification re-checks.
+    String checksum = ChecksumUtil.computeSha256(storedPath);
 
     // ── signature verification ───────────────────────────────────────────────
     SignatureResult sigResult = jarSignatureVerifier.verify(storedPath);

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadServiceTest.java
@@ -1,0 +1,131 @@
+/* 2024-2026 */
+package com.fronzec.frbatchservice.batchjobs.plugins.service;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fronzec.frbatchservice.batchjobs.plugins.audit.AuditService;
+import com.fronzec.frbatchservice.batchjobs.plugins.entity.JobDefinitionEntity;
+import com.fronzec.frbatchservice.batchjobs.plugins.metrics.PluginMetrics;
+import com.fronzec.frbatchservice.batchjobs.plugins.repository.JobDefinitionRepository;
+import com.fronzec.frbatchservice.batchjobs.plugins.util.ChecksumUtil;
+import com.fronzec.frbatchservice.config.AutoApproveConfig;
+import com.fronzec.frbatchservice.web.dto.JarUploadResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+/** Verifies the upload pipeline of {@link JarUploadService}. */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("JarUploadService")
+class JarUploadServiceTest {
+
+  @Mock private JobDefinitionRepository jobDefinitionRepository;
+  @Mock private JarSignatureVerifier jarSignatureVerifier;
+  @Mock private AuditService auditService;
+  @Mock private PluginMetrics pluginMetrics;
+
+  @TempDir private Path jarDir;
+
+  private JarUploadService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new JarUploadService(
+            jobDefinitionRepository,
+            Optional.<AutoApproveConfig>empty(),
+            jarSignatureVerifier,
+            auditService,
+            pluginMetrics,
+            "permissive",
+            jarDir.toString());
+  }
+
+  @Test
+  @DisplayName("computes the persisted checksum from the stored file, never from the multipart stream")
+  void uploadJar_checksumIsComputedFromStoredFile_notMultipartStream() throws IOException {
+    byte[] jarBytes = minimalJar();
+    MockMultipartFile file =
+        new MockMultipartFile(
+            "file", "test-job-1.0.0.jar", "application/java-archive", jarBytes);
+    Path storedPath = jarDir.resolve("test-job-1.0.0.jar");
+
+    when(jobDefinitionRepository.findByJobName("test-job")).thenReturn(Optional.empty());
+    when(jarSignatureVerifier.verify(any()))
+        .thenReturn(new SignatureResult(true, null, List.of()));
+    when(jobDefinitionRepository.save(any(JobDefinitionEntity.class)))
+        .thenAnswer(
+            invocation -> {
+              JobDefinitionEntity saved = invocation.getArgument(0);
+              saved.setId(1L);
+              return saved;
+            });
+
+    JarUploadResponse response;
+    try (MockedStatic<ChecksumUtil> checksum = mockStatic(ChecksumUtil.class)) {
+      // Stub only the Path overload: the digest the service stores must come from
+      // the persisted file. The multipart overload is left unstubbed so that a
+      // regression to hashing the stream would surface a null checksum AND trip
+      // the never() verification below.
+      checksum.when(() -> ChecksumUtil.computeSha256(storedPath)).thenReturn("disk-digest");
+
+      response = service.uploadJar(file, "test-job", "1.0.0", "com.example.MyPlugin");
+
+      // The checksum was read from the persisted file, not from the upload stream.
+      checksum.verify(() -> ChecksumUtil.computeSha256(storedPath));
+      checksum.verify(() -> ChecksumUtil.computeSha256(any(MultipartFile.class)), never());
+    }
+
+    ArgumentCaptor<JobDefinitionEntity> captor =
+        ArgumentCaptor.forClass(JobDefinitionEntity.class);
+    verify(jobDefinitionRepository).save(captor.capture());
+
+    assertTrue(Files.exists(storedPath), "JAR should be written to disk before hashing");
+    assertArrayEquals(
+        jarBytes, Files.readAllBytes(storedPath), "stored bytes should match the upload");
+    assertEquals(
+        "disk-digest",
+        captor.getValue().getJarChecksum(),
+        "persisted checksum must be the digest of the stored file");
+    assertEquals("disk-digest", response.jarChecksum(), "response must expose the same checksum");
+  }
+
+  /** Builds a minimal valid (unsigned) JAR with a manifest and one entry. */
+  private static byte[] minimalJar() throws IOException {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (JarOutputStream jar = new JarOutputStream(out, manifest)) {
+      jar.putNextEntry(new ZipEntry("com/example/MyPlugin.class"));
+      jar.write("stub".getBytes());
+      jar.closeEntry();
+    }
+    return out.toByteArray();
+  }
+}


### PR DESCRIPTION
## PR-A — Plugin engine hygiene (P3 + P5)

First slice of the plugin-engine backbone backlog (deep-dive audit, executable view "La vida de un JAR"). Two small, verified, self-contained fixes.

### P3 — checksum reflects the persisted artifact
`JarUploadService` computed the SHA-256 from the multipart stream **before** writing to disk. Now it computes it from the stored file (`ChecksumUtil.computeSha256(storedPath)`), so the persisted digest matches the exact bytes that load-time integrity verification re-checks. Defensive hardening — removes a latent stream-vs-disk divergence rather than fixing a live bug.

### P5 — guard concurrent registry reads
`getPlugins`, `getPlugin`, and `getPluginBySource` read `pluginsByJobName` without holding the monitor, racing with `registerDynamicPlugin` / `unregisterDynamicPlugin` (which already synchronize). They now take the `pluginsByJobName` monitor — matching the existing `getRegisteredJobNames` pattern. `getPlugins` returns an immutable snapshot; the DB lookup in `getPluginBySource` stays outside the lock.

### Tests
- New `JarUploadServiceTest` (the service had zero coverage) locks the P3 invariant: persisted checksum == digest of the bytes on disk, using a real in-memory JAR.
- Full affected suite green: **18 tests** (ChecksumUtil 7, PluginRegistryService 10, JarUploadService 1).

### Out of scope (deferred)
- **P4** (`classloaderRefs`) — the audit flagged it as a "dead map to remove", but it is write-only scaffolding for classloader cleanup that **P2/PR-C** implements. Removing it now would churn `registerDynamicPlugin`'s signature + its call sites and PR-C would re-add it properly typed. Folded into PR-C.

### Follow-ups
- PR-B = P1 (loadJob atomicity)
- PR-C = P2 + P4 (unload + classloader close, done right)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading to use safer, consistent access when reading registered plugins.
  * Fixed JAR upload handling so duplicate checks happen earlier and checksum values are based on the file actually saved.

* **Tests**
  * Added coverage for JAR uploads to verify files are stored correctly and checksums match the saved content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->