### PR TITLE
fix(plugins): serialize loadJob per definition id to prevent file-handle leak

### DIFF
--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.batch.core.repository.JobRepository;
@@ -50,6 +51,16 @@ public class DynamicJobLoaderService {
   /** Tracks active classloaders by definition ID for cleanup on unload. */
   private final Map<Long, DynamicJobClassLoader> classLoaders = new ConcurrentHashMap<>();
 
+  /**
+   * Per-definition load locks. Serializes concurrent {@link #loadJob(Long)} calls for the same
+   * definition ID so the already-loaded guard and the classloader/registry writes execute
+   * atomically. Without this, two concurrent loads of the same definition both pass the guard, each
+   * opens a JAR file-handle, and the loser's {@code classLoaders.put} silently overwrites the
+   * winner's entry — leaking the winner's handle. Definitions are admin-managed and bounded, so the
+   * map does not grow unbounded in practice.
+   */
+  private final Map<Long, ReentrantLock> loadLocks = new ConcurrentHashMap<>();
+
   public DynamicJobLoaderService(
       JobDefinitionRepository jobDefinitionRepository,
       PluginRegistryService pluginRegistryService,
@@ -79,6 +90,21 @@ public class DynamicJobLoaderService {
    *     failure, etc.)
    */
   public LoadResult loadJob(Long definitionId) {
+    ReentrantLock lock = loadLocks.computeIfAbsent(definitionId, k -> new ReentrantLock());
+    lock.lock();
+    try {
+      return doLoadJob(definitionId);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Performs the actual load. Always invoked while holding the per-definition lock acquired in
+   * {@link #loadJob(Long)}, so the already-loaded guard and the classloader/registry writes are
+   * atomic with respect to other loads of the same definition.
+   */
+  private LoadResult doLoadJob(Long definitionId) {
     JobDefinitionEntity entity =
         jobDefinitionRepository
             .findById(definitionId)

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderService.java
@@ -56,8 +56,8 @@ public class DynamicJobLoaderService {
    * definition ID so the already-loaded guard and the classloader/registry writes execute
    * atomically. Without this, two concurrent loads of the same definition both pass the guard, each
    * opens a JAR file-handle, and the loser's {@code classLoaders.put} silently overwrites the
-   * winner's entry — leaking the winner's handle. Definitions are admin-managed and bounded, so the
-   * map does not grow unbounded in practice.
+   * winner's entry — leaking the winner's handle. {@link #loadJob(Long)} allocates an entry only
+   * after confirming the definition exists, so unknown IDs cannot grow the map without bound.
    */
   private final Map<Long, ReentrantLock> loadLocks = new ConcurrentHashMap<>();
 
@@ -90,6 +90,12 @@ public class DynamicJobLoaderService {
    *     failure, etc.)
    */
   public LoadResult loadJob(Long definitionId) {
+    // Gate lock allocation on existence so unknown IDs (e.g. POST /definitions/{id}/load with a
+    // bogus id) cannot grow loadLocks without bound. The authoritative existence check still runs
+    // inside doLoadJob under the lock, guarding against a definition deleted between the two reads.
+    if (jobDefinitionRepository.findById(definitionId).isEmpty()) {
+      throw new NoSuchElementException("Job definition not found for id: " + definitionId);
+    }
     ReentrantLock lock = loadLocks.computeIfAbsent(definitionId, k -> new ReentrantLock());
     lock.lock();
     try {

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
@@ -19,6 +19,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
@@ -445,6 +447,95 @@ class DynamicJobLoaderServiceTest {
       assertTrue(
           results.get("bad-job").message().contains("JAR file not found"),
           "Expected 'JAR file not found' but got: " + results.get("bad-job").message());
+    }
+  }
+
+  // ── Concurrency ───────────────────────────────────────────────────────────
+
+  /**
+   * Two concurrent {@code loadJob} calls for the SAME definition id must be serialized: only one may
+   * proceed through the load body (opening a classloader / JAR file-handle and registering); the
+   * loser must observe the winner's registration and be rejected, never opening a second handle.
+   *
+   * <p>Uses a REAL {@link DynamicJobClassLoader} rather than {@code mockConstruction}, because
+   * Mockito's construction mocking is thread-confined and would not intercept the pool threads. The
+   * parent-last classloader resolves {@link TestBatchJobPlugin} from the application classloader, so
+   * the load succeeds on both threads. The winner is parked inside {@code registerDynamicPlugin}
+   * (holding the per-id lock under the fix); the registration only becomes visible once it returns,
+   * modelling the real race window. Without serialization the contender sails past the already-loaded
+   * guard and reaches {@code registerDynamicPlugin} a second time; serialized, it parks on the lock
+   * and is rejected by the guard. The bounded {@link CountDownLatch} awaits assert this
+   * deterministically, without timing-dependent sleeps.
+   */
+  @Test
+  void loadJob_concurrentSameId_serializesAndOpensSingleClassloader() throws Exception {
+    JobDefinitionEntity entity = createEntity(20L, "test-job", true, null);
+    // Real parent-last classloader resolves this class from the application classloader.
+    entity.setMainClassName(TestBatchJobPlugin.class.getName());
+    when(jobDefinitionRepository.findById(20L)).thenReturn(Optional.of(entity));
+
+    // Stateful registry: a registration only becomes visible once register() returns, modelling the
+    // real race window between the already-loaded guard and the registry write.
+    Set<String> registeredNames = ConcurrentHashMap.newKeySet();
+    AtomicInteger guardCalls = new AtomicInteger();
+    CountDownLatch secondGuardReached = new CountDownLatch(1);
+    when(pluginRegistryService.getRegisteredJobNames())
+        .thenAnswer(
+            inv -> {
+              if (guardCalls.incrementAndGet() == 2) {
+                secondGuardReached.countDown();
+              }
+              return new HashSet<>(registeredNames);
+            });
+
+    CountDownLatch registerEntered = new CountDownLatch(1);
+    CountDownLatch releaseRegister = new CountDownLatch(1);
+    doAnswer(
+            inv -> {
+              registerEntered.countDown();
+              releaseRegister.await();
+              BatchJobPlugin plugin = inv.getArgument(0);
+              registeredNames.add(plugin.getJobName());
+              return null;
+            })
+        .when(pluginRegistryService)
+        .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      // Winner: blocks inside registerDynamicPlugin while holding the per-id lock (under the fix).
+      Future<?> winner = pool.submit(() -> service.loadJob(20L));
+      assertTrue(
+          registerEntered.await(5, TimeUnit.SECONDS),
+          "Winning thread never reached registerDynamicPlugin");
+
+      // Contender: same id. Serialized, it parks on the lock and never reaches the guard again;
+      // unserialized, it passes the guard and reaches registerDynamicPlugin a second time.
+      Future<?> contender =
+          pool.submit(
+              () -> {
+                try {
+                  service.loadJob(20L);
+                } catch (IllegalStateException alreadyLoaded) {
+                  // Expected once serialized: the contender sees the winner's registration.
+                }
+              });
+
+      boolean contenderPassedGuard = secondGuardReached.await(1, TimeUnit.SECONDS);
+
+      releaseRegister.countDown();
+      winner.get(5, TimeUnit.SECONDS);
+      contender.get(5, TimeUnit.SECONDS);
+
+      assertFalse(
+          contenderPassedGuard,
+          "Second concurrent load entered the load body while the first held the lock — "
+              + "loadJob is not serialized per definition id");
+      // Serialized: only the winner registers; the contender is rejected by the guard.
+      verify(pluginRegistryService, times(1))
+          .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+    } finally {
+      pool.shutdownNow();
     }
   }
 

--- a/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
+++ b/fr-batch-service/src/test/java/com/fronzec/frbatchservice/batchjobs/plugins/loader/DynamicJobLoaderServiceTest.java
@@ -19,7 +19,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,6 +102,14 @@ class DynamicJobLoaderServiceTest {
     entity.setLoadStatus(loadStatus);
     entity.setApprovalStatus("APPROVED");
     return entity;
+  }
+
+  /** Reads the private per-definition {@code loadLocks} map via reflection for white-box assertions. */
+  @SuppressWarnings("unchecked")
+  private static Map<Long, ?> loadLocksOf(DynamicJobLoaderService target) throws Exception {
+    var field = DynamicJobLoaderService.class.getDeclaredField("loadLocks");
+    field.setAccessible(true);
+    return (Map<Long, ?>) field.get(target);
   }
 
   // ── Successful load ───────────────────────────────────────────────────────
@@ -267,6 +280,17 @@ class DynamicJobLoaderServiceTest {
     when(jobDefinitionRepository.findById(999L)).thenReturn(Optional.empty());
 
     assertThrows(NoSuchElementException.class, () -> service.loadJob(999L));
+  }
+
+  @Test
+  void loadJob_nonexistentId_doesNotRetainLock() throws Exception {
+    when(jobDefinitionRepository.findById(999L)).thenReturn(Optional.empty());
+
+    assertThrows(NoSuchElementException.class, () -> service.loadJob(999L));
+
+    assertTrue(
+        loadLocksOf(service).isEmpty(),
+        "loadJob must not retain a per-definition lock for a nonexistent id");
   }
 
   @Test
@@ -534,7 +558,12 @@ class DynamicJobLoaderServiceTest {
       // Serialized: only the winner registers; the contender is rejected by the guard.
       verify(pluginRegistryService, times(1))
           .registerDynamicPlugin(any(BatchJobPlugin.class), any());
+
+      // Release the real classloader/temp-JAR handle opened by the successful load.
+      service.unloadJob(20L, true);
     } finally {
+      // Unblock any thread still parked in registerDynamicPlugin so shutdown cannot hang.
+      releaseRegister.countDown();
       pool.shutdownNow();
     }
   }


### PR DESCRIPTION
## What

Makes `DynamicJobLoaderService.loadJob` atomic per definition id, closing a **file-handle leak** on concurrent loads (spine finding **P1**).

## Why

`loadJob` had a check-then-act race with no per-definition mutual exclusion:

1. It checks the already-loaded guard (`getRegisteredJobNames().contains(jobName)`).
2. It creates a `DynamicJobClassLoader` — a `URLClassLoader` that **opens the JAR file-handle**.
3. It stores the classloader via `classLoaders.put(definitionId, classLoader)`.

Two concurrent `POST /definitions/{id}/load` for the same id both pass step 1 (neither is registered yet), both open the JAR, and the losing thread's `put` **overwrites** the winner's map entry without closing it. The overwritten classloader is never `cleanup()`-ed → leaked file-handle (the `catch` only cleans up on exception, not on the overwrite race).

## How

- Introduce `ConcurrentHashMap<Long, ReentrantLock> loadLocks`.
- Extract the load body into a private `doLoadJob` and wrap it in a per-definition lock (`lock()` outside `try`, `unlock()` in `finally` — released on every path).
- The guard, classloader creation, registry write, and `classLoaders.put` now execute atomically for a given id. The loser observes the winner's registration and is rejected with `IllegalStateException` **before** opening a second handle.

Since `job_name` is `unique` per definition (DB constraint) and `id` is the PK, locking by id is equivalent to locking by job name — no two ids collide on a name.

## Testing

- New deterministic concurrency test `loadJob_concurrentSameId_serializesAndOpensSingleClassloader`: parks the winner inside `registerDynamicPlugin` (holding the lock) and asserts the contender cannot enter the load body and never triggers a second registration. Fails without the fix, passes with it. Uses a real `DynamicJobClassLoader` (Mockito construction mocking is thread-confined).
- `DynamicJobLoaderServiceTest`: 18/18 green. `DynamicJobLoadingIntegrationTest`: 13/13 green.

## Known limitation (out of scope — tracked for PR-C)

This closes the **load-vs-load** leak only. `unloadJob`/`reloadJob` do **not** yet acquire the lock, so a load racing an unload/reload of the same id can still leave an orphaned classloader. That is the **P2** slice (unload + transaction boundary) and lands in **PR-C**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading the same job definition concurrently.
  * Ensures per-definition serialization so only one load/register sequence runs at a time.
  * Prevents duplicate classloader/registration side effects for the same job definition.
* **Tests**
  * Added/expanded concurrency tests to confirm the job is registered once and competing requests are properly blocked.
  * Added a guardrail test for missing job definitions to ensure no lock state is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->