### PR TITLE
feat(plugins): store local uploaded jars outside target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ build/
 
 ### graphify (generated knowledge graph — derived artifact, regenerate with /graphify) ###
 graphify-out/
+
+plugin-jars/

--- a/RUNNING_LOCALLY.md
+++ b/RUNNING_LOCALLY.md
@@ -216,8 +216,8 @@ Seed files applied in order:
 
 ## Step 4 — Plugin Storage (automatic — no action needed)
 
-The backend stores uploaded JARs under `${user.dir}/target/local-plugins/jars/` — i.e.
-`fr-batch-service/target/local-plugins/jars/` when started via the wrapper — and **creates that directory
+The backend stores uploaded JARs under `${user.dir}/../plugin-jars/` — i.e.
+`plugin-jars/` at the repository root when started from `fr-batch-service` — and **creates that directory
 on first upload**. There is no manual `mkdir` step and no machine-specific path baked into config.
 
 > Want a different location? Override `fr-batch-service.plugins.jar-dir` in `application-local.properties`,

--- a/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
+++ b/fr-batch-service/src/main/java/com/fronzec/frbatchservice/batchjobs/plugins/service/JarUploadService.java
@@ -245,7 +245,7 @@ public class JarUploadService {
         String safeJobName = sanitizeNameComponent(jobName);
         String safeVersion = sanitizeNameComponent(version);
 
-        Path dir = Path.of(jarDir);
+        Path dir = Path.of(jarDir).toAbsolutePath().normalize();
         try {
             Files.createDirectories(dir);
         } catch (IOException e) {

--- a/fr-batch-service/src/main/resources/application-local.properties
+++ b/fr-batch-service/src/main/resources/application-local.properties
@@ -57,7 +57,7 @@ fr-batch-service.rest_clients.client1.response_timeout_millis=500
 # Jetty temp dir. ${user.dir} (the process working dir, i.e. fr-batch-service/
 # when run via mvnw) keeps it absolute and machine-independent. The directory is
 # created automatically on first upload (JarUploadService#storeFile).
-fr-batch-service.plugins.jar-dir=${user.dir}/target/local-plugins/jars/
+fr-batch-service.plugins.jar-dir=${user.dir}/../plugin-jars/
 
 # Enable audit listener logging
 logging.level.com.fronzec.frbatchservice.batchjobs.plugins.listener=INFO


### PR DESCRIPTION
## Summary
- store local uploaded plugin JARs in the repository-level `plugin-jars/` directory
- normalize persisted JAR paths
- document the local storage location
- ignore local plugin JARs in Git

## Validation
- `./mvnw test`
- 139 tests passed, 0 failures, 0 errors, 0 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local development instructions to use the repository-level `plugin-jars/` directory for plugin JAR files.

- **Improvements**
  - Local plugin uploads now consistently resolve to an absolute, normalized storage location.
  - Added the plugin JAR directory to version-control exclusions, preventing uploaded files from being tracked accidentally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->