### PR TITLE
chore(repo): rename repository references

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,10 +18,6 @@ tasks:
       task dbbootstraping
       cd ..
 
-#- init: ./spring-batch-projects/mvnw -B dependency:go-offline package -DskipTests
-#  command: java -jar target/*.jar
-#  name: Run SingleThreaded app
-
 image:
   file: .gitpod.Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# spring-batch-projects
+# Spring Batch Plugin Lab
 
 A monorepo for experimenting with Spring Batch: a dynamic plugin host service, four batch job plugins, and a Svelte ops UI.
 

--- a/batch-job-api/README.md
+++ b/batch-job-api/README.md
@@ -18,7 +18,7 @@ mvn -f batch-job-api/pom.xml clean install
 
 ## Publishing
 
-This artifact is published to **GitHub Packages** at `https://maven.pkg.github.com/fronzec/spring-batch-projects`.
+This artifact is published to **GitHub Packages** at `https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab`.
 
 ### 1. GitHub Personal Access Token
 
@@ -55,7 +55,7 @@ Releases are immutable on GitHub Packages. Use `-SNAPSHOT` versions during devel
 <repositories>
   <repository>
     <id>github</id>
-    <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+    <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
   </repository>
 </repositories>
 

--- a/batch-job-api/pom.xml
+++ b/batch-job-api/pom.xml
@@ -56,11 +56,11 @@
   <distributionManagement>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </repository>
     <snapshotRepository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </snapshotRepository>
   </distributionManagement>
 </project>

--- a/fault-tolerant-harvester-job/pom.xml
+++ b/fault-tolerant-harvester-job/pom.xml
@@ -159,7 +159,7 @@
   <repositories>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </repository>
   </repositories>
 </project>

--- a/fr-batch-service/Taskfile.yml
+++ b/fr-batch-service/Taskfile.yml
@@ -26,10 +26,10 @@ tasks:
       - echo "db bootstraping finished"
   dbschema:
     cmds:
-      - mysql -p frbatchservicedb < /workspace/spring-batch-projects/fr-batch-service/_devenvironment/db/00_create_schema.sql
+      - mysql -p frbatchservicedb < /workspace/spring-batch-plugin-lab/fr-batch-service/_devenvironment/db/00_create_schema.sql
   dbdata:
     cmds:
-      - mysql -p frbatchservicedb < /workspace/spring-batch-projects/fr-batch-service/_devenvironment/db/01_init_data.sql
+      - mysql -p frbatchservicedb < /workspace/spring-batch-plugin-lab/fr-batch-service/_devenvironment/db/01_init_data.sql
   prettier:
     cmds:
       # this is a basic config for prettier for java, see pom.xml for prettier-maven-plugin

--- a/fr-batch-service/pom.xml
+++ b/fr-batch-service/pom.xml
@@ -165,7 +165,7 @@
     <repositories>
         <repository>
             <id>github</id>
-            <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+            <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
         </repository>
     </repositories>
 

--- a/partitioned-harvester-job/pom.xml
+++ b/partitioned-harvester-job/pom.xml
@@ -167,7 +167,7 @@
   <repositories>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </repository>
   </repositories>
 </project>

--- a/ticket-bundle-job/pom.xml
+++ b/ticket-bundle-job/pom.xml
@@ -157,7 +157,7 @@
   <repositories>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </repository>
   </repositories>
 </project>

--- a/ticket-pdf-job/pom.xml
+++ b/ticket-pdf-job/pom.xml
@@ -175,7 +175,7 @@
   <repositories>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fronzec/spring-batch-projects</url>
+      <url>https://maven.pkg.github.com/fronzec/spring-batch-plugin-lab</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
Closes #88

## Summary

- Align repository documentation and Maven package URLs with `spring-batch-plugin-lab`.
- Update Gitpod workspace paths for the renamed repository.
- Remove an obsolete commented Gitpod task that referenced a missing root wrapper and retired module.

## Changes

| Area | Change |
|------|--------|
| Repository docs | Rename the README title to Spring Batch Plugin Lab |
| GitHub Packages | Point publishing and consumption URLs to the renamed repository |
| Gitpod | Update workspace paths and remove stale commented configuration |

## Test Plan

- [x] Parsed all changed Maven POM files with `xmllint`.
- [x] Parsed changed YAML files and loaded the service Taskfile.
- [x] Passed 139 backend tests and 156 plugin tests across four modules.
- [x] Passed frontend check, build, and 44 tests.
- [x] Verified the renamed GitHub repository, redirect, origin, and ruleset.
- [ ] Verify fresh authenticated Maven resolution with package-scoped credentials; current credentials return HTTP 401 and local builds used the cache.

## Contributor Checklist

- [x] Linked approved issue #88.
- [x] Uses one Conventional Commit.
- [x] Documentation and repository references updated.
- [x] No generated, historical ADR, IDE, or CodeGraph files changed.
- [x] No `Co-Authored-By` trailers.
